### PR TITLE
feat: add influx2 loader

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,7 @@ loaders: tsbs_load \
 		 tsbs_load_clickhouse \
 		 tsbs_load_cratedb \
 		 tsbs_load_influx \
+		 tsbs_load_influx2 \
  		 tsbs_load_mongo \
  		 tsbs_load_prometheus \
  		 tsbs_load_siridb \

--- a/cmd/tsbs_load_influx2/creator.go
+++ b/cmd/tsbs_load_influx2/creator.go
@@ -1,0 +1,122 @@
+package main
+
+// import (
+// 	"encoding/json"
+// 	"fmt"
+// 	"io/ioutil"
+// 	"log"
+// 	"net/http"
+// 	"net/url"
+// 	"time"
+// )
+
+type dbCreator struct {
+	daemonURL string
+}
+
+func (d *dbCreator) Init() {
+	d.daemonURL = daemonURLs[0] // pick first one since it always exists
+}
+
+func (d *dbCreator) DBExists(dbName string) bool {
+	return true
+
+	// dbs, err := d.listDatabases()
+	// if err != nil {
+	// 	log.Fatal(err)
+	// }
+
+	// for _, db := range dbs {
+	// 	if db == loader.DatabaseName() {
+	// 		return true
+	// 	}
+	// }
+	// return false
+}
+
+// func (d *dbCreator) listDatabases() ([]string, error) {
+// 	u := fmt.Sprintf("%s/query?q=show%%20databases", d.daemonURL)
+// 	resp, err := http.Get(u)
+// 	if err != nil {
+// 		return nil, fmt.Errorf("listDatabases error: %s", err.Error())
+// 	}
+// 	defer resp.Body.Close()
+
+// 	body, err := ioutil.ReadAll(resp.Body)
+// 	if err != nil {
+// 		return nil, err
+// 	}
+
+// 	// Do ad-hoc parsing to find existing database names:
+// 	// {"results":[{"series":[{"name":"databases","columns":["name"],"values":[["_internal"],["benchmark_db"]]}]}]}%
+// 	type listingType struct {
+// 		Results []struct {
+// 			Series []struct {
+// 				Values [][]string
+// 			}
+// 		}
+// 	}
+// 	var listing listingType
+// 	err = json.Unmarshal(body, &listing)
+// 	if err != nil {
+// 		return nil, err
+// 	}
+
+// 	ret := []string{}
+// 	for _, nestedName := range listing.Results[0].Series[0].Values {
+// 		name := nestedName[0]
+// 		// the _internal database is skipped:
+// 		if name == "_internal" {
+// 			continue
+// 		}
+// 		ret = append(ret, name)
+// 	}
+// 	return ret, nil
+// }
+
+func (d *dbCreator) RemoveOldDB(dbName string) error {
+	// u := fmt.Sprintf("%s/query?q=drop+database+%s", d.daemonURL, dbName)
+	// resp, err := http.Post(u, "text/plain", nil)
+	// if err != nil {
+	// 	return fmt.Errorf("drop db error: %s", err.Error())
+	// }
+	// if resp.StatusCode != 200 {
+	// 	return fmt.Errorf("drop db returned non-200 code: %d", resp.StatusCode)
+	// }
+	// time.Sleep(time.Second)
+	return nil
+}
+
+func (d *dbCreator) CreateDB(dbName string) error {
+	// u, err := url.Parse(d.daemonURL)
+	// if err != nil {
+	// 	return err
+	// }
+
+	// // serialize params the right way:
+	// u.Path = "query"
+	// v := u.Query()
+	// v.Set("consistency", "all")
+	// v.Set("q", fmt.Sprintf("CREATE DATABASE %s WITH REPLICATION %d", dbName, replicationFactor))
+	// u.RawQuery = v.Encode()
+
+	// req, err := http.NewRequest("GET", u.String(), nil)
+	// if err != nil {
+	// 	return err
+	// }
+
+	// client := &http.Client{}
+	// resp, err := client.Do(req)
+	// if err != nil {
+	// 	return err
+	// }
+	// defer resp.Body.Close()
+	// // does the body need to be read into the void?
+
+	// if resp.StatusCode != 200 {
+	// 	return fmt.Errorf("bad db create")
+	// }
+
+	// time.Sleep(time.Second)
+	return nil
+}

--- a/cmd/tsbs_load_influx2/creator.go
+++ b/cmd/tsbs_load_influx2/creator.go
@@ -1,15 +1,5 @@
 package main
 
-// import (
-// 	"encoding/json"
-// 	"fmt"
-// 	"io/ioutil"
-// 	"log"
-// 	"net/http"
-// 	"net/url"
-// 	"time"
-// )
-
 type dbCreator struct {
 	daemonURL string
 }
@@ -20,103 +10,12 @@ func (d *dbCreator) Init() {
 
 func (d *dbCreator) DBExists(dbName string) bool {
 	return true
-
-	// dbs, err := d.listDatabases()
-	// if err != nil {
-	// 	log.Fatal(err)
-	// }
-
-	// for _, db := range dbs {
-	// 	if db == loader.DatabaseName() {
-	// 		return true
-	// 	}
-	// }
-	// return false
 }
 
-// func (d *dbCreator) listDatabases() ([]string, error) {
-// 	u := fmt.Sprintf("%s/query?q=show%%20databases", d.daemonURL)
-// 	resp, err := http.Get(u)
-// 	if err != nil {
-// 		return nil, fmt.Errorf("listDatabases error: %s", err.Error())
-// 	}
-// 	defer resp.Body.Close()
-
-// 	body, err := ioutil.ReadAll(resp.Body)
-// 	if err != nil {
-// 		return nil, err
-// 	}
-
-// 	// Do ad-hoc parsing to find existing database names:
-// 	// {"results":[{"series":[{"name":"databases","columns":["name"],"values":[["_internal"],["benchmark_db"]]}]}]}%
-// 	type listingType struct {
-// 		Results []struct {
-// 			Series []struct {
-// 				Values [][]string
-// 			}
-// 		}
-// 	}
-// 	var listing listingType
-// 	err = json.Unmarshal(body, &listing)
-// 	if err != nil {
-// 		return nil, err
-// 	}
-
-// 	ret := []string{}
-// 	for _, nestedName := range listing.Results[0].Series[0].Values {
-// 		name := nestedName[0]
-// 		// the _internal database is skipped:
-// 		if name == "_internal" {
-// 			continue
-// 		}
-// 		ret = append(ret, name)
-// 	}
-// 	return ret, nil
-// }
-
 func (d *dbCreator) RemoveOldDB(dbName string) error {
-	// u := fmt.Sprintf("%s/query?q=drop+database+%s", d.daemonURL, dbName)
-	// resp, err := http.Post(u, "text/plain", nil)
-	// if err != nil {
-	// 	return fmt.Errorf("drop db error: %s", err.Error())
-	// }
-	// if resp.StatusCode != 200 {
-	// 	return fmt.Errorf("drop db returned non-200 code: %d", resp.StatusCode)
-	// }
-	// time.Sleep(time.Second)
 	return nil
 }
 
 func (d *dbCreator) CreateDB(dbName string) error {
-	// u, err := url.Parse(d.daemonURL)
-	// if err != nil {
-	// 	return err
-	// }
-
-	// // serialize params the right way:
-	// u.Path = "query"
-	// v := u.Query()
-	// v.Set("consistency", "all")
-	// v.Set("q", fmt.Sprintf("CREATE DATABASE %s WITH REPLICATION %d", dbName, replicationFactor))
-	// u.RawQuery = v.Encode()
-
-	// req, err := http.NewRequest("GET", u.String(), nil)
-	// if err != nil {
-	// 	return err
-	// }
-
-	// client := &http.Client{}
-	// resp, err := client.Do(req)
-	// if err != nil {
-	// 	return err
-	// }
-	// defer resp.Body.Close()
-	// // does the body need to be read into the void?
-
-	// if resp.StatusCode != 200 {
-	// 	return fmt.Errorf("bad db create")
-	// }
-
-	// time.Sleep(time.Second)
 	return nil
 }

--- a/cmd/tsbs_load_influx2/http_writer.go
+++ b/cmd/tsbs_load_influx2/http_writer.go
@@ -73,7 +73,7 @@ func (w *HTTPWriter) initializeReq(req *fasthttp.Request, body []byte, isGzip bo
 	if isGzip {
 		req.Header.Add(headerContentEncoding, headerGzip)
 	}
-	req.Header.Add(headerAuth, "Token " + authToken)
+	req.Header.Add(headerAuth, "Token "+authToken)
 	req.SetBody(body)
 }
 

--- a/cmd/tsbs_load_influx2/http_writer.go
+++ b/cmd/tsbs_load_influx2/http_writer.go
@@ -1,0 +1,125 @@
+package main
+
+// This file lifted wholesale from mountainflux by Mark Rushakoff.
+
+import (
+	"bytes"
+	"fmt"
+	"net/url"
+	"time"
+
+	"github.com/valyala/fasthttp"
+)
+
+const (
+	httpClientName        = "tsbs_load_influx"
+	headerContentEncoding = "Content-Encoding"
+	headerGzip            = "gzip"
+	headerAuth            = "Authorization"
+)
+
+var (
+	errBackoff          = fmt.Errorf("backpressure is needed")
+	backoffMagicWords0  = []byte("engine: cache maximum memory size exceeded")
+	backoffMagicWords1  = []byte("write failed: hinted handoff queue not empty")
+	backoffMagicWords2a = []byte("write failed: read message type: read tcp")
+	backoffMagicWords2b = []byte("i/o timeout")
+	backoffMagicWords3  = []byte("write failed: engine: cache-max-memory-size exceeded")
+	backoffMagicWords4  = []byte("timeout")
+	backoffMagicWords5  = []byte("write failed: can not exceed max connections of 500")
+)
+
+// HTTPWriterConfig is the configuration used to create an HTTPWriter.
+type HTTPWriterConfig struct {
+	// URL of the host, in form "http://example.com:8086"
+	Host string
+
+	// Name of the target bucket into which points will be written.
+	Bucket string
+
+	// Debug label for more informative errors.
+	DebugInfo string
+}
+
+// HTTPWriter is a Writer that writes to an InfluxDB HTTP server.
+type HTTPWriter struct {
+	client fasthttp.Client
+
+	c   HTTPWriterConfig
+	url []byte
+}
+
+// NewHTTPWriter returns a new HTTPWriter from the supplied HTTPWriterConfig.
+func NewHTTPWriter(c HTTPWriterConfig, orgID string) *HTTPWriter {
+	return &HTTPWriter{
+		client: fasthttp.Client{
+			Name: httpClientName,
+		},
+
+		c:   c,
+		url: []byte(c.Host + "/api/v2/write?org=" + orgID + "&bucket=" + url.QueryEscape(c.Bucket)),
+	}
+}
+
+var (
+	methodPost = []byte("POST")
+	textPlain  = []byte("text/plain")
+)
+
+func (w *HTTPWriter) initializeReq(req *fasthttp.Request, body []byte, isGzip bool, authToken string) {
+	req.Header.SetContentTypeBytes(textPlain)
+	req.Header.SetMethodBytes(methodPost)
+	req.Header.SetRequestURIBytes(w.url)
+	if isGzip {
+		req.Header.Add(headerContentEncoding, headerGzip)
+	}
+	req.Header.Add(headerAuth, "Token " + authToken)
+	req.SetBody(body)
+}
+
+func (w *HTTPWriter) executeReq(req *fasthttp.Request, resp *fasthttp.Response) (int64, error) {
+	start := time.Now()
+	err := w.client.Do(req, resp)
+	lat := time.Since(start).Nanoseconds()
+	if err == nil {
+		sc := resp.StatusCode()
+		if sc == 500 && backpressurePred(resp.Body()) {
+			err = errBackoff
+		} else if sc != fasthttp.StatusNoContent {
+			err = fmt.Errorf("[DebugInfo: %s] Invalid write response (status %d): %s", w.c.DebugInfo, sc, resp.Body())
+		}
+	}
+	return lat, err
+}
+
+// WriteLineProtocol writes the given byte slice to the HTTP server described in the Writer's HTTPWriterConfig.
+// It returns the latency in nanoseconds and any error received while sending the data over HTTP,
+// or it returns a new error if the HTTP response isn't as expected.
+func (w *HTTPWriter) WriteLineProtocol(body []byte, isGzip bool, authToken string) (int64, error) {
+	req := fasthttp.AcquireRequest()
+	defer fasthttp.ReleaseRequest(req)
+	w.initializeReq(req, body, isGzip, authToken)
+
+	resp := fasthttp.AcquireResponse()
+	defer fasthttp.ReleaseResponse(resp)
+
+	return w.executeReq(req, resp)
+}
+
+func backpressurePred(body []byte) bool {
+	if bytes.Contains(body, backoffMagicWords0) {
+		return true
+	} else if bytes.Contains(body, backoffMagicWords1) {
+		return true
+	} else if bytes.Contains(body, backoffMagicWords2a) && bytes.Contains(body, backoffMagicWords2b) {
+		return true
+	} else if bytes.Contains(body, backoffMagicWords3) {
+		return true
+	} else if bytes.Contains(body, backoffMagicWords4) {
+		return true
+	} else if bytes.Contains(body, backoffMagicWords5) {
+		return true
+	} else {
+		return false
+	}
+}

--- a/cmd/tsbs_load_influx2/http_writer_test.go
+++ b/cmd/tsbs_load_influx2/http_writer_test.go
@@ -1,0 +1,235 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/valyala/fasthttp"
+)
+
+const (
+	shouldBackoffParam = "shouldErr"
+	shouldInvalidParam = "shouldInvalid"
+	httpServerPort     = ":8080"
+	httpDelay          = 50 * time.Millisecond
+)
+
+var (
+	testConf = HTTPWriterConfig{
+		Host:     "http://localhost" + httpServerPort + "/",
+		Database: "test",
+	}
+	testConsistency = "one"
+)
+
+func runHTTPServer(c chan struct{}) {
+	m := http.NewServeMux()
+	s := http.Server{Addr: httpServerPort, Handler: m}
+	i := int64(0)
+	m.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		if strings.Contains(r.URL.RawQuery, shouldBackoffParam) {
+			coinflip := atomic.AddInt64(&i, 1)
+			if coinflip%2 == 1 {
+				w.WriteHeader(http.StatusInternalServerError)
+				fmt.Fprintf(w, string(backoffMagicWords1))
+			} else {
+				w.WriteHeader(http.StatusNoContent)
+				fmt.Fprintf(w, "")
+			}
+		} else if strings.Contains(r.URL.RawQuery, shouldInvalidParam) {
+			fmt.Fprintf(w, "success should be an empty msg")
+		} else {
+			w.WriteHeader(http.StatusNoContent)
+			fmt.Fprintf(w, "")
+		}
+	})
+
+	go s.ListenAndServe()
+	time.Sleep(httpDelay) // give time for server to start
+	c <- struct{}{}
+	time.Sleep(httpDelay) // sleep to not grab my own msg
+	<-c
+	s.Shutdown(context.Background())
+	c <- struct{}{}
+}
+
+func launchHTTPServer() chan struct{} {
+	c := make(chan struct{})
+	go runHTTPServer(c)
+	<-c // wait for server to be ready
+	return c
+}
+
+func shutdownHTTPServer(c chan struct{}) {
+	c <- struct{}{}       // tell server to shutdown
+	time.Sleep(httpDelay) // sleep to not grab my own msg
+	<-c                   // wait for clean shutdown
+}
+
+func testWriterMatchesConfig(w *HTTPWriter, conf HTTPWriterConfig, consistency string) error {
+	// Check HTTP Config is the same
+	if got := w.c.Host; got != conf.Host {
+		return fmt.Errorf("incorrect config host: got %s want %s", got, conf.Host)
+	}
+	if got := w.c.Database; got != conf.Database {
+		return fmt.Errorf("incorrect config host: got %s want %s", got, conf.Database)
+	}
+
+	// Check URL is accurate
+	got := string(w.url)
+	if !strings.Contains(got, conf.Host) {
+		return fmt.Errorf("url does not contain correct host: looking for %s in %s", conf.Host, got)
+	}
+	if !strings.Contains(got, consistency) {
+		return fmt.Errorf("url does not contain correct consistency: looking for %s in %s", consistency, got)
+	}
+	if want := url.QueryEscape(conf.Database); !strings.Contains(got, want) {
+		return fmt.Errorf("url does not contain correct database name: looking for %s in %s", want, got)
+	}
+
+	return nil
+}
+
+func TestNewHTTPWriter(t *testing.T) {
+	w := NewHTTPWriter(testConf, testConsistency)
+	// Check client name
+	if got := w.client.Name; got != httpClientName {
+		t.Errorf("name of http client is incorrect: got %s want %s", got, httpClientName)
+	}
+
+	err := testWriterMatchesConfig(w, testConf, testConsistency)
+	if err != nil {
+		t.Error(err)
+	}
+}
+
+func TestHTTPWriterInitializeReq(t *testing.T) {
+	req := fasthttp.AcquireRequest()
+	defer fasthttp.ReleaseRequest(req)
+	w := NewHTTPWriter(testConf, testConsistency)
+	body := "this is a test body"
+	w.initializeReq(req, []byte(body), false)
+
+	if got := string(req.Body()); got != body {
+		t.Errorf("non-gzip: body not correct: got '%s' want '%s'", got, body)
+	}
+	if got := string(req.Header.Method()); got != string(methodPost) {
+		t.Errorf("non-gzip: method not correct: got %s want %s", got, string(methodPost))
+	}
+	if got := string(req.Header.RequestURI()); got != string(w.url) {
+		t.Errorf("non-gzip: URI is not correct: got %s want %s", got, string(w.url))
+	}
+	if got := string(req.Header.Peek(headerContentEncoding)); got != "" {
+		t.Errorf("non-gzip: Content-Encoding is not empty: got %s", got)
+	}
+
+	w.initializeReq(req, []byte(body), true)
+	if got := string(req.Header.Peek(headerContentEncoding)); got != headerGzip {
+		t.Errorf("gzip: Content-Encoding is not correct: got %s want %s", got, headerGzip)
+	}
+}
+
+func TestHTTPWriterExecuteReq(t *testing.T) {
+	c := launchHTTPServer()
+
+	// Success case test, make sure no error and positive latency
+	req := fasthttp.AcquireRequest()
+	defer fasthttp.ReleaseRequest(req)
+	w := NewHTTPWriter(testConf, testConsistency)
+	body := "this is a test body"
+	normalURL := w.url // save for later modification
+	w.initializeReq(req, []byte(body), false)
+	resp := fasthttp.AcquireResponse()
+	defer fasthttp.ReleaseResponse(resp)
+	lat, err := w.executeReq(req, resp)
+	if err != nil {
+		t.Errorf("unexpected error received: %v", err)
+	}
+	if lat <= 0 {
+		t.Errorf("latency is unrealistic (<= 0): %d", lat)
+	}
+
+	// Backoff case test, make sure its a backoff error and positive latency
+	resp = fasthttp.AcquireResponse()
+	defer fasthttp.ReleaseResponse(resp)
+	w.url = []byte(fmt.Sprintf("%s&%s=true", string(normalURL), shouldBackoffParam))
+	req = fasthttp.AcquireRequest()
+	defer fasthttp.ReleaseRequest(req)
+	w.initializeReq(req, []byte(body), false)
+	lat, err = w.executeReq(req, resp)
+	if err != errBackoff {
+		t.Errorf("unexpected error response received (not backoff error): %v", err)
+	}
+	if lat <= 0 {
+		t.Errorf("latency is unrealistic (<= 0): %d", lat)
+	}
+
+	// Unexpected response case test, make sure its an error and positive latency
+	resp = fasthttp.AcquireResponse()
+	defer fasthttp.ReleaseResponse(resp)
+	w.url = []byte(fmt.Sprintf("%s&%s=true", string(normalURL), shouldInvalidParam))
+	req = fasthttp.AcquireRequest()
+	defer fasthttp.ReleaseRequest(req)
+	w.initializeReq(req, []byte(body), false)
+	lat, err = w.executeReq(req, resp)
+	if err == nil {
+		t.Errorf("unexpected non-error response received")
+	}
+	if lat <= 0 {
+		t.Errorf("latency is unrealistic (<= 0): %d", lat)
+	}
+
+	shutdownHTTPServer(c)
+}
+
+func TestBackpressurePred(t *testing.T) {
+	cases := []struct {
+		body string
+		want bool
+	}{
+		{
+			body: "yadda yadda" + string(backoffMagicWords0),
+			want: true,
+		},
+		{
+			body: "yadda" + string(backoffMagicWords1),
+			want: true,
+		},
+		{
+			body: string(backoffMagicWords2a),
+			want: false, // need both magic strings or it fails
+		},
+		{
+			body: string(backoffMagicWords2a) + " AND " + string(backoffMagicWords2b),
+			want: true,
+		},
+		{
+			body: string(backoffMagicWords3) + " yadda",
+			want: true,
+		},
+		{
+			body: "yadda " + string(backoffMagicWords4) + " yadda",
+			want: true,
+		},
+		{
+			body: "foo " + string(backoffMagicWords5) + " yadda",
+			want: true,
+		},
+		{
+			body: string(backoffMagicWords0[2:]),
+			want: false,
+		},
+	}
+
+	for _, c := range cases {
+		if got := backpressurePred([]byte(c.body)); got != c.want {
+			t.Errorf("'%s' did not give correct backpressure result: got %v want %v", c.body, got, c.want)
+		}
+	}
+}

--- a/cmd/tsbs_load_influx2/main.go
+++ b/cmd/tsbs_load_influx2/main.go
@@ -1,0 +1,125 @@
+// bulk_load_influx loads an InfluxDB daemon with data from stdin.
+//
+// The caller is responsible for assuring that the database is empty before
+// bulk load.
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"log"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/blagojts/viper"
+	"github.com/spf13/pflag"
+	"github.com/timescale/tsbs/internal/utils"
+	"github.com/timescale/tsbs/load"
+	"github.com/timescale/tsbs/pkg/targets"
+	"github.com/timescale/tsbs/pkg/targets/constants"
+	"github.com/timescale/tsbs/pkg/targets/initializers"
+)
+
+// Program option vars:
+var (
+	daemonURLs        []string
+	replicationFactor int
+	backoff           time.Duration
+	useGzip           bool
+	doAbortOnExist    bool
+	consistency       string
+	orgID       string
+	authToken       string
+)
+
+// Global vars
+var (
+	loader  load.BenchmarkRunner
+	config  load.BenchmarkRunnerConfig
+	bufPool sync.Pool
+	target  targets.ImplementedTarget
+)
+
+var consistencyChoices = map[string]struct{}{
+	"any":    {},
+	"one":    {},
+	"quorum": {},
+	"all":    {},
+}
+
+// allows for testing
+var fatal = log.Fatalf
+
+// Parse args:
+func init() {
+	target = initializers.GetTarget(constants.FormatInflux2)
+	config = load.BenchmarkRunnerConfig{}
+	config.AddToFlagSet(pflag.CommandLine)
+	target.TargetSpecificFlags("", pflag.CommandLine)
+	var csvDaemonURLs string
+
+	pflag.Parse()
+
+	err := utils.SetupConfigFile()
+
+	if err != nil {
+		panic(fmt.Errorf("fatal error config file: %s", err))
+	}
+
+	if err := viper.Unmarshal(&config); err != nil {
+		panic(fmt.Errorf("unable to decode config: %s", err))
+	}
+
+	csvDaemonURLs = viper.GetString("urls")
+	replicationFactor = viper.GetInt("replication-factor")
+	consistency = viper.GetString("consistency")
+	backoff = viper.GetDuration("backoff")
+	useGzip = viper.GetBool("gzip")
+	orgID = viper.GetString("org-id")
+	authToken = viper.GetString("auth-token")
+
+	if _, ok := consistencyChoices[consistency]; !ok {
+		log.Fatalf("invalid consistency settings")
+	}
+
+	daemonURLs = strings.Split(csvDaemonURLs, ",")
+	if len(daemonURLs) == 0 {
+		log.Fatal("missing 'urls' flag")
+	}
+	config.HashWorkers = false
+	loader = load.GetBenchmarkRunner(config)
+}
+
+type benchmark struct{}
+
+func (b *benchmark) GetDataSource() targets.DataSource {
+	return &fileDataSource{scanner: bufio.NewScanner(load.GetBufferedReader(config.FileName))}
+}
+
+func (b *benchmark) GetBatchFactory() targets.BatchFactory {
+	return &factory{}
+}
+
+func (b *benchmark) GetPointIndexer(_ uint) targets.PointIndexer {
+	return &targets.ConstantIndexer{}
+}
+
+func (b *benchmark) GetProcessor() targets.Processor {
+	return &processor{}
+}
+
+func (b *benchmark) GetDBCreator() targets.DBCreator {
+	return &dbCreator{}
+}
+
+func main() {
+	bufPool = sync.Pool{
+		New: func() interface{} {
+			return bytes.NewBuffer(make([]byte, 0, 4*1024*1024))
+		},
+	}
+
+	loader.RunBenchmark(&benchmark{})
+}

--- a/cmd/tsbs_load_influx2/main.go
+++ b/cmd/tsbs_load_influx2/main.go
@@ -30,8 +30,8 @@ var (
 	useGzip           bool
 	doAbortOnExist    bool
 	consistency       string
-	orgID       string
-	authToken       string
+	orgID             string
+	authToken         string
 )
 
 // Global vars

--- a/cmd/tsbs_load_influx2/process.go
+++ b/cmd/tsbs_load_influx2/process.go
@@ -1,0 +1,103 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"github.com/timescale/tsbs/pkg/targets"
+	"time"
+
+	"github.com/valyala/fasthttp"
+)
+
+const backingOffChanCap = 100
+
+// allows for testing
+var printFn = fmt.Printf
+
+type processor struct {
+	backingOffChan chan bool
+	backingOffDone chan struct{}
+	httpWriter     *HTTPWriter
+}
+
+func (p *processor) Init(numWorker int, _, _ bool) {
+	daemonURL := daemonURLs[numWorker%len(daemonURLs)]
+	cfg := HTTPWriterConfig{
+		DebugInfo: fmt.Sprintf("worker #%d, dest url: %s", numWorker, daemonURL),
+		Host:      daemonURL,
+		Bucket:  loader.DatabaseName(),
+	}
+	w := NewHTTPWriter(cfg, orgID)
+	p.initWithHTTPWriter(numWorker, w)
+}
+
+func (p *processor) initWithHTTPWriter(numWorker int, w *HTTPWriter) {
+	p.backingOffChan = make(chan bool, backingOffChanCap)
+	p.backingOffDone = make(chan struct{})
+	p.httpWriter = w
+	go p.processBackoffMessages(numWorker)
+}
+
+func (p *processor) Close(_ bool) {
+	close(p.backingOffChan)
+	<-p.backingOffDone
+}
+
+func (p *processor) ProcessBatch(b targets.Batch, doLoad bool) (uint64, uint64) {
+	batch := b.(*batch)
+
+	// Write the batch: try until backoff is not needed.
+	if doLoad {
+		var err error
+		for {
+			if useGzip {
+				compressedBatch := bufPool.Get().(*bytes.Buffer)
+				fasthttp.WriteGzip(compressedBatch, batch.buf.Bytes())
+				_, err = p.httpWriter.WriteLineProtocol(compressedBatch.Bytes(), true, authToken)
+				// Return the compressed batch buffer to the pool.
+				compressedBatch.Reset()
+				bufPool.Put(compressedBatch)
+			} else {
+				_, err = p.httpWriter.WriteLineProtocol(batch.buf.Bytes(), false, authToken)
+			}
+
+			if err == errBackoff {
+				p.backingOffChan <- true
+				time.Sleep(backoff)
+			} else {
+				p.backingOffChan <- false
+				break
+			}
+		}
+		if err != nil {
+			fatal("Error writing: %s\n", err.Error())
+		}
+	}
+	metricCnt := batch.metrics
+	rowCnt := batch.rows
+
+	// Return the batch buffer to the pool.
+	batch.buf.Reset()
+	bufPool.Put(batch.buf)
+	return metricCnt, uint64(rowCnt)
+}
+
+func (p *processor) processBackoffMessages(workerID int) {
+	var totalBackoffSecs float64
+	var start time.Time
+	last := false
+	for this := range p.backingOffChan {
+		if this && !last {
+			start = time.Now()
+			last = true
+		} else if !this && last {
+			took := time.Now().Sub(start)
+			printFn("[worker %d] backoff took %.02fsec\n", workerID, took.Seconds())
+			totalBackoffSecs += took.Seconds()
+			last = false
+			start = time.Now()
+		}
+	}
+	printFn("[worker %d] backoffs took a total of %fsec of runtime\n", workerID, totalBackoffSecs)
+	p.backingOffDone <- struct{}{}
+}

--- a/cmd/tsbs_load_influx2/process.go
+++ b/cmd/tsbs_load_influx2/process.go
@@ -25,7 +25,7 @@ func (p *processor) Init(numWorker int, _, _ bool) {
 	cfg := HTTPWriterConfig{
 		DebugInfo: fmt.Sprintf("worker #%d, dest url: %s", numWorker, daemonURL),
 		Host:      daemonURL,
-		Bucket:  loader.DatabaseName(),
+		Bucket:    loader.DatabaseName(),
 	}
 	w := NewHTTPWriter(cfg, orgID)
 	p.initWithHTTPWriter(numWorker, w)

--- a/cmd/tsbs_load_influx2/process_test.go
+++ b/cmd/tsbs_load_influx2/process_test.go
@@ -1,0 +1,242 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/timescale/tsbs/pkg/data"
+)
+
+func emptyLog(_ string, _ ...interface{}) (int, error) {
+	return 0, nil
+}
+
+func TestProcessorInit(t *testing.T) {
+	daemonURLs = []string{"url1", "url2"}
+	printFn = emptyLog
+	p := &processor{}
+	p.Init(0, false, false)
+	p.Close(true)
+	if got := p.httpWriter.c.Host; got != daemonURLs[0] {
+		t.Errorf("incorrect host: got %s want %s", got, daemonURLs[0])
+	}
+	if got := p.httpWriter.c.Database; got != loader.DatabaseName() {
+		t.Errorf("incorrect database: got %s want %s", got, loader.DatabaseName())
+	}
+
+	p = &processor{}
+	p.Init(1, false, false)
+	p.Close(true)
+	if got := p.httpWriter.c.Host; got != daemonURLs[1] {
+		t.Errorf("incorrect host: got %s want %s", got, daemonURLs[1])
+	}
+
+	p = &processor{}
+	p.Init(len(daemonURLs), false, false)
+	p.Close(true)
+	if got := p.httpWriter.c.Host; got != daemonURLs[0] {
+		t.Errorf("incorrect host: got %s want %s", got, daemonURLs[0])
+	}
+
+}
+
+func TestProcessorInitWithHTTPWriterConfig(t *testing.T) {
+	var b bytes.Buffer
+	counter := int64(0)
+	var m sync.Mutex
+	printFn = func(s string, args ...interface{}) (n int, err error) {
+		atomic.AddInt64(&counter, 1)
+		m.Lock()
+		defer m.Unlock()
+		return fmt.Fprintf(&b, s, args...)
+	}
+	workerNum := 4
+	p := &processor{}
+	w := NewHTTPWriter(testConf, testConsistency)
+	p.initWithHTTPWriter(workerNum, w)
+	p.Close(true)
+
+	// Check p was initialized correctly with channels
+	if got := cap(p.backingOffChan); got != backingOffChanCap {
+		t.Errorf("backing off chan cap incorrect: got %d want %d", got, backingOffChanCap)
+	}
+	if got := cap(p.backingOffDone); got != 0 {
+		t.Errorf("backing off done chan cap not 0: got %d", got)
+	}
+
+	// Check p was initialized with correct writer given conf
+	err := testWriterMatchesConfig(p.httpWriter, testConf, testConsistency)
+	if err != nil {
+		t.Error(err)
+	}
+
+	// Check that backoff successfully shut down
+	if got := atomic.LoadInt64(&counter); got != 1 {
+		t.Errorf("printFn called incorrect # of times: got %d want %d", got, 1)
+	}
+	got := string(b.Bytes())
+	if !strings.Contains(got, fmt.Sprintf("worker %d", workerNum)) {
+		t.Errorf("printFn did not contain correct worker number: %s", got)
+	}
+}
+
+func TestProcessorProcessBatch(t *testing.T) {
+	bufPool = sync.Pool{
+		New: func() interface{} {
+			return bytes.NewBuffer(make([]byte, 0, 4*1024*1024))
+		},
+	}
+	f := &factory{}
+	b := f.New().(*batch)
+	pt := data.LoadedPoint{
+		Data: []byte("tag1=tag1val,tag2=tag2val col1=0.0,col2=0.0 140"),
+	}
+	b.Append(pt)
+
+	cases := []struct {
+		doLoad        bool
+		useGzip       bool
+		shouldBackoff bool
+		shouldFatal   bool
+	}{
+		{
+			doLoad:  false,
+			useGzip: false,
+		},
+		{
+			doLoad:  true,
+			useGzip: false,
+		},
+		{
+			doLoad:  true,
+			useGzip: true,
+		},
+		{
+			doLoad:        true,
+			useGzip:       false,
+			shouldBackoff: true,
+		},
+		{
+			doLoad:      true,
+			shouldFatal: true,
+		},
+	}
+
+	for _, c := range cases {
+		var ch chan struct{}
+		fatalCalled := false
+		if c.shouldFatal {
+			fatal = func(format string, args ...interface{}) {
+				fatalCalled = true
+			}
+		} else {
+			fatal = func(format string, args ...interface{}) {
+				t.Errorf("fatal called for case %v unexpectedly\n", c)
+				fmt.Printf(format, args...)
+			}
+			ch = launchHTTPServer()
+		}
+
+		p := &processor{}
+		w := NewHTTPWriter(testConf, testConsistency)
+
+		// If the case should backoff, we tell our dummy server to do so by
+		// modifying the URL params. This should keep ProcessBatch in a loop
+		// until it gets a response that is not a backoff (every other response from the server).
+		if c.shouldBackoff {
+			normalURL := string(w.url)
+			w.url = []byte(fmt.Sprintf("%s&%s=true", normalURL, shouldBackoffParam))
+		}
+
+		p.initWithHTTPWriter(0, w)
+		useGzip = c.useGzip
+		mCnt, rCnt := p.ProcessBatch(b, c.doLoad)
+		if c.shouldFatal {
+			if !fatalCalled {
+				t.Errorf("fatal was not called when it should have been")
+			}
+			continue
+		} else {
+			if mCnt != b.metrics {
+				t.Errorf("process batch returned less metrics than batch: got %d want %d", mCnt, b.metrics)
+			}
+			if rCnt != uint64(b.rows) {
+				t.Errorf("process batch returned less rows than batch: got %d want %d", rCnt, b.rows)
+			}
+			p.Close(true)
+
+			shutdownHTTPServer(ch)
+			time.Sleep(50 * time.Millisecond)
+		}
+	}
+}
+
+func TestProcessorProcessBackoffMessages(t *testing.T) {
+	var b bytes.Buffer
+	counter := int64(0)
+	var m sync.Mutex
+	printFn = func(s string, args ...interface{}) (n int, err error) {
+		atomic.AddInt64(&counter, 1)
+		m.Lock()
+		defer m.Unlock()
+		return fmt.Fprintf(&b, s, args...)
+	}
+	workerNum := 4
+	p := &processor{}
+	w := NewHTTPWriter(testConf, testConsistency)
+	p.initWithHTTPWriter(workerNum, w)
+
+	// Sending false at the beginning should do nothing
+	p.backingOffChan <- false
+	time.Sleep(50 * time.Millisecond)
+	if got := atomic.LoadInt64(&counter); got != 0 {
+		m.Lock()
+		defer m.Unlock()
+		t.Errorf("printFn called when not expected after just false: msg %s", string(b.Bytes()))
+	}
+	// Same if another false:
+	p.backingOffChan <- false
+	time.Sleep(50 * time.Millisecond)
+	if got := atomic.LoadInt64(&counter); got != 0 {
+		m.Lock()
+		defer m.Unlock()
+		t.Errorf("printFn called when not expected after second false: msg %s", string(b.Bytes()))
+	}
+
+	// Send true, should be no print
+	p.backingOffChan <- true
+	time.Sleep(50 * time.Millisecond)
+	if got := atomic.LoadInt64(&counter); got != 0 {
+		m.Lock()
+		defer m.Unlock()
+		t.Errorf("printFn called when not expected after first true: msg %s", string(b.Bytes()))
+	}
+	// Another true, should be no print still
+	p.backingOffChan <- true
+	time.Sleep(50 * time.Millisecond)
+	if got := atomic.LoadInt64(&counter); got != 0 {
+		m.Lock()
+		defer m.Unlock()
+		t.Errorf("printFn called when not expected after second true: msg %s", string(b.Bytes()))
+	}
+	// Now false, should be a print with non-0 time
+	p.backingOffChan <- false
+	time.Sleep(50 * time.Millisecond)
+	if got := atomic.LoadInt64(&counter); got != 1 {
+		m.Lock()
+		defer m.Unlock()
+		t.Errorf("printFn not called right number of times after false: %d with %s", got, string(b.Bytes()))
+	} else {
+		m.Lock()
+		msg := string(b.Bytes())
+		m.Unlock()
+		if !strings.Contains(msg, "took 0.1") {
+			t.Errorf("backoff might have taken an incorrect amt of time: %s", msg)
+		}
+	}
+}

--- a/cmd/tsbs_load_influx2/scan.go
+++ b/cmd/tsbs_load_influx2/scan.go
@@ -1,0 +1,65 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"strings"
+
+	"github.com/timescale/tsbs/pkg/data"
+	"github.com/timescale/tsbs/pkg/data/usecases/common"
+	"github.com/timescale/tsbs/pkg/targets"
+)
+
+const errNotThreeTuplesFmt = "parse error: line does not have 3 tuples, has %d"
+
+var newLine = []byte("\n")
+
+type fileDataSource struct {
+	scanner *bufio.Scanner
+}
+
+func (d *fileDataSource) NextItem() data.LoadedPoint {
+	ok := d.scanner.Scan()
+	if !ok && d.scanner.Err() == nil { // nothing scanned & no error = EOF
+		return data.LoadedPoint{}
+	} else if !ok {
+		fatal("scan error: %v", d.scanner.Err())
+		return data.LoadedPoint{}
+	}
+	return data.NewLoadedPoint(d.scanner.Bytes())
+}
+
+func (d *fileDataSource) Headers() *common.GeneratedDataHeaders { return nil }
+
+type batch struct {
+	buf     *bytes.Buffer
+	rows    uint
+	metrics uint64
+}
+
+func (b *batch) Len() uint {
+	return b.rows
+}
+
+func (b *batch) Append(item data.LoadedPoint) {
+	that := item.Data.([]byte)
+	thatStr := string(that)
+	b.rows++
+	// Each influx line is format "csv-tags csv-fields timestamp", so we split by space
+	// and then on the middle element, we split by comma to count number of fields added
+	args := strings.Split(thatStr, " ")
+	if len(args) != 3 {
+		fatal(errNotThreeTuplesFmt, len(args))
+		return
+	}
+	b.metrics += uint64(len(strings.Split(args[1], ",")))
+
+	b.buf.Write(that)
+	b.buf.Write(newLine)
+}
+
+type factory struct{}
+
+func (f *factory) New() targets.Batch {
+	return &batch{buf: bufPool.Get().(*bytes.Buffer)}
+}

--- a/cmd/tsbs_load_influx2/scan_test.go
+++ b/cmd/tsbs_load_influx2/scan_test.go
@@ -1,0 +1,105 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"sync"
+	"testing"
+
+	"github.com/timescale/tsbs/pkg/data"
+)
+
+func TestBatch(t *testing.T) {
+	bufPool = sync.Pool{
+		New: func() interface{} {
+			return bytes.NewBuffer(make([]byte, 0, 4*1024*1024))
+		},
+	}
+	f := &factory{}
+	b := f.New().(*batch)
+	if b.Len() != 0 {
+		t.Errorf("batch not initialized with count 0")
+	}
+	p := data.LoadedPoint{
+		Data: []byte("tag1=tag1val,tag2=tag2val col1=0.0,col2=0.0 140"),
+	}
+	b.Append(p)
+	if b.Len() != 1 {
+		t.Errorf("batch count is not 1 after first append")
+	}
+	if b.rows != 1 {
+		t.Errorf("batch row count is not 1 after first append")
+	}
+	if b.metrics != 2 {
+		t.Errorf("batch metric count is not 2 after first append")
+	}
+
+	p = data.LoadedPoint{
+		Data: []byte("tag1=tag1val,tag2=tag2val col1=1.0,col2=1.0 190"),
+	}
+	b.Append(p)
+	if b.Len() != 2 {
+		t.Errorf("batch count is not 1 after first append")
+	}
+	if b.rows != 2 {
+		t.Errorf("batch row count is not 1 after first append")
+	}
+	if b.metrics != 4 {
+		t.Errorf("batch metric count is not 2 after first append")
+	}
+
+	p = data.LoadedPoint{
+		Data: []byte("bad_point"),
+	}
+	errMsg := ""
+	fatal = func(f string, args ...interface{}) {
+		errMsg = fmt.Sprintf(f, args...)
+	}
+	b.Append(p)
+	if errMsg == "" {
+		t.Errorf("batch append did not error with ill-formed point")
+	}
+}
+
+func TestFileDataSourceNextItem(t *testing.T) {
+	cases := []struct {
+		desc        string
+		input       string
+		result      []byte
+		shouldFatal bool
+	}{
+		{
+			desc:   "correct input",
+			input:  "cpu,tag1=tag1text,tag2=tag2text col1=0.0,col2=0.0 140\n",
+			result: []byte("cpu,tag1=tag1text,tag2=tag2text col1=0.0,col2=0.0 140"),
+		},
+		{
+			desc:   "correct input with extra",
+			input:  "cpu,tag1=tag1text,tag2=tag2text col1=0.0,col2=0.0 140\nextra_is_ignored",
+			result: []byte("cpu,tag1=tag1text,tag2=tag2text col1=0.0,col2=0.0 140"),
+		},
+	}
+
+	for _, c := range cases {
+		br := bufio.NewReader(bytes.NewReader([]byte(c.input)))
+		ds := &fileDataSource{scanner: bufio.NewScanner(br)}
+		p := ds.NextItem()
+		data := p.Data.([]byte)
+		if !bytes.Equal(data, c.result) {
+			t.Errorf("%s: incorrect result: got\n%v\nwant\n%v", c.desc, data, c.result)
+		}
+	}
+}
+
+func TestDecodeEOF(t *testing.T) {
+	input := []byte("cpu,tag1=tag1text,tag2=tag2text col1=0.0,col2=0.0 140")
+	br := bufio.NewReader(bytes.NewReader([]byte(input)))
+	ds := &fileDataSource{scanner: bufio.NewScanner(br)}
+	_ = ds.NextItem()
+	// nothing left, should be EOF
+	p := ds.NextItem()
+	if p.Data != nil {
+		t.Errorf("expected p to be nil, got %v", p)
+	}
+}

--- a/pkg/targets/constants/constants.go
+++ b/pkg/targets/constants/constants.go
@@ -14,6 +14,7 @@ const (
 	FormatVictoriaMetrics = "victoriametrics"
 	FormatTimestream      = "timestream"
 	FormatQuestDB         = "questdb"
+	FormatInflux2          = "influx2"
 )
 
 func SupportedFormats() []string {
@@ -30,5 +31,6 @@ func SupportedFormats() []string {
 		FormatVictoriaMetrics,
 		FormatTimestream,
 		FormatQuestDB,
+		FormatInflux2,
 	}
 }

--- a/pkg/targets/influx2/implemented_target.go
+++ b/pkg/targets/influx2/implemented_target.go
@@ -1,0 +1,40 @@
+package influx2
+
+import (
+	"github.com/blagojts/viper"
+	"github.com/spf13/pflag"
+	"github.com/timescale/tsbs/pkg/data/serialize"
+	"github.com/timescale/tsbs/pkg/data/source"
+	"github.com/timescale/tsbs/pkg/targets"
+	"github.com/timescale/tsbs/pkg/targets/constants"
+	"time"
+)
+
+func NewTarget() targets.ImplementedTarget {
+	return &influxTarget{}
+}
+
+type influxTarget struct {
+}
+
+func (t *influxTarget) TargetSpecificFlags(flagPrefix string, flagSet *pflag.FlagSet) {
+	flagSet.String(flagPrefix+"urls", "http://localhost:8086", "InfluxDB URLs, comma-separated. Will be used in a round-robin fashion.")
+	flagSet.Int(flagPrefix+"replication-factor", 1, "Cluster replication factor (only applies to clustered databases).")
+	flagSet.String(flagPrefix+"consistency", "all", "Write consistency. Must be one of: any, one, quorum, all.")
+	flagSet.Duration(flagPrefix+"backoff", time.Second, "Time to sleep between requests when server indicates backpressure is needed.")
+	flagSet.Bool(flagPrefix+"gzip", true, "Whether to gzip encode requests (default true).")
+	flagSet.String(flagPrefix+"org-id", "tsbs", "InfluxDB organization ID (default tsbs).")
+	flagSet.String(flagPrefix+"auth-token", "tsbs-token", "InfluxDB Authorization Token (default tsbs-token).")
+}
+
+func (t *influxTarget) TargetName() string {
+	return constants.FormatInflux
+}
+
+func (t *influxTarget) Serializer() serialize.PointSerializer {
+	return &Serializer{}
+}
+
+func (t *influxTarget) Benchmark(string, *source.DataSourceConfig, *viper.Viper) (targets.Benchmark, error) {
+	panic("not implemented")
+}

--- a/pkg/targets/influx2/serializer.go
+++ b/pkg/targets/influx2/serializer.go
@@ -1,0 +1,95 @@
+package influx2
+
+import (
+	"github.com/timescale/tsbs/pkg/data"
+	"github.com/timescale/tsbs/pkg/data/serialize"
+	"io"
+)
+
+// Serializer writes a Point in a serialized form for MongoDB
+type Serializer struct{}
+
+// Serialize writes Point data to the given writer, conforming to the
+// InfluxDB wire protocol.
+//
+// This function writes output that looks like:
+// <measurement>,<tag key>=<tag value> <field name>=<field value> <timestamp>\n
+//
+// For example:
+// foo,tag0=bar baz=-1.0 100\n
+func (s *Serializer) Serialize(p *data.Point, w io.Writer) (err error) {
+	buf := make([]byte, 0, 1024)
+	buf = append(buf, p.MeasurementName()...)
+
+	fakeTags := make([]int, 0)
+	tagKeys := p.TagKeys()
+	tagValues := p.TagValues()
+	for i := 0; i < len(tagKeys); i++ {
+		if tagValues[i] == nil {
+			continue
+		}
+		switch v := tagValues[i].(type) {
+		case string:
+			buf = append(buf, ',')
+			buf = append(buf, tagKeys[i]...)
+			buf = append(buf, '=')
+			buf = append(buf, []byte(v)...)
+		default:
+			fakeTags = append(fakeTags, i)
+		}
+	}
+	fieldKeys := p.FieldKeys()
+	if len(fakeTags) > 0 || len(fieldKeys) > 0 {
+		buf = append(buf, ' ')
+	}
+	firstFieldFormatted := false
+	for i := 0; i < len(fakeTags); i++ {
+		tagIndex := fakeTags[i]
+		// don't append a comma before the first field
+		if firstFieldFormatted {
+			buf = append(buf, ',')
+		}
+		firstFieldFormatted = true
+		buf = appendField(buf, tagKeys[tagIndex], tagValues[tagIndex])
+	}
+
+	fieldValues := p.FieldValues()
+	for i := 0; i < len(fieldKeys); i++ {
+		value := fieldValues[i]
+		if value == nil {
+			continue
+		}
+		// don't append a comma before the first field
+		if firstFieldFormatted {
+			buf = append(buf, ',')
+		}
+		firstFieldFormatted = true
+		buf = appendField(buf, fieldKeys[i], value)
+	}
+
+	// first field wasn't formatted, because all the fields were nil, InfluxDB will reject the insert
+	if !firstFieldFormatted {
+		return nil
+	}
+	buf = append(buf, ' ')
+	buf = serialize.FastFormatAppend(p.Timestamp().UTC().UnixNano(), buf)
+	buf = append(buf, '\n')
+	_, err = w.Write(buf)
+
+	return err
+}
+
+func appendField(buf, key []byte, v interface{}) []byte {
+	buf = append(buf, key...)
+	buf = append(buf, '=')
+
+	buf = serialize.FastFormatAppend(v, buf)
+
+	// Influx uses 'i' to indicate integers:
+	switch v.(type) {
+	case int, int64:
+		buf = append(buf, 'i')
+	}
+
+	return buf
+}

--- a/pkg/targets/influx2/serializer_test.go
+++ b/pkg/targets/influx2/serializer_test.go
@@ -1,0 +1,41 @@
+package influx2
+
+import (
+	"github.com/timescale/tsbs/pkg/data/serialize"
+	"testing"
+)
+
+func TestInfluxSerializerSerialize(t *testing.T) {
+	cases := []serialize.SerializeCase{
+		{
+			Desc:       "a regular Point",
+			InputPoint: serialize.TestPointDefault(),
+			Output:     "cpu,hostname=host_0,region=eu-west-1,datacenter=eu-west-1b usage_guest_nice=38.24311829 1451606400000000000\n",
+		},
+		{
+			Desc:       "a regular Point using int as value",
+			InputPoint: serialize.TestPointInt(),
+			Output:     "cpu,hostname=host_0,region=eu-west-1,datacenter=eu-west-1b usage_guest=38i 1451606400000000000\n",
+		},
+		{
+			Desc:       "a regular Point with multiple fields",
+			InputPoint: serialize.TestPointMultiField(),
+			Output:     "cpu,hostname=host_0,region=eu-west-1,datacenter=eu-west-1b big_usage_guest=5000000000i,usage_guest=38i,usage_guest_nice=38.24311829 1451606400000000000\n",
+		},
+		{
+			Desc:       "a Point with no tags",
+			InputPoint: serialize.TestPointNoTags(),
+			Output:     "cpu usage_guest_nice=38.24311829 1451606400000000000\n",
+		}, {
+			Desc:       "a Point with a nil tag",
+			InputPoint: serialize.TestPointWithNilTag(),
+			Output:     "cpu usage_guest_nice=38.24311829 1451606400000000000\n",
+		}, {
+			Desc:       "a Point with a nil field",
+			InputPoint: serialize.TestPointWithNilField(),
+			Output:     "cpu usage_guest_nice=38.24311829 1451606400000000000\n",
+		},
+	}
+
+	serialize.SerializerTest(t, cases, &Serializer{})
+}

--- a/pkg/targets/initializers/target_initializers.go
+++ b/pkg/targets/initializers/target_initializers.go
@@ -9,6 +9,7 @@ import (
 	"github.com/timescale/tsbs/pkg/targets/constants"
 	"github.com/timescale/tsbs/pkg/targets/crate"
 	"github.com/timescale/tsbs/pkg/targets/influx"
+	"github.com/timescale/tsbs/pkg/targets/influx2"
 	"github.com/timescale/tsbs/pkg/targets/mongo"
 	"github.com/timescale/tsbs/pkg/targets/prometheus"
 	"github.com/timescale/tsbs/pkg/targets/questdb"
@@ -45,6 +46,8 @@ func GetTarget(format string) targets.ImplementedTarget {
 		return timestream.NewTarget()
 	case constants.FormatQuestDB:
 		return questdb.NewTarget()
+	case constants.FormatInflux2:
+		return influx2.NewTarget()
 	}
 
 	supportedFormatsStr := strings.Join(constants.SupportedFormats(), ",")


### PR DESCRIPTION
The influx2 loader is modified from the influx loader. It maps the db-name to influx2's bucket id. Current implementation doesn't support creating/dropping buckets.

We need to manually create an orgID, a bucketID first. You could refer to influxdb's setup guide to create them.
https://docs.influxdata.com/influxdb/v2.7/get-started/setup/