### PR TITLE
feat: gen greptime queries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 .idea
 .vscode
 *~
+bin
 
 # High Dynamic Range (HDR) Histogram files
 *.hdr

--- a/cmd/tsbs_generate_queries/databases/greptime/common.go
+++ b/cmd/tsbs_generate_queries/databases/greptime/common.go
@@ -1,0 +1,66 @@
+package greptime
+
+import (
+	"fmt"
+	"net/url"
+	"time"
+
+	"github.com/timescale/tsbs/cmd/tsbs_generate_queries/uses/devops"
+	"github.com/timescale/tsbs/cmd/tsbs_generate_queries/uses/iot"
+	"github.com/timescale/tsbs/cmd/tsbs_generate_queries/utils"
+	"github.com/timescale/tsbs/pkg/query"
+)
+
+// BaseGenerator contains settings specific for Influx database.
+type BaseGenerator struct {
+}
+
+// GenerateEmptyQuery returns an empty query.HTTP.
+func (g *BaseGenerator) GenerateEmptyQuery() query.Query {
+	return query.NewHTTP()
+}
+
+// fillInQuery fills the query struct with data.
+func (g *BaseGenerator) fillInQuery(qi query.Query, humanLabel, humanDesc, influxql string) {
+	v := url.Values{}
+	v.Set("sql", influxql)
+	q := qi.(*query.HTTP)
+	q.HumanLabel = []byte(humanLabel)
+	q.RawQuery = []byte(influxql)
+	q.HumanDescription = []byte(humanDesc)
+	q.Method = []byte("POST")
+	q.Path = []byte(fmt.Sprintf("/v1/sql?%s", v.Encode()))
+	q.Body = nil
+}
+
+// NewDevops creates a new devops use case query generator.
+func (g *BaseGenerator) NewDevops(start, end time.Time, scale int) (utils.QueryGenerator, error) {
+	core, err := devops.NewCore(start, end, scale)
+
+	if err != nil {
+		return nil, err
+	}
+
+	devops := &Devops{
+		BaseGenerator: g,
+		Core:          core,
+	}
+
+	return devops, nil
+}
+
+// NewIoT creates a new iot use case query generator.
+func (g *BaseGenerator) NewIoT(start, end time.Time, scale int) (utils.QueryGenerator, error) {
+	core, err := iot.NewCore(start, end, scale)
+
+	if err != nil {
+		return nil, err
+	}
+
+	devops := &IoT{
+		BaseGenerator: g,
+		Core:          core,
+	}
+
+	return devops, nil
+}

--- a/cmd/tsbs_generate_queries/databases/greptime/devops.go
+++ b/cmd/tsbs_generate_queries/databases/greptime/devops.go
@@ -119,7 +119,7 @@ func (d *Devops) MaxAllCPU(qi query.Query, nHosts int, duration time.Duration) {
 func (d *Devops) LastPointPerHost(qi query.Query) {
 	humanLabel := "Influx last row per host"
 	humanDesc := humanLabel + ": cpu"
-	influxql := "SELECT * from cpu group by \"hostname\" order by time desc limit 1"
+	influxql := "SELECT * from cpu group by \"hostname\" order by ts desc limit 1"
 	d.fillInQuery(qi, humanLabel, humanDesc, influxql)
 }
 
@@ -144,6 +144,6 @@ func (d *Devops) HighCPUForHosts(qi query.Query, nHosts int) {
 	humanLabel, err := devops.GetHighCPULabel("Influx", nHosts)
 	databases.PanicIfErr(err)
 	humanDesc := fmt.Sprintf("%s: %s", humanLabel, interval.StartString())
-	influxql := fmt.Sprintf("SELECT * from cpu where usage_user > 90.0 %s and time >= '%s' and time < '%s'", hostWhereClause, interval.StartString(), interval.EndString())
+	influxql := fmt.Sprintf("SELECT * from cpu where usage_user > 90.0 %s and ts >= '%s' and ts < '%s'", hostWhereClause, interval.StartString(), interval.EndString())
 	d.fillInQuery(qi, humanLabel, humanDesc, influxql)
 }

--- a/cmd/tsbs_generate_queries/databases/greptime/devops.go
+++ b/cmd/tsbs_generate_queries/databases/greptime/devops.go
@@ -1,0 +1,149 @@
+package greptime
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/timescale/tsbs/cmd/tsbs_generate_queries/databases"
+	"github.com/timescale/tsbs/cmd/tsbs_generate_queries/uses/devops"
+	"github.com/timescale/tsbs/pkg/query"
+)
+
+// Devops produces Influx-specific queries for all the devops query types.
+type Devops struct {
+	*BaseGenerator
+	*devops.Core
+}
+
+func (d *Devops) getHostWhereWithHostnames(hostnames []string) string {
+	hostnameClauses := []string{}
+	for _, s := range hostnames {
+		hostnameClauses = append(hostnameClauses, fmt.Sprintf("hostname = '%s'", s))
+	}
+
+	combinedHostnameClause := strings.Join(hostnameClauses, " or ")
+	return "(" + combinedHostnameClause + ")"
+}
+
+func (d *Devops) getHostWhereString(nHosts int) string {
+	hostnames, err := d.GetRandomHosts(nHosts)
+	databases.PanicIfErr(err)
+	return d.getHostWhereWithHostnames(hostnames)
+}
+
+func (d *Devops) getSelectClausesAggMetrics(agg string, metrics []string) []string {
+	selectClauses := make([]string, len(metrics))
+	for i, m := range metrics {
+		selectClauses[i] = fmt.Sprintf("%s(%s)", agg, m)
+	}
+
+	return selectClauses
+}
+
+// GroupByTime selects the MAX for numMetrics metrics under 'cpu',
+// per minute for nhosts hosts,
+// e.g. in pseudo-SQL:
+//
+// SELECT minute, max(metric1), ..., max(metricN)
+// FROM cpu
+// WHERE (hostname = '$HOSTNAME_1' OR ... OR hostname = '$HOSTNAME_N')
+// AND time >= '$HOUR_START' AND time < '$HOUR_END'
+// GROUP BY minute ORDER BY minute ASC
+func (d *Devops) GroupByTime(qi query.Query, nHosts, numMetrics int, timeRange time.Duration) {
+	interval := d.Interval.MustRandWindow(timeRange)
+	metrics, err := devops.GetCPUMetricsSlice(numMetrics)
+	databases.PanicIfErr(err)
+	selectClauses := d.getSelectClausesAggMetrics("max", metrics)
+	whereHosts := d.getHostWhereString(nHosts)
+
+	humanLabel := fmt.Sprintf("Influx %d cpu metric(s), random %4d hosts, random %s by 1m", numMetrics, nHosts, timeRange)
+	humanDesc := fmt.Sprintf("%s: %s", humanLabel, interval.StartString())
+	influxql := fmt.Sprintf("SELECT %s from cpu where %s and time >= '%s' and time < '%s' group by time(1m)", strings.Join(selectClauses, ", "), whereHosts, interval.StartString(), interval.EndString())
+	d.fillInQuery(qi, humanLabel, humanDesc, influxql)
+}
+
+// GroupByOrderByLimit benchmarks a query that has a time WHERE clause, that groups by a truncated date, orders by that date, and takes a limit:
+// SELECT date_trunc('minute', time) AS t, MAX(cpu) FROM cpu
+// WHERE time < '$TIME'
+// GROUP BY t ORDER BY t DESC
+// LIMIT $LIMIT
+func (d *Devops) GroupByOrderByLimit(qi query.Query) {
+	interval := d.Interval.MustRandWindow(time.Hour)
+	where := fmt.Sprintf("WHERE time < '%s'", interval.EndString())
+
+	humanLabel := "Influx max cpu over last 5 min-intervals (random end)"
+	humanDesc := fmt.Sprintf("%s: %s", humanLabel, interval.StartString())
+	influxql := fmt.Sprintf(`SELECT max(usage_user) from cpu %s group by time(1m) limit 5`, where)
+	d.fillInQuery(qi, humanLabel, humanDesc, influxql)
+}
+
+// GroupByTimeAndPrimaryTag selects the AVG of numMetrics metrics under 'cpu' per device per hour for a day,
+// e.g. in pseudo-SQL:
+//
+// SELECT AVG(metric1), ..., AVG(metricN)
+// FROM cpu
+// WHERE time >= '$HOUR_START' AND time < '$HOUR_END'
+// GROUP BY hour, hostname ORDER BY hour, hostname
+func (d *Devops) GroupByTimeAndPrimaryTag(qi query.Query, numMetrics int) {
+	metrics, err := devops.GetCPUMetricsSlice(numMetrics)
+	databases.PanicIfErr(err)
+	interval := d.Interval.MustRandWindow(devops.DoubleGroupByDuration)
+	selectClauses := d.getSelectClausesAggMetrics("mean", metrics)
+
+	humanLabel := devops.GetDoubleGroupByLabel("Influx", numMetrics)
+	humanDesc := fmt.Sprintf("%s: %s", humanLabel, interval.StartString())
+	influxql := fmt.Sprintf("SELECT %s from cpu where time >= '%s' and time < '%s' group by time(1h),hostname", strings.Join(selectClauses, ", "), interval.StartString(), interval.EndString())
+	d.fillInQuery(qi, humanLabel, humanDesc, influxql)
+}
+
+// MaxAllCPU selects the MAX of all metrics under 'cpu' per hour for nhosts hosts,
+// e.g. in pseudo-SQL:
+//
+// SELECT MAX(metric1), ..., MAX(metricN)
+// FROM cpu WHERE (hostname = '$HOSTNAME_1' OR ... OR hostname = '$HOSTNAME_N')
+// AND time >= '$HOUR_START' AND time < '$HOUR_END'
+// GROUP BY hour ORDER BY hour
+func (d *Devops) MaxAllCPU(qi query.Query, nHosts int, duration time.Duration) {
+	interval := d.Interval.MustRandWindow(duration)
+	whereHosts := d.getHostWhereString(nHosts)
+	selectClauses := d.getSelectClausesAggMetrics("max", devops.GetAllCPUMetrics())
+
+	humanLabel := devops.GetMaxAllLabel("Influx", nHosts)
+	humanDesc := fmt.Sprintf("%s: %s", humanLabel, interval.StartString())
+	influxql := fmt.Sprintf("SELECT %s from cpu where %s and time >= '%s' and time < '%s' group by time(1h)", strings.Join(selectClauses, ","), whereHosts, interval.StartString(), interval.EndString())
+	d.fillInQuery(qi, humanLabel, humanDesc, influxql)
+}
+
+// LastPointPerHost finds the last row for every host in the dataset
+func (d *Devops) LastPointPerHost(qi query.Query) {
+	humanLabel := "Influx last row per host"
+	humanDesc := humanLabel + ": cpu"
+	influxql := "SELECT * from cpu group by \"hostname\" order by time desc limit 1"
+	d.fillInQuery(qi, humanLabel, humanDesc, influxql)
+}
+
+// HighCPUForHosts populates a query that gets CPU metrics when the CPU has high
+// usage between a time period for a number of hosts (if 0, it will search all hosts),
+// e.g. in pseudo-SQL:
+//
+// SELECT * FROM cpu
+// WHERE usage_user > 90.0
+// AND time >= '$TIME_START' AND time < '$TIME_END'
+// AND (hostname = '$HOST' OR hostname = '$HOST2'...)
+func (d *Devops) HighCPUForHosts(qi query.Query, nHosts int) {
+	interval := d.Interval.MustRandWindow(devops.HighCPUDuration)
+
+	var hostWhereClause string
+	if nHosts == 0 {
+		hostWhereClause = ""
+	} else {
+		hostWhereClause = fmt.Sprintf("and %s", d.getHostWhereString(nHosts))
+	}
+
+	humanLabel, err := devops.GetHighCPULabel("Influx", nHosts)
+	databases.PanicIfErr(err)
+	humanDesc := fmt.Sprintf("%s: %s", humanLabel, interval.StartString())
+	influxql := fmt.Sprintf("SELECT * from cpu where usage_user > 90.0 %s and time >= '%s' and time < '%s'", hostWhereClause, interval.StartString(), interval.EndString())
+	d.fillInQuery(qi, humanLabel, humanDesc, influxql)
+}

--- a/cmd/tsbs_generate_queries/databases/greptime/devops_test.go
+++ b/cmd/tsbs_generate_queries/databases/greptime/devops_test.go
@@ -1,0 +1,477 @@
+package greptime
+
+import (
+	"fmt"
+	"math/rand"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/timescale/tsbs/cmd/tsbs_generate_queries/uses/devops"
+	"github.com/timescale/tsbs/pkg/query"
+)
+
+func TestDevopsGetHostWhereWithHostnames(t *testing.T) {
+	cases := []struct {
+		desc      string
+		hostnames []string
+		want      string
+	}{
+		{
+			desc:      "single host",
+			hostnames: []string{"foo1"},
+			want:      "(hostname = 'foo1')",
+		},
+		{
+			desc:      "multi host (2)",
+			hostnames: []string{"foo1", "foo2"},
+			want:      "(hostname = 'foo1' or hostname = 'foo2')",
+		},
+		{
+			desc:      "multi host (3)",
+			hostnames: []string{"foo1", "foo2", "foo3"},
+			want:      "(hostname = 'foo1' or hostname = 'foo2' or hostname = 'foo3')",
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.desc, func(t *testing.T) {
+			b := BaseGenerator{}
+			dq, err := b.NewDevops(time.Now(), time.Now(), 10)
+			if err != nil {
+				t.Fatalf("Error while creating devops generator")
+			}
+			d := dq.(*Devops)
+
+			if got := d.getHostWhereWithHostnames(c.hostnames); got != c.want {
+				t.Errorf("incorrect output: got %s want %s", got, c.want)
+			}
+		})
+	}
+}
+
+func TestDevopsGetHostWhereString(t *testing.T) {
+	cases := []struct {
+		desc   string
+		nHosts int
+		want   string
+	}{
+		{
+			desc:   "single host",
+			nHosts: 1,
+			want:   "(hostname = 'host_1')",
+		},
+		{
+			desc:   "multi host (2)",
+			nHosts: 2,
+			want:   "(hostname = 'host_7' or hostname = 'host_9')",
+		},
+		{
+			desc:   "multi host (3)",
+			nHosts: 3,
+			want:   "(hostname = 'host_1' or hostname = 'host_8' or hostname = 'host_5')",
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.desc, func(t *testing.T) {
+			b := BaseGenerator{}
+			dq, err := b.NewDevops(time.Now(), time.Now(), 10)
+			if err != nil {
+				t.Fatalf("Error while creating devops generator")
+			}
+			d := dq.(*Devops)
+
+			if got := d.getHostWhereString(c.nHosts); got != c.want {
+				t.Errorf("incorrect output:\ngot\n%s\nwant\n%s", got, c.want)
+			}
+		})
+	}
+
+}
+
+func TestDevopsGetSelectClausesAggMetrics(t *testing.T) {
+	cases := []struct {
+		desc    string
+		agg     string
+		metrics []string
+		want    string
+	}{
+		{
+			desc:    "single metric - max",
+			agg:     "max",
+			metrics: []string{"foo"},
+			want:    "max(foo)",
+		},
+		{
+			desc:    "multiple metric - max",
+			agg:     "max",
+			metrics: []string{"foo", "bar"},
+			want:    "max(foo),max(bar)",
+		},
+		{
+			desc:    "multiple metric - avg",
+			agg:     "avg",
+			metrics: []string{"foo", "bar"},
+			want:    "avg(foo),avg(bar)",
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.desc, func(t *testing.T) {
+			b := BaseGenerator{}
+			dq, err := b.NewDevops(time.Now(), time.Now(), 10)
+			if err != nil {
+				t.Fatalf("Error while creating devops generator")
+			}
+			d := dq.(*Devops)
+
+			if got := strings.Join(d.getSelectClausesAggMetrics(c.agg, c.metrics), ","); got != c.want {
+				t.Errorf("incorrect output: got %s want %s", got, c.want)
+			}
+		})
+	}
+}
+
+func TestDevopsGroupByTime(t *testing.T) {
+	expectedHumanLabel := "Influx 1 cpu metric(s), random    1 hosts, random 1s by 1m"
+	expectedHumanDesc := "Influx 1 cpu metric(s), random    1 hosts, random 1s by 1m: 1970-01-01T00:05:58Z"
+	expectedQuery := "SELECT max(usage_user) from cpu " +
+		"where (hostname = 'host_9') and " +
+		"time >= '1970-01-01T00:05:58Z' and time < '1970-01-01T00:05:59Z' " +
+		"group by time(1m)"
+
+	v := url.Values{}
+	v.Set("q", expectedQuery)
+	expectedPath := fmt.Sprintf("/query?%s", v.Encode())
+
+	rand.Seed(123) // Setting seed for testing purposes.
+	s := time.Unix(0, 0)
+	e := s.Add(time.Hour)
+	b := BaseGenerator{}
+	dq, err := b.NewDevops(s, e, 10)
+	if err != nil {
+		t.Fatalf("Error while creating devops generator")
+	}
+	d := dq.(*Devops)
+
+	metrics := 1
+	nHosts := 1
+	duration := time.Second
+
+	q := d.GenerateEmptyQuery()
+	d.GroupByTime(q, nHosts, metrics, duration)
+
+	verifyQuery(t, q, expectedHumanLabel, expectedHumanDesc, expectedPath)
+}
+
+func TestDevopsGroupByOrderByLimit(t *testing.T) {
+	expectedHumanLabel := "Influx max cpu over last 5 min-intervals (random end)"
+	expectedHumanDesc := "Influx max cpu over last 5 min-intervals (random end): 1970-01-01T00:16:22Z"
+	expectedQuery := "SELECT max(usage_user) from cpu " +
+		"WHERE time < '1970-01-01T01:16:22Z' group by time(1m) limit 5"
+
+	v := url.Values{}
+	v.Set("q", expectedQuery)
+	expectedPath := fmt.Sprintf("/query?%s", v.Encode())
+
+	rand.Seed(123) // Setting seed for testing purposes.
+	s := time.Unix(0, 0)
+	e := s.Add(2 * time.Hour)
+	b := BaseGenerator{}
+	dq, err := b.NewDevops(s, e, 10)
+	if err != nil {
+		t.Fatalf("Error while creating devops generator")
+	}
+	d := dq.(*Devops)
+
+	q := d.GenerateEmptyQuery()
+	d.GroupByOrderByLimit(q)
+
+	verifyQuery(t, q, expectedHumanLabel, expectedHumanDesc, expectedPath)
+}
+
+func TestDevopsGroupByTimeAndPrimaryTag(t *testing.T) {
+	cases := []testCase{
+		{
+			desc:    "zero metrics",
+			input:   0,
+			fail:    true,
+			failMsg: "cannot get 0 metrics",
+		},
+		{
+			desc:               "1 metric",
+			input:              1,
+			expectedHumanLabel: "Influx mean of 1 metrics, all hosts, random 12h0m0s by 1h",
+			expectedHumanDesc:  "Influx mean of 1 metrics, all hosts, random 12h0m0s by 1h: 1970-01-01T00:16:22Z",
+			expectedQuery: "SELECT mean(usage_user) from cpu " +
+				"where time >= '1970-01-01T00:16:22Z' and time < '1970-01-01T12:16:22Z' " +
+				"group by time(1h),hostname",
+		},
+		{
+			desc:               "5 metrics",
+			input:              5,
+			expectedHumanLabel: "Influx mean of 5 metrics, all hosts, random 12h0m0s by 1h",
+			expectedHumanDesc:  "Influx mean of 5 metrics, all hosts, random 12h0m0s by 1h: 1970-01-01T00:54:10Z",
+			expectedQuery: "SELECT mean(usage_user), mean(usage_system), mean(usage_idle), mean(usage_nice), mean(usage_iowait) " +
+				"from cpu " +
+				"where time >= '1970-01-01T00:54:10Z' and time < '1970-01-01T12:54:10Z' " +
+				"group by time(1h),hostname",
+		},
+	}
+
+	testFunc := func(d *Devops, c testCase) query.Query {
+		q := d.GenerateEmptyQuery()
+		d.GroupByTimeAndPrimaryTag(q, c.input)
+		return q
+	}
+
+	start := time.Unix(0, 0)
+	end := start.Add(devops.DoubleGroupByDuration).Add(time.Hour)
+
+	runTestCases(t, testFunc, start, end, cases)
+}
+
+func TestMaxAllCPU(t *testing.T) {
+	cases := []testCase{
+		{
+			desc:    "zero hosts",
+			input:   0,
+			fail:    true,
+			failMsg: "number of hosts cannot be < 1; got 0",
+		},
+		{
+			desc:               "1 host",
+			input:              1,
+			expectedHumanLabel: "Influx max of all CPU metrics, random    1 hosts, random 8h0m0s by 1h",
+			expectedHumanDesc:  "Influx max of all CPU metrics, random    1 hosts, random 8h0m0s by 1h: 1970-01-01T00:54:10Z",
+			expectedQuery: "SELECT max(usage_user),max(usage_system),max(usage_idle),max(usage_nice),max(usage_iowait)," +
+				"max(usage_irq),max(usage_softirq),max(usage_steal),max(usage_guest),max(usage_guest_nice) " +
+				"from cpu " +
+				"where (hostname = 'host_3') and " +
+				"time >= '1970-01-01T00:54:10Z' and time < '1970-01-01T08:54:10Z' " +
+				"group by time(1h)",
+		},
+		{
+			desc:               "5 hosts",
+			input:              5,
+			expectedHumanLabel: "Influx max of all CPU metrics, random    5 hosts, random 8h0m0s by 1h",
+			expectedHumanDesc:  "Influx max of all CPU metrics, random    5 hosts, random 8h0m0s by 1h: 1970-01-01T00:37:12Z",
+			expectedQuery: "SELECT max(usage_user),max(usage_system),max(usage_idle),max(usage_nice),max(usage_iowait)," +
+				"max(usage_irq),max(usage_softirq),max(usage_steal),max(usage_guest),max(usage_guest_nice) " +
+				"from cpu " +
+				"where (hostname = 'host_9' or hostname = 'host_5' or hostname = 'host_1' or hostname = 'host_7' or hostname = 'host_2') " +
+				"and time >= '1970-01-01T00:37:12Z' and time < '1970-01-01T08:37:12Z' " +
+				"group by time(1h)",
+		},
+	}
+
+	testFunc := func(d *Devops, c testCase) query.Query {
+		q := d.GenerateEmptyQuery()
+		d.MaxAllCPU(q, c.input, devops.MaxAllDuration)
+		return q
+	}
+
+	start := time.Unix(0, 0)
+	end := start.Add(devops.MaxAllDuration).Add(time.Hour)
+
+	runTestCases(t, testFunc, start, end, cases)
+}
+
+func TestLastPointPerHost(t *testing.T) {
+	expectedHumanLabel := "Influx last row per host"
+	expectedHumanDesc := "Influx last row per host: cpu"
+	expectedQuery := `SELECT * from cpu group by "hostname" order by time desc limit 1`
+
+	v := url.Values{}
+	v.Set("q", expectedQuery)
+	expectedPath := fmt.Sprintf("/query?%s", v.Encode())
+
+	rand.Seed(123) // Setting seed for testing purposes.
+	s := time.Unix(0, 0)
+	e := s.Add(2 * time.Hour)
+	b := BaseGenerator{}
+	dq, err := b.NewDevops(s, e, 10)
+	if err != nil {
+		t.Fatalf("Error while creating devops generator")
+	}
+	d := dq.(*Devops)
+
+	q := d.GenerateEmptyQuery()
+	d.LastPointPerHost(q)
+
+	verifyQuery(t, q, expectedHumanLabel, expectedHumanDesc, expectedPath)
+}
+
+func TestHighCPUForHosts(t *testing.T) {
+	cases := []testCase{
+		{
+			desc:    "negative hosts",
+			input:   -1,
+			fail:    true,
+			failMsg: "number of hosts cannot be < 1; got -1",
+		},
+		{
+			desc:               "zero hosts",
+			input:              0,
+			expectedHumanLabel: "Influx CPU over threshold, all hosts",
+			expectedHumanDesc:  "Influx CPU over threshold, all hosts: 1970-01-01T00:54:10Z",
+			expectedQuery: "SELECT * from cpu " +
+				"where usage_user > 90.0  and " +
+				"time >= '1970-01-01T00:54:10Z' and time < '1970-01-01T12:54:10Z'",
+		},
+		{
+			desc:               "1 host",
+			input:              1,
+			expectedHumanLabel: "Influx CPU over threshold, 1 host(s)",
+			expectedHumanDesc:  "Influx CPU over threshold, 1 host(s): 1970-01-01T00:47:30Z",
+			expectedQuery: "SELECT * from cpu " +
+				"where usage_user > 90.0 and (hostname = 'host_5') and " +
+				"time >= '1970-01-01T00:47:30Z' and time < '1970-01-01T12:47:30Z'",
+		},
+		{
+			desc:               "5 hosts",
+			input:              5,
+			expectedHumanLabel: "Influx CPU over threshold, 5 host(s)",
+			expectedHumanDesc:  "Influx CPU over threshold, 5 host(s): 1970-01-01T00:17:45Z",
+			expectedQuery: "SELECT * from cpu " +
+				"where usage_user > 90.0 and " +
+				"(hostname = 'host_9' or hostname = 'host_5' or hostname = 'host_1' or hostname = 'host_7' or hostname = 'host_2') and " +
+				"time >= '1970-01-01T00:17:45Z' and time < '1970-01-01T12:17:45Z'",
+		},
+	}
+
+	testFunc := func(d *Devops, c testCase) query.Query {
+		q := d.GenerateEmptyQuery()
+		d.HighCPUForHosts(q, c.input)
+		return q
+	}
+
+	start := time.Unix(0, 0)
+	end := start.Add(devops.HighCPUDuration).Add(time.Hour)
+
+	runTestCases(t, testFunc, start, end, cases)
+}
+
+func TestDevopsFillInQuery(t *testing.T) {
+	humanLabel := "this is my label"
+	humanDesc := "and now my description"
+	influxql := "SELECT * from cpu where usage_user > 90.0 and time < '2017-01-01'"
+	b := BaseGenerator{}
+	dq, err := b.NewDevops(time.Now(), time.Now(), 10)
+	if err != nil {
+		t.Fatalf("Error while creating devops generator")
+	}
+	d := dq.(*Devops)
+	qi := d.GenerateEmptyQuery()
+	q := qi.(*query.HTTP)
+	if len(q.HumanLabel) != 0 {
+		t.Errorf("empty query has non-zero length human label")
+	}
+	if len(q.HumanDescription) != 0 {
+		t.Errorf("empty query has non-zero length human desc")
+	}
+	if len(q.Method) != 0 {
+		t.Errorf("empty query has non-zero length method")
+	}
+	if len(q.Path) != 0 {
+		t.Errorf("empty query has non-zero length path")
+	}
+
+	d.fillInQuery(q, humanLabel, humanDesc, influxql)
+	if got := string(q.HumanLabel); got != humanLabel {
+		t.Errorf("filled query mislabeled: got %s want %s", got, humanLabel)
+	}
+	if got := string(q.HumanDescription); got != humanDesc {
+		t.Errorf("filled query mis-described: got %s want %s", got, humanDesc)
+	}
+	if got := string(q.Method); got != "POST" {
+		t.Errorf("filled query has wrong method: got %s want POST", got)
+	}
+	v := url.Values{}
+	v.Set("q", influxql)
+	encoded := v.Encode()
+	if got := string(q.Path); got != "/query?"+encoded {
+		t.Errorf("filled query has wrong path: got %s want /query?%s", got, encoded)
+	}
+}
+
+type testCase struct {
+	desc               string
+	input              int
+	fail               bool
+	failMsg            string
+	expectedHumanLabel string
+	expectedHumanDesc  string
+	expectedQuery      string
+}
+
+func runTestCases(t *testing.T, testFunc func(*Devops, testCase) query.Query, s time.Time, e time.Time, cases []testCase) {
+	rand.Seed(123) // Setting seed for testing purposes.
+
+	for _, c := range cases {
+		t.Run(c.desc, func(t *testing.T) {
+			b := BaseGenerator{}
+			dq, err := b.NewDevops(s, e, 10)
+			if err != nil {
+				t.Fatalf("Error while creating devops generator")
+			}
+			d := dq.(*Devops)
+
+			if c.fail {
+				func() {
+					defer func() {
+						r := recover()
+						if r == nil {
+							t.Errorf("did not panic when should")
+						}
+
+						if r != c.failMsg {
+							t.Fatalf("incorrect fail message: got %s, want %s", r, c.failMsg)
+						}
+					}()
+
+					testFunc(d, c)
+				}()
+			} else {
+				q := testFunc(d, c)
+
+				v := url.Values{}
+				v.Set("q", c.expectedQuery)
+				expectedPath := fmt.Sprintf("/query?%s", v.Encode())
+
+				verifyQuery(t, q, c.expectedHumanLabel, c.expectedHumanDesc, expectedPath)
+			}
+
+		})
+	}
+}
+
+func verifyQuery(t *testing.T, q query.Query, humanLabel, humanDesc, path string) {
+	influxql, ok := q.(*query.HTTP)
+
+	if !ok {
+		t.Fatal("Filled query is not *query.HTTP type")
+	}
+
+	if got := string(influxql.HumanLabel); got != humanLabel {
+		t.Errorf("incorrect human label:\ngot\n%s\nwant\n%s", got, humanLabel)
+	}
+
+	if got := string(influxql.HumanDescription); got != humanDesc {
+		t.Errorf("incorrect human description:\ngot\n%s\nwant\n%s", got, humanDesc)
+	}
+
+	if got := string(influxql.Method); got != "POST" {
+		t.Errorf("incorrect method:\ngot\n%s\nwant POST", got)
+	}
+
+	if got := string(influxql.Path); got != path {
+		t.Errorf("incorrect path:\ngot\n%s\nwant\n%s", got, path)
+	}
+
+	if influxql.Body != nil {
+		t.Errorf("body not nil, got %+v", influxql.Body)
+	}
+}

--- a/cmd/tsbs_generate_queries/databases/greptime/iot.go
+++ b/cmd/tsbs_generate_queries/databases/greptime/iot.go
@@ -1,0 +1,325 @@
+package greptime
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/timescale/tsbs/cmd/tsbs_generate_queries/databases"
+	"github.com/timescale/tsbs/cmd/tsbs_generate_queries/uses/iot"
+	"github.com/timescale/tsbs/pkg/query"
+)
+
+// IoT produces Influx-specific queries for all the iot query types.
+type IoT struct {
+	*iot.Core
+	*BaseGenerator
+}
+
+// NewIoT makes an IoT object ready to generate Queries.
+func NewIoT(start, end time.Time, scale int, g *BaseGenerator) *IoT {
+	c, err := iot.NewCore(start, end, scale)
+	databases.PanicIfErr(err)
+	return &IoT{
+		Core:          c,
+		BaseGenerator: g,
+	}
+}
+
+func (i *IoT) getTrucksWhereWithNames(names []string) string {
+	nameClauses := []string{}
+	for _, s := range names {
+		nameClauses = append(nameClauses, fmt.Sprintf("\"name\" = '%s'", s))
+	}
+
+	combinedHostnameClause := strings.Join(nameClauses, " or ")
+	return "(" + combinedHostnameClause + ")"
+}
+
+func (i *IoT) getTruckWhereString(nTrucks int) string {
+	names, err := i.GetRandomTrucks(nTrucks)
+	if err != nil {
+		panic(err.Error())
+	}
+	return i.getTrucksWhereWithNames(names)
+}
+
+// LastLocByTruck finds the truck location for nTrucks.
+func (i *IoT) LastLocByTruck(qi query.Query, nTrucks int) {
+	influxql := fmt.Sprintf(`SELECT "name", "driver", "latitude", "longitude" 
+		FROM "readings" 
+		WHERE %s 
+		ORDER BY "time" 
+		LIMIT 1`,
+		i.getTruckWhereString(nTrucks))
+
+	humanLabel := "Influx last location by specific truck"
+	humanDesc := fmt.Sprintf("%s: random %4d trucks", humanLabel, nTrucks)
+
+	i.fillInQuery(qi, humanLabel, humanDesc, influxql)
+}
+
+// LastLocPerTruck finds all the truck locations along with truck and driver names.
+func (i *IoT) LastLocPerTruck(qi query.Query) {
+
+	influxql := fmt.Sprintf(`SELECT "latitude", "longitude" 
+		FROM "readings" 
+		WHERE "fleet"='%s' 
+		GROUP BY "name","driver" 
+		ORDER BY "time" 
+		LIMIT 1`,
+		i.GetRandomFleet())
+
+	humanLabel := "Influx last location per truck"
+	humanDesc := humanLabel
+
+	i.fillInQuery(qi, humanLabel, humanDesc, influxql)
+}
+
+// TrucksWithLowFuel finds all trucks with low fuel (less than 10%).
+func (i *IoT) TrucksWithLowFuel(qi query.Query) {
+	influxql := fmt.Sprintf(`SELECT "name", "driver", "fuel_state" 
+		FROM "diagnostics" 
+		WHERE "fuel_state" <= 0.1 AND "fleet" = '%s' 
+		GROUP BY "name" 
+		ORDER BY "time" DESC 
+		LIMIT 1`,
+		i.GetRandomFleet())
+
+	humanLabel := "Influx trucks with low fuel"
+	humanDesc := fmt.Sprintf("%s: under 10 percent", humanLabel)
+
+	i.fillInQuery(qi, humanLabel, humanDesc, influxql)
+}
+
+// TrucksWithHighLoad finds all trucks that have load over 90%.
+func (i *IoT) TrucksWithHighLoad(qi query.Query) {
+	influxql := fmt.Sprintf(`SELECT "name", "driver", "current_load", "load_capacity" 
+		FROM (SELECT  "current_load", "load_capacity" 
+		 FROM "diagnostics" WHERE fleet = '%s' 
+		 GROUP BY "name","driver" 
+		 ORDER BY "time" DESC 
+		 LIMIT 1) 
+		WHERE "current_load" >= 0.9 * "load_capacity" 
+		GROUP BY "name" 
+		ORDER BY "time" DESC`,
+		i.GetRandomFleet())
+
+	humanLabel := "Influx trucks with high load"
+	humanDesc := fmt.Sprintf("%s: over 90 percent", humanLabel)
+
+	i.fillInQuery(qi, humanLabel, humanDesc, influxql)
+}
+
+// StationaryTrucks finds all trucks that have low average velocity in a time window.
+func (i *IoT) StationaryTrucks(qi query.Query) {
+	interval := i.Interval.MustRandWindow(iot.StationaryDuration)
+	influxql := fmt.Sprintf(`SELECT "name", "driver" 
+		FROM(SELECT mean("velocity") as mean_velocity 
+		 FROM "readings" 
+		 WHERE time > '%s' AND time <= '%s' 
+		 GROUP BY time(10m),"name","driver","fleet"  
+		 LIMIT 1) 
+		WHERE "fleet" = '%s' AND "mean_velocity" < 1 
+		GROUP BY "name"`,
+		interval.Start().Format(time.RFC3339),
+		interval.End().Format(time.RFC3339),
+		i.GetRandomFleet())
+
+	humanLabel := "Influx stationary trucks"
+	humanDesc := fmt.Sprintf("%s: with low avg velocity in last 10 minutes", humanLabel)
+
+	i.fillInQuery(qi, humanLabel, humanDesc, influxql)
+}
+
+// TrucksWithLongDrivingSessions finds all trucks that have not stopped at least 20 mins in the last 4 hours.
+func (i *IoT) TrucksWithLongDrivingSessions(qi query.Query) {
+	interval := i.Interval.MustRandWindow(iot.LongDrivingSessionDuration)
+	influxql := fmt.Sprintf(`SELECT "name","driver" 
+		FROM(SELECT count(*) AS ten_min 
+		 FROM(SELECT mean("velocity") AS mean_velocity 
+		  FROM readings 
+		  WHERE "fleet" = '%s' AND time > '%s' AND time <= '%s' 
+		  GROUP BY time(10m),"name","driver") 
+		 WHERE "mean_velocity" > 1 
+		 GROUP BY "name","driver") 
+		WHERE ten_min_mean_velocity > %d`,
+		i.GetRandomFleet(),
+		interval.Start().Format(time.RFC3339),
+		interval.End().Format(time.RFC3339),
+		// Calculate number of 10 min intervals that is the max driving duration for the session if we rest 5 mins per hour.
+		tenMinutePeriods(5, iot.LongDrivingSessionDuration))
+
+	humanLabel := "Influx trucks with longer driving sessions"
+	humanDesc := fmt.Sprintf("%s: stopped less than 20 mins in 4 hour period", humanLabel)
+
+	i.fillInQuery(qi, humanLabel, humanDesc, influxql)
+}
+
+// TrucksWithLongDailySessions finds all trucks that have driven more than 10 hours in the last 24 hours.
+func (i *IoT) TrucksWithLongDailySessions(qi query.Query) {
+	interval := i.Interval.MustRandWindow(iot.DailyDrivingDuration)
+	influxql := fmt.Sprintf(`SELECT "name","driver" 
+		FROM(SELECT count(*) AS ten_min 
+		 FROM(SELECT mean("velocity") AS mean_velocity 
+		  FROM readings 
+		  WHERE "fleet" = '%s' AND time > '%s' AND time <= '%s' 
+		  GROUP BY time(10m),"name","driver") 
+		 WHERE "mean_velocity" > 1 
+		 GROUP BY "name","driver") 
+		WHERE ten_min_mean_velocity > %d`,
+		i.GetRandomFleet(),
+		interval.Start().Format(time.RFC3339),
+		interval.End().Format(time.RFC3339),
+		// Calculate number of 10 min intervals that is the max driving duration for the session if we rest 35 mins per hour.
+		tenMinutePeriods(35, iot.DailyDrivingDuration))
+
+	humanLabel := "Influx trucks with longer daily sessions"
+	humanDesc := fmt.Sprintf("%s: drove more than 10 hours in the last 24 hours", humanLabel)
+
+	i.fillInQuery(qi, humanLabel, humanDesc, influxql)
+}
+
+// AvgVsProjectedFuelConsumption calculates average and projected fuel consumption per fleet.
+func (i *IoT) AvgVsProjectedFuelConsumption(qi query.Query) {
+	influxql := `SELECT mean("fuel_consumption") AS "mean_fuel_consumption", mean("nominal_fuel_consumption") AS "nominal_fuel_consumption" 
+		FROM "readings" 
+		WHERE "velocity" > 1 
+		GROUP BY "fleet"`
+
+	humanLabel := "Influx average vs projected fuel consumption per fleet"
+	humanDesc := humanLabel
+
+	i.fillInQuery(qi, humanLabel, humanDesc, influxql)
+}
+
+// AvgDailyDrivingDuration finds the average driving duration per driver.
+func (i *IoT) AvgDailyDrivingDuration(qi query.Query) {
+	start := i.Interval.Start().Format(time.RFC3339)
+	end := i.Interval.End().Format(time.RFC3339)
+	influxql := fmt.Sprintf(`SELECT count("mv")/6 as "hours driven" 
+		FROM (SELECT mean("velocity") as "mv" 
+		 FROM "readings" 
+		 WHERE time > '%s' AND time < '%s' 
+		 GROUP BY time(10m),"fleet", "name", "driver") 
+		WHERE time > '%s' AND time < '%s' 
+		GROUP BY time(1d),"fleet", "name", "driver"`,
+		start,
+		end,
+		start,
+		end,
+	)
+
+	humanLabel := "Influx average driver driving duration per day"
+	humanDesc := humanLabel
+
+	i.fillInQuery(qi, humanLabel, humanDesc, influxql)
+}
+
+// AvgDailyDrivingSession finds the average driving session without stopping per driver per day.
+func (i *IoT) AvgDailyDrivingSession(qi query.Query) {
+	start := i.Interval.Start().Format(time.RFC3339)
+	end := i.Interval.End().Format(time.RFC3339)
+	influxql := fmt.Sprintf(`SELECT "elapsed" 
+		INTO "random_measure2_1" 
+		FROM (SELECT difference("difka"), elapsed("difka", 1m) 
+		 FROM (SELECT "difka" 
+		  FROM (SELECT difference("mv") AS difka 
+		   FROM (SELECT floor(mean("velocity")/10)/floor(mean("velocity")/10) AS "mv" 
+		    FROM "readings" 
+		    WHERE "name"!='' AND time > '%s' AND time < '%s' 
+		    GROUP BY time(10m), "name" fill(0)) 
+		   GROUP BY "name") 
+		  WHERE "difka"!=0 
+		  GROUP BY "name") 
+		 GROUP BY "name") 
+		WHERE "difference" = -2 
+		GROUP BY "name"; 
+		SELECT mean("elapsed") 
+		FROM "random_measure2_1" 
+		WHERE time > '%s' AND time < '%s' 
+		GROUP BY time(1d),"name"`,
+		start,
+		end,
+		start,
+		end,
+	)
+
+	humanLabel := "Influx average driver driving session without stopping per day"
+	humanDesc := humanLabel
+
+	i.fillInQuery(qi, humanLabel, humanDesc, influxql)
+}
+
+// AvgLoad finds the average load per truck model per fleet.
+func (i *IoT) AvgLoad(qi query.Query) {
+	influxql := `SELECT mean("ml") AS mean_load_percentage 
+		FROM (SELECT "current_load"/"load_capacity" AS "ml" 
+		 FROM "diagnostics" 
+		 GROUP BY "name", "fleet", "model") 
+		GROUP BY "fleet", "model"`
+
+	humanLabel := "Influx average load per truck model per fleet"
+	humanDesc := humanLabel
+
+	i.fillInQuery(qi, humanLabel, humanDesc, influxql)
+}
+
+// DailyTruckActivity returns the number of hours trucks has been active (not out-of-commission) per day per fleet per model.
+func (i *IoT) DailyTruckActivity(qi query.Query) {
+	start := i.Interval.Start().Format(time.RFC3339)
+	end := i.Interval.End().Format(time.RFC3339)
+	influxql := fmt.Sprintf(`SELECT count("ms")/144 
+		FROM (SELECT mean("status") AS ms 
+		 FROM "diagnostics" 
+		 WHERE time >= '%s' AND time < '%s' 
+		 GROUP BY time(10m), "model", "fleet") 
+		WHERE time >= '%s' AND time < '%s' AND "ms"<1 
+		GROUP BY time(1d), "model", "fleet"`,
+		start,
+		end,
+		start,
+		end,
+	)
+
+	humanLabel := "Influx daily truck activity per fleet per model"
+	humanDesc := humanLabel
+
+	i.fillInQuery(qi, humanLabel, humanDesc, influxql)
+}
+
+// TruckBreakdownFrequency calculates the amount of times a truck model broke down in the last period.
+func (i *IoT) TruckBreakdownFrequency(qi query.Query) {
+	start := i.Interval.Start().Format(time.RFC3339)
+	end := i.Interval.End().Format(time.RFC3339)
+	influxql := fmt.Sprintf(`SELECT count("state_changed") 
+		FROM (SELECT difference("broken_down") AS "state_changed" 
+		 FROM (SELECT floor(2*(sum("nzs")/count("nzs")))/floor(2*(sum("nzs")/count("nzs"))) AS "broken_down" 
+		  FROM (SELECT "model", "status"/"status" AS nzs 
+		   FROM "diagnostics" 
+		   WHERE time >= '%s' AND time < '%s') 
+		  WHERE time >= '%s' AND time < '%s' 
+		  GROUP BY time(10m),"model") 
+		 GROUP BY "model") 
+		WHERE "state_changed" = 1 
+		GROUP BY "model"`,
+		start,
+		end,
+		start,
+		end,
+	)
+
+	humanLabel := "Influx truck breakdown frequency per model"
+	humanDesc := humanLabel
+
+	i.fillInQuery(qi, humanLabel, humanDesc, influxql)
+}
+
+// tenMinutePeriods calculates the number of 10 minute periods that can fit in
+// the time duration if we subtract the minutes specified by minutesPerHour value.
+// E.g.: 4 hours - 5 minutes per hour = 3 hours and 40 minutes = 22 ten minute periods
+func tenMinutePeriods(minutesPerHour float64, duration time.Duration) int {
+	durationMinutes := duration.Minutes()
+	leftover := minutesPerHour * duration.Hours()
+	return int((durationMinutes - leftover) / 10)
+}

--- a/cmd/tsbs_generate_queries/databases/greptime/iot_test.go
+++ b/cmd/tsbs_generate_queries/databases/greptime/iot_test.go
@@ -1,0 +1,558 @@
+package greptime
+
+import (
+	"fmt"
+	"math/rand"
+	"net/url"
+	"testing"
+	"time"
+
+	"github.com/timescale/tsbs/pkg/query"
+)
+
+const (
+	testScale = 10
+)
+
+type IoTTestCase struct {
+	desc               string
+	input              int
+	fail               bool
+	failMsg            string
+	expectedHumanLabel string
+	expectedHumanDesc  string
+	expectedQuery      string
+}
+
+func TestLastLocByTruck(t *testing.T) {
+	cases := []IoTTestCase{
+		{
+			desc:    "zero trucks",
+			input:   0,
+			fail:    true,
+			failMsg: "number of trucks cannot be < 1; got 0",
+		},
+		{
+			desc:    "more trucks than scale",
+			input:   2 * testScale,
+			fail:    true,
+			failMsg: "number of trucks (20) larger than total trucks. See --scale (10)",
+		},
+		{
+			desc:  "one truck",
+			input: 1,
+
+			expectedHumanLabel: "Influx last location by specific truck",
+			expectedHumanDesc:  "Influx last location by specific truck: random    1 trucks",
+			expectedQuery: `SELECT "name", "driver", "latitude", "longitude" 
+		FROM "readings" 
+		WHERE ("name" = 'truck_5') 
+		ORDER BY "time" 
+		LIMIT 1`,
+		},
+		{
+			desc:  "three truck",
+			input: 3,
+
+			expectedHumanLabel: "Influx last location by specific truck",
+			expectedHumanDesc:  "Influx last location by specific truck: random    3 trucks",
+			expectedQuery: `SELECT "name", "driver", "latitude", "longitude" 
+		FROM "readings" 
+		WHERE ("name" = 'truck_9' or "name" = 'truck_3' or "name" = 'truck_5') 
+		ORDER BY "time" 
+		LIMIT 1`,
+		},
+	}
+
+	testFunc := func(i *IoT, c IoTTestCase) query.Query {
+		q := i.GenerateEmptyQuery()
+		i.LastLocByTruck(q, c.input)
+		return q
+	}
+
+	runIoTTestCases(t, testFunc, time.Now(), time.Now(), cases)
+}
+
+func TestLastLocPerTruck(t *testing.T) {
+	cases := []IoTTestCase{
+		{
+			desc: "default",
+
+			expectedHumanLabel: "Influx last location per truck",
+			expectedHumanDesc:  "Influx last location per truck",
+			expectedQuery: "/query?q=SELECT+%22latitude%22%2C+%22longitude%22+%0A%09%09" +
+				"FROM+%22readings%22+%0A%09%09WHERE+%22fleet%22%3D%27South%27+%0A%09%09" +
+				"GROUP+BY+%22name%22%2C%22driver%22+%0A%09%09ORDER+BY+%22time%22+%0A%09%09LIMIT+1",
+		},
+	}
+
+	for _, c := range cases {
+		rand.Seed(123)
+		b := BaseGenerator{}
+		ig, err := b.NewIoT(time.Now(), time.Now(), 10)
+		if err != nil {
+			t.Fatalf("Error while creating iot generator")
+		}
+
+		g := ig.(*IoT)
+
+		q := g.GenerateEmptyQuery()
+		g.LastLocPerTruck(q)
+
+		verifyQuery(t, q, c.expectedHumanLabel, c.expectedHumanDesc, c.expectedQuery)
+	}
+}
+
+func TestTrucksWithLowFuel(t *testing.T) {
+	cases := []IoTTestCase{
+		{
+			desc: "default",
+
+			expectedHumanLabel: "Influx trucks with low fuel",
+			expectedHumanDesc:  "Influx trucks with low fuel: under 10 percent",
+			expectedQuery: "/query?q=SELECT+%22name%22%2C+%22driver%22%2C+%22fuel_state%22+%0A%09%09" +
+				"FROM+%22diagnostics%22+%0A%09%09WHERE+%22fuel_state%22+%3C%3D+0.1+AND+%22fleet%22+%3D+%27South%27+%0A%09%09" +
+				"GROUP+BY+%22name%22+%0A%09%09ORDER+BY+%22time%22+DESC+%0A%09%09LIMIT+1",
+		},
+	}
+
+	for _, c := range cases {
+		rand.Seed(123)
+		b := BaseGenerator{}
+		ig, err := b.NewIoT(time.Now(), time.Now(), 10)
+		if err != nil {
+			t.Fatalf("Error while creating iot generator")
+		}
+
+		g := ig.(*IoT)
+
+		q := g.GenerateEmptyQuery()
+		g.TrucksWithLowFuel(q)
+
+		verifyQuery(t, q, c.expectedHumanLabel, c.expectedHumanDesc, c.expectedQuery)
+	}
+}
+
+func TestTrucksWithHighLoad(t *testing.T) {
+	cases := []IoTTestCase{
+		{
+			desc: "default",
+
+			expectedHumanLabel: "Influx trucks with high load",
+			expectedHumanDesc:  "Influx trucks with high load: over 90 percent",
+			expectedQuery: "/query?q=SELECT+%22name%22%2C+%22driver%22%2C+%22current_load%22%2C+%22load_capacity%22+%0A%09%09" +
+				"FROM+%28SELECT++%22current_load%22%2C+%22load_capacity%22+%0A%09%09+FROM+%22diagnostics%22+" +
+				"WHERE+fleet+%3D+%27South%27+%0A%09%09+GROUP+BY+%22name%22%2C%22driver%22+%0A%09%09+" +
+				"ORDER+BY+%22time%22+DESC+%0A%09%09+LIMIT+1%29+%0A%09%09WHERE+%22current_load%22+%3E%3D+0.9+%2A+%22load_capacity%22+%0A%09%09" +
+				"GROUP+BY+%22name%22+%0A%09%09ORDER+BY+%22time%22+DESC",
+		},
+	}
+
+	for _, c := range cases {
+		rand.Seed(123)
+		b := BaseGenerator{}
+		ig, err := b.NewIoT(time.Now(), time.Now(), 10)
+		if err != nil {
+			t.Fatalf("Error while creating iot generator")
+		}
+
+		g := ig.(*IoT)
+
+		q := g.GenerateEmptyQuery()
+		g.TrucksWithHighLoad(q)
+
+		verifyQuery(t, q, c.expectedHumanLabel, c.expectedHumanDesc, c.expectedQuery)
+	}
+}
+
+func TestStationaryTrucks(t *testing.T) {
+	cases := []IoTTestCase{
+		{
+			desc: "default",
+
+			expectedHumanLabel: "Influx stationary trucks",
+			expectedHumanDesc:  "Influx stationary trucks: with low avg velocity in last 10 minutes",
+
+			expectedQuery: "/query?q=SELECT+%22name%22%2C+%22driver%22+%0A%09%09FROM%28" +
+				"SELECT+mean%28%22velocity%22%29+as+mean_velocity+%0A%09%09+FROM+%22readings%22+%0A%09%09+" +
+				"WHERE+time+%3E+%271970-01-01T00%3A36%3A22Z%27+AND+time+%3C%3D+%271970-01-01T00%3A46%3A22Z%27+%0A%09%09+" +
+				"GROUP+BY+time%2810m%29%2C%22name%22%2C%22driver%22%2C%22fleet%22++%0A%09%09+" +
+				"LIMIT+1%29+%0A%09%09WHERE+%22fleet%22+%3D+%27West%27+AND+%22mean_velocity%22+%3C+1+%0A%09%09GROUP+BY+%22name%22",
+		},
+	}
+
+	for _, c := range cases {
+		b := &BaseGenerator{}
+		g := NewIoT(time.Unix(0, 0), time.Unix(0, 0).Add(time.Hour), 10, b)
+
+		q := g.GenerateEmptyQuery()
+		rand.Seed(123)
+		g.StationaryTrucks(q)
+
+		verifyQuery(t, q, c.expectedHumanLabel, c.expectedHumanDesc, c.expectedQuery)
+	}
+}
+
+func TestTrucksWithLongDrivingSessions(t *testing.T) {
+	cases := []IoTTestCase{
+		{
+			desc: "default",
+
+			expectedHumanLabel: "Influx trucks with longer driving sessions",
+			expectedHumanDesc:  "Influx trucks with longer driving sessions: stopped less than 20 mins in 4 hour period",
+
+			expectedQuery: "/query?q=SELECT+%22name%22%2C%22driver%22+%0A%09%09FROM%28" +
+				"SELECT+count%28%2A%29+AS+ten_min+%0A%09%09+FROM%28SELECT+mean%28%22velocity%22%29+AS+mean_velocity+%0A%09%09++" +
+				"FROM+readings+%0A%09%09++" +
+				"WHERE+%22fleet%22+%3D+%27West%27+AND+time+%3E+%271970-01-01T00%3A16%3A22Z%27+AND+time+%3C%3D+%271970-01-01T04%3A16%3A22Z%27+%0A%09%09++" +
+				"GROUP+BY+time%2810m%29%2C%22name%22%2C%22driver%22%29+%0A%09%09+" +
+				"WHERE+%22mean_velocity%22+%3E+1+%0A%09%09+GROUP+BY+%22name%22%2C%22driver%22%29+%0A%09%09" +
+				"WHERE+ten_min_mean_velocity+%3E+22",
+		},
+	}
+
+	for _, c := range cases {
+		b := BaseGenerator{}
+		ig, err := b.NewIoT(time.Unix(0, 0), time.Unix(0, 0).Add(6*time.Hour), 10)
+		if err != nil {
+			t.Fatalf("Error while creating iot generator")
+		}
+
+		g := ig.(*IoT)
+
+		q := g.GenerateEmptyQuery()
+		rand.Seed(123)
+		g.TrucksWithLongDrivingSessions(q)
+
+		verifyQuery(t, q, c.expectedHumanLabel, c.expectedHumanDesc, c.expectedQuery)
+	}
+}
+
+func TestTrucksWithLongDailySessions(t *testing.T) {
+	cases := []IoTTestCase{
+		{
+			desc: "default",
+
+			expectedHumanLabel: "Influx trucks with longer daily sessions",
+			expectedHumanDesc:  "Influx trucks with longer daily sessions: drove more than 10 hours in the last 24 hours",
+
+			expectedQuery: "/query?q=SELECT+%22name%22%2C%22driver%22+%0A%09%09" +
+				"FROM%28SELECT+count%28%2A%29+AS+ten_min+%0A%09%09+FROM%28" +
+				"SELECT+mean%28%22velocity%22%29+AS+mean_velocity+%0A%09%09++FROM+readings+%0A%09%09++" +
+				"WHERE+%22fleet%22+%3D+%27West%27+AND+time+%3E+%271970-01-01T00%3A16%3A22Z%27+AND+time+%3C%3D+%271970-01-02T00%3A16%3A22Z%27+%0A%09%09++" +
+				"GROUP+BY+time%2810m%29%2C%22name%22%2C%22driver%22%29+%0A%09%09+" +
+				"WHERE+%22mean_velocity%22+%3E+1+%0A%09%09+" +
+				"GROUP+BY+%22name%22%2C%22driver%22%29+%0A%09%09WHERE+ten_min_mean_velocity+%3E+60",
+		},
+	}
+
+	for _, c := range cases {
+		b := BaseGenerator{}
+		ig, err := b.NewIoT(time.Unix(0, 0), time.Unix(0, 0).Add(25*time.Hour), 10)
+		if err != nil {
+			t.Fatalf("Error while creating iot generator")
+		}
+
+		g := ig.(*IoT)
+
+		q := g.GenerateEmptyQuery()
+		rand.Seed(123)
+		g.TrucksWithLongDailySessions(q)
+
+		verifyQuery(t, q, c.expectedHumanLabel, c.expectedHumanDesc, c.expectedQuery)
+	}
+}
+
+func TestAvgVsProjectedFuelConsumption(t *testing.T) {
+	cases := []IoTTestCase{
+		{
+			desc: "default",
+
+			expectedHumanLabel: "Influx average vs projected fuel consumption per fleet",
+			expectedHumanDesc:  "Influx average vs projected fuel consumption per fleet",
+
+			expectedQuery: "/query?q=SELECT+mean%28%22fuel_consumption%22%29+AS+%22mean_fuel_consumption%22%2C+mean%28%22nominal_fuel_consumption%22%29+AS+%22nominal_fuel_consumption%22+%0A%09%09" +
+				"FROM+%22readings%22+%0A%09%09WHERE+%22velocity%22+%3E+1+%0A%09%09GROUP+BY+%22fleet%22",
+		},
+	}
+
+	for _, c := range cases {
+		b := BaseGenerator{}
+		ig, err := b.NewIoT(time.Unix(0, 0), time.Unix(0, 0).Add(25*time.Hour), 10)
+		if err != nil {
+			t.Fatalf("Error while creating iot generator")
+		}
+
+		g := ig.(*IoT)
+
+		q := g.GenerateEmptyQuery()
+		rand.Seed(123)
+		g.AvgVsProjectedFuelConsumption(q)
+
+		verifyQuery(t, q, c.expectedHumanLabel, c.expectedHumanDesc, c.expectedQuery)
+	}
+}
+
+func TestAvgDailyDrivingDuration(t *testing.T) {
+	cases := []IoTTestCase{
+		{
+			desc: "default",
+
+			expectedHumanLabel: "Influx average driver driving duration per day",
+			expectedHumanDesc:  "Influx average driver driving duration per day",
+
+			expectedQuery: "/query?q=SELECT+count%28%22mv%22%29%2F6+as+%22hours+driven%22+%0A%09%09" +
+				"FROM+%28SELECT+mean%28%22velocity%22%29+as+%22mv%22+%0A%09%09+" +
+				"FROM+%22readings%22+%0A%09%09+WHERE+time+%3E+%271970-01-01T00%3A00%3A00Z%27+AND+time+%3C+%271970-01-02T01%3A00%3A00Z%27+%0A%09%09+" +
+				"GROUP+BY+time%2810m%29%2C%22fleet%22%2C+%22name%22%2C+%22driver%22%29+%0A%09%09" +
+				"WHERE+time+%3E+%271970-01-01T00%3A00%3A00Z%27+AND+time+%3C+%271970-01-02T01%3A00%3A00Z%27+%0A%09%09" +
+				"GROUP+BY+time%281d%29%2C%22fleet%22%2C+%22name%22%2C+%22driver%22",
+		},
+	}
+
+	for _, c := range cases {
+		b := BaseGenerator{}
+		ig, err := b.NewIoT(time.Unix(0, 0), time.Unix(0, 0).Add(25*time.Hour), 10)
+		if err != nil {
+			t.Fatalf("Error while creating iot generator")
+		}
+
+		g := ig.(*IoT)
+
+		q := g.GenerateEmptyQuery()
+		rand.Seed(123)
+		g.AvgDailyDrivingDuration(q)
+
+		verifyQuery(t, q, c.expectedHumanLabel, c.expectedHumanDesc, c.expectedQuery)
+	}
+}
+
+func TestAvgDailyDrivingSession(t *testing.T) {
+	cases := []IoTTestCase{
+		{
+			desc: "default",
+
+			expectedHumanLabel: "Influx average driver driving session without stopping per day",
+			expectedHumanDesc:  "Influx average driver driving session without stopping per day",
+
+			expectedQuery: "/query?q=SELECT+%22elapsed%22+%0A%09%09INTO+%22random_measure2_1%22+%0A%09%09FROM+%28" +
+				"SELECT+difference%28%22difka%22%29%2C+elapsed%28%22difka%22%2C+1m%29+%0A%09%09+" +
+				"FROM+%28SELECT+%22difka%22+%0A%09%09++FROM+%28SELECT+difference%28%22mv%22%29+AS+difka+%0A%09%09+++" +
+				"FROM+%28SELECT+floor%28mean%28%22velocity%22%29%2F10%29%2Ffloor%28mean%28%22velocity%22%29%2F10%29+AS+%22mv%22+%0A%09%09++++" +
+				"FROM+%22readings%22+%0A%09%09++++" +
+				"WHERE+%22name%22%21%3D%27%27+AND+time+%3E+%271970-01-01T00%3A00%3A00Z%27+AND+time+%3C+%271970-01-02T01%3A00%3A00Z%27+%0A%09%09++++" +
+				"GROUP+BY+time%2810m%29%2C+%22name%22+fill%280%29%29+%0A%09%09+++" +
+				"GROUP+BY+%22name%22%29+%0A%09%09++WHERE+%22difka%22%21%3D0+%0A%09%09++" +
+				"GROUP+BY+%22name%22%29+%0A%09%09+GROUP+BY+%22name%22%29+%0A%09%09" +
+				"WHERE+%22difference%22+%3D+-2+%0A%09%09GROUP+BY+%22name%22%3B+%0A%09%09" +
+				"SELECT+mean%28%22elapsed%22%29+%0A%09%09FROM+%22random_measure2_1%22+%0A%09%09" +
+				"WHERE+time+%3E+%271970-01-01T00%3A00%3A00Z%27+AND+time+%3C+%271970-01-02T01%3A00%3A00Z%27+%0A%09%09" +
+				"GROUP+BY+time%281d%29%2C%22name%22",
+		},
+	}
+
+	for _, c := range cases {
+		b := BaseGenerator{}
+		ig, err := b.NewIoT(time.Unix(0, 0), time.Unix(0, 0).Add(25*time.Hour), 10)
+		if err != nil {
+			t.Fatalf("Error while creating iot generator")
+		}
+
+		g := ig.(*IoT)
+
+		q := g.GenerateEmptyQuery()
+		rand.Seed(123)
+		g.AvgDailyDrivingSession(q)
+
+		verifyQuery(t, q, c.expectedHumanLabel, c.expectedHumanDesc, c.expectedQuery)
+	}
+}
+
+func TestAvgLoad(t *testing.T) {
+	cases := []IoTTestCase{
+		{
+			desc: "default",
+
+			expectedHumanLabel: "Influx average load per truck model per fleet",
+			expectedHumanDesc:  "Influx average load per truck model per fleet",
+
+			expectedQuery: "/query?q=SELECT+mean%28%22ml%22%29+AS+mean_load_percentage+%0A%09%09" +
+				"FROM+%28SELECT+%22current_load%22%2F%22load_capacity%22+AS+%22ml%22+%0A%09%09+" +
+				"FROM+%22diagnostics%22+%0A%09%09+GROUP+BY+%22name%22%2C+%22fleet%22%2C+%22model%22%29+%0A%09%09" +
+				"GROUP+BY+%22fleet%22%2C+%22model%22",
+		},
+	}
+
+	for _, c := range cases {
+		b := BaseGenerator{}
+		ig, err := b.NewIoT(time.Unix(0, 0), time.Unix(0, 0).Add(25*time.Hour), 10)
+		if err != nil {
+			t.Fatalf("Error while creating iot generator")
+		}
+
+		g := ig.(*IoT)
+
+		q := g.GenerateEmptyQuery()
+		rand.Seed(123)
+		g.AvgLoad(q)
+
+		verifyQuery(t, q, c.expectedHumanLabel, c.expectedHumanDesc, c.expectedQuery)
+	}
+}
+
+func TestDailyTruckActivity(t *testing.T) {
+	cases := []IoTTestCase{
+		{
+			desc: "default",
+
+			expectedHumanLabel: "Influx daily truck activity per fleet per model",
+			expectedHumanDesc:  "Influx daily truck activity per fleet per model",
+
+			expectedQuery: "/query?q=SELECT+count%28%22ms%22%29%2F144+%0A%09%09FROM+%28" +
+				"SELECT+mean%28%22status%22%29+AS+ms+%0A%09%09+FROM+%22diagnostics%22+%0A%09%09+" +
+				"WHERE+time+%3E%3D+%271970-01-01T00%3A00%3A00Z%27+AND+time+%3C+%271970-01-02T01%3A00%3A00Z%27+%0A%09%09+" +
+				"GROUP+BY+time%2810m%29%2C+%22model%22%2C+%22fleet%22%29+%0A%09%09" +
+				"WHERE+time+%3E%3D+%271970-01-01T00%3A00%3A00Z%27+AND+time+%3C+%271970-01-02T01%3A00%3A00Z%27+AND+%22ms%22%3C1+%0A%09%09" +
+				"GROUP+BY+time%281d%29%2C+%22model%22%2C+%22fleet%22",
+		},
+	}
+
+	for _, c := range cases {
+		b := BaseGenerator{}
+		ig, err := b.NewIoT(time.Unix(0, 0), time.Unix(0, 0).Add(25*time.Hour), 10)
+		if err != nil {
+			t.Fatalf("Error while creating iot generator")
+		}
+
+		g := ig.(*IoT)
+
+		q := g.GenerateEmptyQuery()
+		rand.Seed(123)
+		g.DailyTruckActivity(q)
+
+		verifyQuery(t, q, c.expectedHumanLabel, c.expectedHumanDesc, c.expectedQuery)
+	}
+}
+
+func TestTruckBreakdownFrequency(t *testing.T) {
+	cases := []IoTTestCase{
+		{
+			desc: "default",
+
+			expectedHumanLabel: "Influx truck breakdown frequency per model",
+			expectedHumanDesc:  "Influx truck breakdown frequency per model",
+
+			expectedQuery: "/query?q=SELECT+count%28%22state_changed%22%29+%0A%09%09" +
+				"FROM+%28SELECT+difference%28%22broken_down%22%29+AS+%22state_changed%22+%0A%09%09+" +
+				"FROM+%28SELECT+floor%282%2A%28sum%28%22nzs%22%29%2Fcount%28%22nzs%22%29%29%29%2Ffloor%282%2A%28sum%28%22nzs%22%29%2Fcount%28%22nzs%22%29%29%29+AS+%22broken_down%22+%0A%09%09++" +
+				"FROM+%28SELECT+%22model%22%2C+%22status%22%2F%22status%22+AS+nzs+%0A%09%09+++" +
+				"FROM+%22diagnostics%22+%0A%09%09+++" +
+				"WHERE+time+%3E%3D+%271970-01-01T00%3A00%3A00Z%27+AND+time+%3C+%271970-01-02T01%3A00%3A00Z%27%29+%0A%09%09++" +
+				"WHERE+time+%3E%3D+%271970-01-01T00%3A00%3A00Z%27+AND+time+%3C+%271970-01-02T01%3A00%3A00Z%27+%0A%09%09++" +
+				"GROUP+BY+time%2810m%29%2C%22model%22%29+%0A%09%09+GROUP+BY+%22model%22%29+%0A%09%09" +
+				"WHERE+%22state_changed%22+%3D+1+%0A%09%09GROUP+BY+%22model%22",
+		},
+	}
+
+	for _, c := range cases {
+		b := BaseGenerator{}
+		ig, err := b.NewIoT(time.Unix(0, 0), time.Unix(0, 0).Add(25*time.Hour), 10)
+		if err != nil {
+			t.Fatalf("Error while creating iot generator")
+		}
+
+		g := ig.(*IoT)
+
+		q := g.GenerateEmptyQuery()
+		rand.Seed(123)
+		g.TruckBreakdownFrequency(q)
+
+		verifyQuery(t, q, c.expectedHumanLabel, c.expectedHumanDesc, c.expectedQuery)
+	}
+}
+
+func TestTenMinutePeriods(t *testing.T) {
+	cases := []struct {
+		minutesPerHour float64
+		duration       time.Duration
+		result         int
+	}{
+		{
+			minutesPerHour: 5.0,
+			duration:       4 * time.Hour,
+			result:         22,
+		},
+		{
+			minutesPerHour: 10.0,
+			duration:       24 * time.Hour,
+			result:         120,
+		},
+		{
+			minutesPerHour: 0.0,
+			duration:       24 * time.Hour,
+			result:         144,
+		},
+		{
+			minutesPerHour: 1.0,
+			duration:       0 * time.Minute,
+			result:         0,
+		},
+		{
+			minutesPerHour: 0.0,
+			duration:       0 * time.Minute,
+			result:         0,
+		},
+		{
+			minutesPerHour: 1.0,
+			duration:       30 * time.Minute,
+			result:         2,
+		},
+	}
+
+	for _, c := range cases {
+		if got := tenMinutePeriods(c.minutesPerHour, c.duration); got != c.result {
+			t.Errorf("incorrect result for %.2f minutes per hour, duration %s: got %d want %d", c.minutesPerHour, c.duration.String(), got, c.result)
+		}
+	}
+
+}
+
+func runIoTTestCases(t *testing.T, testFunc func(*IoT, IoTTestCase) query.Query, s time.Time, e time.Time, cases []IoTTestCase) {
+	rand.Seed(123) // Setting seed for testing purposes.
+
+	for _, c := range cases {
+		t.Run(c.desc, func(t *testing.T) {
+			b := BaseGenerator{}
+			dq, err := b.NewIoT(s, e, testScale)
+			if err != nil {
+				t.Fatalf("Error while creating devops generator")
+			}
+			i := dq.(*IoT)
+
+			if c.fail {
+				func() {
+					defer func() {
+						r := recover()
+						if r == nil {
+							t.Fatalf("did not panic when should")
+						}
+
+						if r != c.failMsg {
+							t.Fatalf("incorrect fail message: got %s, want %s", r, c.failMsg)
+						}
+					}()
+
+					testFunc(i, c)
+				}()
+			} else {
+				q := testFunc(i, c)
+
+				v := url.Values{}
+				v.Set("q", c.expectedQuery)
+				expectedPath := fmt.Sprintf("/query?%s", v.Encode())
+
+				verifyQuery(t, q, c.expectedHumanLabel, c.expectedHumanDesc, expectedPath)
+			}
+		})
+	}
+}

--- a/cmd/tsbs_run_queries_influx/http_client.go
+++ b/cmd/tsbs_run_queries_influx/http_client.go
@@ -3,6 +3,7 @@ package main
 import (
 	"encoding/json"
 	"fmt"
+	"io"
 	"io/ioutil"
 	"net/http"
 	"net/url"
@@ -71,6 +72,7 @@ func (w *HTTPClient) Do(q *query.HTTP, opts *HTTPClientDoOptions) (lag float64, 
 
 	// populate a request with data from the Query:
 	req, err := http.NewRequest(string(q.Method), string(w.uri), nil)
+	req.Header.Add("Content-Type", "application/x-www-form-urlencoded")
 	if err != nil {
 		panic(err)
 	}
@@ -83,7 +85,8 @@ func (w *HTTPClient) Do(q *query.HTTP, opts *HTTPClientDoOptions) (lag float64, 
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusOK {
-		panic("http request did not return status 200 OK")
+		body, _ := io.ReadAll(resp.Body)
+		panic(fmt.Sprintf("http request did not return status 200 OK, code=%d, body=%s", resp.StatusCode, body))
 	}
 
 	var body []byte

--- a/pkg/query/factories/init_factories.go
+++ b/pkg/query/factories/init_factories.go
@@ -5,6 +5,7 @@ import (
 	"github.com/timescale/tsbs/cmd/tsbs_generate_queries/databases/cassandra"
 	"github.com/timescale/tsbs/cmd/tsbs_generate_queries/databases/clickhouse"
 	"github.com/timescale/tsbs/cmd/tsbs_generate_queries/databases/cratedb"
+	"github.com/timescale/tsbs/cmd/tsbs_generate_queries/databases/greptime"
 	"github.com/timescale/tsbs/cmd/tsbs_generate_queries/databases/influx"
 	"github.com/timescale/tsbs/cmd/tsbs_generate_queries/databases/mongo"
 	"github.com/timescale/tsbs/cmd/tsbs_generate_queries/databases/questdb"
@@ -39,5 +40,6 @@ func InitQueryFactories(config *config.QueryGeneratorConfig) map[string]interfac
 		DBName: config.DbName,
 	}
 	factories[constants.FormatQuestDB] = &questdb.BaseGenerator{}
+	factories[constants.FormatGreptime] = &greptime.BaseGenerator{}
 	return factories
 }

--- a/pkg/targets/constants/constants.go
+++ b/pkg/targets/constants/constants.go
@@ -15,6 +15,7 @@ const (
 	FormatTimestream      = "timestream"
 	FormatQuestDB         = "questdb"
 	FormatInflux2          = "influx2"
+	FormatGreptime          = "greptime"
 )
 
 func SupportedFormats() []string {
@@ -32,5 +33,6 @@ func SupportedFormats() []string {
 		FormatTimestream,
 		FormatQuestDB,
 		FormatInflux2,
+		FormatGreptime,
 	}
 }

--- a/pkg/targets/initializers/target_initializers.go
+++ b/pkg/targets/initializers/target_initializers.go
@@ -48,6 +48,9 @@ func GetTarget(format string) targets.ImplementedTarget {
 		return questdb.NewTarget()
 	case constants.FormatInflux2:
 		return influx2.NewTarget()
+	case constants.FormatGreptime:
+		// Reuses influx's target.
+		return influx.NewTarget()
 	}
 
 	supportedFormatsStr := strings.Join(constants.SupportedFormats(), ",")


### PR DESCRIPTION
Currently only support
- LastPointPerHost (lastpoint)
- HighCPUForHosts (high-cpu-*)

Query GreptimeDB
```bash
./bin/tsbs_generate_queries --use-case="devops" --seed=123 --scale=4000 \
    --timestamp-start="2016-01-01T00:00:00Z" \
    --timestamp-end="2016-01-02T00:00:00Z" \
    --query-type="high-cpu-1" \
    --queries=1000 \
    --format="greptime" > greptime-query.dat

./bin/tsbs_run_queries_influx --file=./greptime-query.dat \
    --db-name=public \
    --debug=4 \
    --urls="http://localhost:4000"
```
