### PR TITLE
feat: replace mean with avg

### DIFF
--- a/cmd/tsbs_generate_queries/databases/greptime/devops.go
+++ b/cmd/tsbs_generate_queries/databases/greptime/devops.go
@@ -89,7 +89,7 @@ func (d *Devops) GroupByTimeAndPrimaryTag(qi query.Query, numMetrics int) {
 	metrics, err := devops.GetCPUMetricsSlice(numMetrics)
 	databases.PanicIfErr(err)
 	interval := d.Interval.MustRandWindow(devops.DoubleGroupByDuration)
-	selectClauses := d.getSelectClausesAggMetrics("mean", metrics)
+	selectClauses := d.getSelectClausesAggMetrics("avg", metrics)
 
 	humanLabel := devops.GetDoubleGroupByLabel("Influx", numMetrics)
 	humanDesc := fmt.Sprintf("%s: %s", humanLabel, interval.StartString())


### PR DESCRIPTION
Projection pushdown has regression for UDAF mean.

See https://github.com/GreptimeTeam/greptimedb/issues/2730