### PR TITLE
fix: handle existing GreptimeDB databases

### DIFF
--- a/cmd/tsbs_load_greptime/creator.go
+++ b/cmd/tsbs_load_greptime/creator.go
@@ -7,7 +7,8 @@ import (
 	"io/ioutil"
 	"log"
 	"net/http"
-	"time"
+	"net/url"
+	"strings"
 )
 
 type dbCreator struct {
@@ -34,102 +35,85 @@ func (d *dbCreator) DBExists(dbName string) bool {
 	}
 
 	for _, db := range dbs {
-		if db == loader.DatabaseName() {
+		if db == dbName {
 			return true
 		}
 	}
 	return false
 }
 
-func (d *dbCreator) listDatabases() ([]string, error) {
-	u := fmt.Sprintf("%s/v1/sql?sql=show%%20databases", d.daemonURL)
-	req, err := http.NewRequest("GET", u, nil)
+func (d *dbCreator) executeSQL(sql string) ([]byte, error) {
+	form := url.Values{}
+	form.Set("sql", sql)
+	req, err := http.NewRequest(
+		http.MethodPost,
+		strings.TrimRight(d.daemonURL, "/")+"/v1/sql",
+		strings.NewReader(form.Encode()),
+	)
 	if err != nil {
-		return nil, fmt.Errorf("listDatabases error: %s", err.Error())
+		return nil, fmt.Errorf("create SQL request: %w", err)
 	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	d.addAuthHeader(req)
 
-	client := &http.Client{}
-	resp, err := client.Do(req)
+	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
-		return nil, fmt.Errorf("listDatabases error: %s", err.Error())
+		return nil, fmt.Errorf("execute SQL %q: %w", sql, err)
 	}
 	defer resp.Body.Close()
 
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("read response for SQL %q: %w", sql, err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf(
+			"execute SQL %q returned %s: %s",
+			sql,
+			resp.Status,
+			strings.TrimSpace(string(body)),
+		)
+	}
+	return body, nil
+}
+
+func (d *dbCreator) listDatabases() ([]string, error) {
+	body, err := d.executeSQL("SHOW DATABASES")
+	if err != nil {
+		return nil, fmt.Errorf("list databases: %w", err)
 	}
 
-	// Do ad-hoc parsing to find existing database names:
-	// {"code":0,"output":[{"records":{"schema":{"column_schemas":[{"name":"Schemas","data_type":"String"}]},"rows":[["public"]]}}],"execution_time_ms":0}
 	type listingType struct {
 		Output []struct {
-			Rows [][]string
-		}
+			Records struct {
+				Rows [][]string `json:"rows"`
+			} `json:"records"`
+		} `json:"output"`
 	}
 	var listing listingType
-	err = json.Unmarshal(body, &listing)
-	if err != nil {
-		return nil, err
+	if err := json.Unmarshal(body, &listing); err != nil {
+		return nil, fmt.Errorf("decode database listing: %w", err)
+	}
+	if len(listing.Output) == 0 {
+		return nil, fmt.Errorf("decode database listing: response contains no output")
 	}
 
-	ret := []string{}
-	for _, nestedName := range listing.Output[0].Rows {
-		name := nestedName[0]
-		// the _internal database is skipped:
-		if name == "_internal" {
-			continue
+	databaseNames := make([]string, 0, len(listing.Output[0].Records.Rows))
+	for i, row := range listing.Output[0].Records.Rows {
+		if len(row) == 0 {
+			return nil, fmt.Errorf("decode database listing: row %d contains no database name", i)
 		}
-		ret = append(ret, name)
+		databaseNames = append(databaseNames, row[0])
 	}
-	return ret, nil
+	return databaseNames, nil
 }
 
 func (d *dbCreator) RemoveOldDB(dbName string) error {
-	u := fmt.Sprintf("%s/v1/sql?sql=drop+database+%s", d.daemonURL, dbName)
-	req, err := http.NewRequest("POST", u, nil)
-	if err != nil {
-		return fmt.Errorf("drop db error: %s", err.Error())
-	}
-	req.Header.Set("Content-Type", "text/plain")
-	d.addAuthHeader(req)
-
-	client := &http.Client{}
-	resp, err := client.Do(req)
-	if err != nil {
-		return fmt.Errorf("drop db error: %s", err.Error())
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode != 200 {
-		return fmt.Errorf("drop db returned non-200 code: %d", resp.StatusCode)
-	}
-	time.Sleep(time.Second)
-	return nil
+	_, err := d.executeSQL(fmt.Sprintf("DROP DATABASE %s", dbName))
+	return err
 }
 
 func (d *dbCreator) CreateDB(dbName string) error {
-	u := fmt.Sprintf("%s/v1/sql?sql=create%%20database%%20%s", d.daemonURL, dbName)
-	req, err := http.NewRequest("GET", u, nil)
-	if err != nil {
-		return fmt.Errorf("create db error: %s", err.Error())
-	}
-	d.addAuthHeader(req)
-
-	client := &http.Client{}
-	resp, err := client.Do(req)
-	if err != nil {
-		return fmt.Errorf("create db error: %s", err.Error())
-	}
-	defer resp.Body.Close()
-
-	// does the body need to be read into the void?
-
-	if resp.StatusCode != 200 {
-		return fmt.Errorf("bad db create")
-	}
-
-	time.Sleep(time.Second)
-	return nil
+	_, err := d.executeSQL(fmt.Sprintf("CREATE DATABASE %s", dbName))
+	return err
 }

--- a/cmd/tsbs_load_greptime/creator_test.go
+++ b/cmd/tsbs_load_greptime/creator_test.go
@@ -1,0 +1,133 @@
+package main
+
+import (
+	"encoding/base64"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func TestListDatabases(t *testing.T) {
+	oldUsername, oldPassword := username, password
+	username, password = "greptime", "secret"
+	defer func() {
+		username, password = oldUsername, oldPassword
+	}()
+
+	wantAuthorization := "Basic " + base64.StdEncoding.EncodeToString([]byte("greptime:secret"))
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Errorf("unexpected method: got %s want %s", r.Method, http.MethodPost)
+		}
+		if got := r.Header.Get("Content-Type"); got != "application/x-www-form-urlencoded" {
+			t.Errorf("unexpected content type: got %q", got)
+		}
+		if got := r.Header.Get("Authorization"); got != wantAuthorization {
+			t.Errorf("unexpected authorization: got %q want %q", got, wantAuthorization)
+		}
+		if err := r.ParseForm(); err != nil {
+			t.Errorf("parse request form: %v", err)
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		if got := r.Form.Get("sql"); got != "SHOW DATABASES" {
+			t.Errorf("unexpected SQL: got %q", got)
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `{"output":[{"records":{"schema":{"column_schemas":[{"name":"Database","data_type":"String"}]},"rows":[["greptime_private"],["information_schema"],["public"],["benchmark"]],"total_rows":4}}],"execution_time_ms":2}`)
+	}))
+	defer server.Close()
+
+	creator := &dbCreator{daemonURL: server.URL + "/"}
+	want := []string{"greptime_private", "information_schema", "public", "benchmark"}
+	got, err := creator.listDatabases()
+	if err != nil {
+		t.Fatalf("list databases: %v", err)
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("unexpected databases: got %v want %v", got, want)
+	}
+	if !creator.DBExists("benchmark") {
+		t.Error("expected benchmark database to exist")
+	}
+	if creator.DBExists("missing") {
+		t.Error("did not expect missing database to exist")
+	}
+}
+
+func TestListDatabasesRejectsMalformedResponses(t *testing.T) {
+	tests := []struct {
+		name    string
+		body    string
+		wantErr string
+	}{
+		{name: "invalid JSON", body: `{`, wantErr: "decode database listing"},
+		{name: "missing output", body: `{}`, wantErr: "response contains no output"},
+		{name: "empty row", body: `{"output":[{"records":{"rows":[[]]}}]}`, wantErr: "row 0 contains no database name"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				fmt.Fprint(w, test.body)
+			}))
+			defer server.Close()
+
+			creator := &dbCreator{daemonURL: server.URL}
+			_, err := creator.listDatabases()
+			if err == nil || !strings.Contains(err.Error(), test.wantErr) {
+				t.Fatalf("unexpected error: got %v want substring %q", err, test.wantErr)
+			}
+		})
+	}
+}
+
+func TestCreateAndRemoveDatabase(t *testing.T) {
+	var statements []string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := r.ParseForm(); err != nil {
+			t.Errorf("parse request form: %v", err)
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		statements = append(statements, r.Form.Get("sql"))
+		fmt.Fprint(w, `{"output":[{"affectedrows":1}],"execution_time_ms":1}`)
+	}))
+	defer server.Close()
+
+	creator := &dbCreator{daemonURL: server.URL}
+	if err := creator.CreateDB("benchmark"); err != nil {
+		t.Fatalf("create database: %v", err)
+	}
+	if err := creator.RemoveOldDB("benchmark"); err != nil {
+		t.Fatalf("remove database: %v", err)
+	}
+
+	want := []string{"CREATE DATABASE benchmark", "DROP DATABASE benchmark"}
+	if !reflect.DeepEqual(statements, want) {
+		t.Fatalf("unexpected SQL statements: got %v want %v", statements, want)
+	}
+}
+
+func TestCreateDatabaseReportsServerError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+		fmt.Fprint(w, `{"error":"Database 'benchmark' already exists"}`)
+	}))
+	defer server.Close()
+
+	creator := &dbCreator{daemonURL: server.URL}
+	err := creator.CreateDB("benchmark")
+	if err == nil {
+		t.Fatal("expected create database to fail")
+	}
+	for _, want := range []string{"400 Bad Request", "Database 'benchmark' already exists"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("error %q does not contain %q", err, want)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

- use GreptimeDB's POST form SQL API for database lifecycle requests
- parse database names from `output[].records.rows`
- remove the inherited InfluxDB `_internal` handling and use the supplied database name
- surface HTTP status and GreptimeDB response bodies on failures
- remove unnecessary DDL sleeps and add focused HTTP tests

## Root cause

The GreptimeDB loader was forked from the InfluxDB loader, but its database-listing parser still expected the wrong response shape. Existing databases were therefore not detected, and the loader attempted `CREATE DATABASE` again. GreptimeDB returned HTTP 400, which the loader reduced to the opaque `panic: bad db create` message.

## Impact

Existing databases are now detected correctly. The shared TSBS behavior is preserved: with `--do-create-db=true`, an existing database is recreated; with `--do-create-db=false`, it is reused.

## Testing

- `go test ./cmd/tsbs_load_greptime ./load`
- `git diff --check`