### PR TITLE
Add InfluxDB 3 benchmark support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,6 +22,7 @@ loaders: tsbs_load \
 		 tsbs_load_cratedb \
 		 tsbs_load_influx \
 		 tsbs_load_influx2 \
+		 tsbs_load_influx3 \
  		 tsbs_load_mongo \
  		 tsbs_load_prometheus \
  		 tsbs_load_siridb \
@@ -35,6 +36,7 @@ runners: tsbs_run_queries_akumuli \
 		 tsbs_run_queries_clickhouse \
 		 tsbs_run_queries_cratedb \
 		 tsbs_run_queries_influx \
+		 tsbs_run_queries_influx3 \
 		 tsbs_run_queries_mongo \
 		 tsbs_run_queries_siridb \
 		 tsbs_run_queries_timescaledb \
@@ -48,6 +50,8 @@ test:
       ./cmd/tsbs_generate_queries \
       ./cmd/tsbs_load \
       ./cmd/tsbs_load_greptime \
+      ./cmd/tsbs_load_influx3 \
+      ./cmd/tsbs_run_queries_influx3 \
       ./internal/... \
       ./load/... \
       ./pkg/...

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Current databases supported:
 + ClickHouse [(supplemental docs)](docs/clickhouse.md)
 + CrateDB [(supplemental docs)](docs/cratedb.md)
 + InfluxDB [(supplemental docs)](docs/influx.md)
++ InfluxDB 3 Core and Enterprise [(supplemental docs)](docs/influx3.md)
 + MongoDB [(supplemental docs)](docs/mongo.md)
 + QuestDB [(supplemental docs)](docs/questdb.md)
 + SiriDB [(supplemental docs)](docs/siridb.md)
@@ -75,6 +76,7 @@ cases are implemented for each database:
 |ClickHouse|X||
 |CrateDB|X||
 |InfluxDB|X|X|
+|InfluxDB 3|X||
 |MongoDB|X|
 |QuestDB|X|X
 |SiriDB|X|
@@ -134,7 +136,7 @@ Variables needed:
 1. an end time. E.g., `2016-01-04T00:00:00Z`
 1. how much time should be between each reading per device, in seconds. E.g., `10s`
 1. and which database(s) you want to generate for. E.g., `timescaledb`
- (choose from `cassandra`, `clickhouse`, `cratedb`, `influx`, `mongo`, `questdb`, `siridb`,
+ (choose from `cassandra`, `clickhouse`, `cratedb`, `influx`, `influx3`, `mongo`, `questdb`, `siridb`,
   `timescaledb` or `victoriametrics`)
 
 Given the above steps you can now generate a dataset (or multiple

--- a/cmd/tsbs_generate_queries/databases/influx3/common.go
+++ b/cmd/tsbs_generate_queries/databases/influx3/common.go
@@ -1,0 +1,36 @@
+package influx3
+
+import (
+	"time"
+
+	"github.com/timescale/tsbs/cmd/tsbs_generate_queries/uses/devops"
+	"github.com/timescale/tsbs/cmd/tsbs_generate_queries/utils"
+	"github.com/timescale/tsbs/pkg/query"
+)
+
+const queryPath = "/api/v3/query_sql"
+
+// BaseGenerator contains settings specific to InfluxDB 3.
+type BaseGenerator struct{}
+
+func (g *BaseGenerator) GenerateEmptyQuery() query.Query {
+	return query.NewHTTP()
+}
+
+func (g *BaseGenerator) fillInQuery(qi query.Query, humanLabel, humanDesc, sql string) {
+	q := qi.(*query.HTTP)
+	q.HumanLabel = []byte(humanLabel)
+	q.HumanDescription = []byte(humanDesc)
+	q.Method = []byte("POST")
+	q.Path = []byte(queryPath)
+	q.Body = nil
+	q.RawQuery = []byte(sql)
+}
+
+func (g *BaseGenerator) NewDevops(start, end time.Time, scale int) (utils.QueryGenerator, error) {
+	core, err := devops.NewCore(start, end, scale)
+	if err != nil {
+		return nil, err
+	}
+	return &Devops{BaseGenerator: g, Core: core}, nil
+}

--- a/cmd/tsbs_generate_queries/databases/influx3/devops.go
+++ b/cmd/tsbs_generate_queries/databases/influx3/devops.go
@@ -1,0 +1,156 @@
+package influx3
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/timescale/tsbs/cmd/tsbs_generate_queries/databases"
+	"github.com/timescale/tsbs/cmd/tsbs_generate_queries/uses/devops"
+	"github.com/timescale/tsbs/pkg/query"
+)
+
+const databaseLabel = "InfluxDB 3"
+
+var cpuTagColumns = []string{
+	"hostname",
+	"region",
+	"datacenter",
+	"rack",
+	"os",
+	"arch",
+	"team",
+	"service",
+	"service_version",
+	"service_environment",
+}
+
+// Devops produces InfluxDB 3 SQL queries for the TSBS devops query types.
+type Devops struct {
+	*BaseGenerator
+	*devops.Core
+}
+
+func (d *Devops) getHostWhereWithHostnames(hostnames []string) string {
+	quoted := make([]string, len(hostnames))
+	for i, hostname := range hostnames {
+		quoted[i] = fmt.Sprintf("'%s'", strings.ReplaceAll(hostname, "'", "''"))
+	}
+	return fmt.Sprintf("hostname IN (%s)", strings.Join(quoted, ", "))
+}
+
+func (d *Devops) getHostWhereString(nHosts int) string {
+	hostnames, err := d.GetRandomHosts(nHosts)
+	databases.PanicIfErr(err)
+	return d.getHostWhereWithHostnames(hostnames)
+}
+
+func getSelectClausesAggMetrics(agg string, metrics []string) []string {
+	clauses := make([]string, len(metrics))
+	for i, metric := range metrics {
+		clauses[i] = fmt.Sprintf("%[1]s(%[2]s) AS %[1]s_%[2]s", agg, metric)
+	}
+	return clauses
+}
+
+func (d *Devops) GroupByTime(qi query.Query, nHosts, numMetrics int, timeRange time.Duration) {
+	interval := d.Interval.MustRandWindow(timeRange)
+	metrics, err := devops.GetCPUMetricsSlice(numMetrics)
+	databases.PanicIfErr(err)
+
+	sql := fmt.Sprintf(`SELECT date_bin(INTERVAL '1 minute', time) AS minute,
+       %s
+FROM cpu
+WHERE %s AND time >= '%s' AND time < '%s'
+GROUP BY 1
+ORDER BY 1 ASC`,
+		strings.Join(getSelectClausesAggMetrics("max", metrics), ", "),
+		d.getHostWhereString(nHosts), interval.StartString(), interval.EndString())
+
+	humanLabel := fmt.Sprintf("%s %d cpu metric(s), random %4d hosts, random %s by 1m", databaseLabel, numMetrics, nHosts, timeRange)
+	humanDesc := fmt.Sprintf("%s: %s", humanLabel, interval.StartString())
+	d.fillInQuery(qi, humanLabel, humanDesc, sql)
+}
+
+func (d *Devops) GroupByOrderByLimit(qi query.Query) {
+	interval := d.Interval.MustRandWindow(time.Hour)
+	sql := fmt.Sprintf(`SELECT date_bin(INTERVAL '1 minute', time) AS minute,
+       max(usage_user) AS max_usage_user
+FROM cpu
+WHERE time < '%s'
+GROUP BY 1
+ORDER BY 1 DESC
+LIMIT 5`, interval.EndString())
+
+	humanLabel := databaseLabel + " max cpu over last 5 min-intervals (random end)"
+	humanDesc := fmt.Sprintf("%s: %s", humanLabel, interval.EndString())
+	d.fillInQuery(qi, humanLabel, humanDesc, sql)
+}
+
+func (d *Devops) GroupByTimeAndPrimaryTag(qi query.Query, numMetrics int) {
+	interval := d.Interval.MustRandWindow(devops.DoubleGroupByDuration)
+	metrics, err := devops.GetCPUMetricsSlice(numMetrics)
+	databases.PanicIfErr(err)
+
+	sql := fmt.Sprintf(`SELECT date_bin(INTERVAL '1 hour', time) AS hour,
+       hostname,
+       %s
+FROM cpu
+WHERE time >= '%s' AND time < '%s'
+GROUP BY 1, hostname
+ORDER BY 1 ASC, hostname ASC`,
+		strings.Join(getSelectClausesAggMetrics("avg", metrics), ", "),
+		interval.StartString(), interval.EndString())
+
+	humanLabel := devops.GetDoubleGroupByLabel(databaseLabel, numMetrics)
+	humanDesc := fmt.Sprintf("%s: %s", humanLabel, interval.StartString())
+	d.fillInQuery(qi, humanLabel, humanDesc, sql)
+}
+
+func (d *Devops) MaxAllCPU(qi query.Query, nHosts int, duration time.Duration) {
+	interval := d.Interval.MustRandWindow(duration)
+	sql := fmt.Sprintf(`SELECT date_bin(INTERVAL '1 hour', time) AS hour,
+       %s
+FROM cpu
+WHERE %s AND time >= '%s' AND time < '%s'
+GROUP BY 1
+ORDER BY 1 ASC`,
+		strings.Join(getSelectClausesAggMetrics("max", devops.GetAllCPUMetrics()), ", "),
+		d.getHostWhereString(nHosts), interval.StartString(), interval.EndString())
+
+	humanLabel := devops.GetMaxAllLabel(databaseLabel, nHosts)
+	humanDesc := fmt.Sprintf("%s: %s", humanLabel, interval.StartString())
+	d.fillInQuery(qi, humanLabel, humanDesc, sql)
+}
+
+func (d *Devops) LastPointPerHost(qi query.Query) {
+	columns := append([]string{}, cpuTagColumns...)
+	columns = append(columns, devops.GetAllCPUMetrics()...)
+
+	selectClauses := []string{"hostname", "last_value(time ORDER BY time) AS time"}
+	for _, column := range columns[1:] {
+		selectClauses = append(selectClauses, fmt.Sprintf("last_value(%[1]s ORDER BY time) AS %[1]s", column))
+	}
+
+	sql := fmt.Sprintf("SELECT %s\nFROM cpu\nGROUP BY hostname\nORDER BY hostname ASC", strings.Join(selectClauses, ",\n       "))
+	humanLabel := databaseLabel + " last row per host"
+	d.fillInQuery(qi, humanLabel, humanLabel+": cpu", sql)
+}
+
+func (d *Devops) HighCPUForHosts(qi query.Query, nHosts int) {
+	interval := d.Interval.MustRandWindow(devops.HighCPUDuration)
+	predicates := []string{
+		"usage_user > 90.0",
+		fmt.Sprintf("time >= '%s'", interval.StartString()),
+		fmt.Sprintf("time < '%s'", interval.EndString()),
+	}
+	if nHosts > 0 {
+		predicates = append(predicates, d.getHostWhereString(nHosts))
+	}
+
+	sql := fmt.Sprintf("SELECT *\nFROM cpu\nWHERE %s\nORDER BY time ASC, hostname ASC", strings.Join(predicates, " AND "))
+	humanLabel, err := devops.GetHighCPULabel(databaseLabel, nHosts)
+	databases.PanicIfErr(err)
+	humanDesc := fmt.Sprintf("%s: %s", humanLabel, interval.StartString())
+	d.fillInQuery(qi, humanLabel, humanDesc, sql)
+}

--- a/cmd/tsbs_generate_queries/databases/influx3/devops_test.go
+++ b/cmd/tsbs_generate_queries/databases/influx3/devops_test.go
@@ -1,0 +1,121 @@
+package influx3
+
+import (
+	"math/rand"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/timescale/tsbs/cmd/tsbs_generate_queries/uses/devops"
+	"github.com/timescale/tsbs/pkg/query"
+)
+
+func newTestDevops(t *testing.T) *Devops {
+	t.Helper()
+	rand.Seed(123)
+	start := time.Date(2016, 1, 1, 0, 0, 0, 0, time.UTC)
+	generator, err := (&BaseGenerator{}).NewDevops(start, start.Add(72*time.Hour), 100)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return generator.(*Devops)
+}
+
+func assertHTTPQuery(t *testing.T, q query.Query, fragments ...string) {
+	t.Helper()
+	hq := q.(*query.HTTP)
+	if got := string(hq.Method); got != "POST" {
+		t.Fatalf("unexpected method: %q", got)
+	}
+	if got := string(hq.Path); got != queryPath {
+		t.Fatalf("unexpected path: %q", got)
+	}
+	for _, fragment := range fragments {
+		if !strings.Contains(string(hq.RawQuery), fragment) {
+			t.Errorf("query does not contain %q:\n%s", fragment, hq.RawQuery)
+		}
+	}
+	q.Release()
+}
+
+func TestHostFilter(t *testing.T) {
+	d := newTestDevops(t)
+	if got, want := d.getHostWhereWithHostnames([]string{"host_1", "host_2"}), "hostname IN ('host_1', 'host_2')"; got != want {
+		t.Fatalf("got %q want %q", got, want)
+	}
+}
+
+func TestCPUQueries(t *testing.T) {
+	t.Run("single group by", func(t *testing.T) {
+		d := newTestDevops(t)
+		q := d.GenerateEmptyQuery()
+		d.GroupByTime(q, 2, 5, time.Hour)
+		assertHTTPQuery(t, q,
+			"date_bin(INTERVAL '1 minute', time)",
+			"max(usage_iowait) AS max_usage_iowait",
+			"hostname IN (",
+			"GROUP BY 1",
+			"ORDER BY 1 ASC",
+		)
+	})
+
+	t.Run("order by limit", func(t *testing.T) {
+		d := newTestDevops(t)
+		q := d.GenerateEmptyQuery()
+		d.GroupByOrderByLimit(q)
+		assertHTTPQuery(t, q, "WHERE time < '", "ORDER BY 1 DESC", "LIMIT 5")
+	})
+
+	t.Run("double group by", func(t *testing.T) {
+		d := newTestDevops(t)
+		q := d.GenerateEmptyQuery()
+		d.GroupByTimeAndPrimaryTag(q, 5)
+		assertHTTPQuery(t, q,
+			"date_bin(INTERVAL '1 hour', time)",
+			"avg(usage_iowait) AS avg_usage_iowait",
+			"GROUP BY 1, hostname",
+			"ORDER BY 1 ASC, hostname ASC",
+		)
+	})
+
+	t.Run("max all", func(t *testing.T) {
+		d := newTestDevops(t)
+		q := d.GenerateEmptyQuery()
+		d.MaxAllCPU(q, 8, devops.MaxAllDuration)
+		assertHTTPQuery(t, q,
+			"max(usage_user) AS max_usage_user",
+			"max(usage_guest_nice) AS max_usage_guest_nice",
+			"hostname IN (",
+		)
+	})
+
+	t.Run("last point", func(t *testing.T) {
+		d := newTestDevops(t)
+		q := d.GenerateEmptyQuery()
+		d.LastPointPerHost(q)
+		assertHTTPQuery(t, q,
+			"last_value(time ORDER BY time) AS time",
+			"last_value(region ORDER BY time) AS region",
+			"last_value(usage_guest_nice ORDER BY time) AS usage_guest_nice",
+			"GROUP BY hostname",
+			"ORDER BY hostname ASC",
+		)
+	})
+
+	t.Run("high CPU all hosts", func(t *testing.T) {
+		d := newTestDevops(t)
+		q := d.GenerateEmptyQuery()
+		d.HighCPUForHosts(q, 0)
+		if strings.Contains(string(q.(*query.HTTP).RawQuery), "hostname IN") {
+			t.Fatal("all-host query unexpectedly contains a host filter")
+		}
+		assertHTTPQuery(t, q, "usage_user > 90.0", "time >= '", "time < '", "ORDER BY time ASC, hostname ASC")
+	})
+
+	t.Run("high CPU one host", func(t *testing.T) {
+		d := newTestDevops(t)
+		q := d.GenerateEmptyQuery()
+		d.HighCPUForHosts(q, 1)
+		assertHTTPQuery(t, q, "usage_user > 90.0", "hostname IN ('host_")
+	})
+}

--- a/cmd/tsbs_load_influx3/creator.go
+++ b/cmd/tsbs_load_influx3/creator.go
@@ -1,0 +1,118 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+)
+
+type dbCreator struct {
+	daemonURL string
+	client    *http.Client
+}
+
+func (d *dbCreator) Init() {
+	d.daemonURL = daemonURLs[0]
+	d.client = &http.Client{}
+}
+
+func (d *dbCreator) newRequest(method, endpoint string, body io.Reader) (*http.Request, error) {
+	req, err := http.NewRequest(method, d.daemonURL+endpoint, body)
+	if err != nil {
+		return nil, err
+	}
+	if adminToken != "" {
+		req.Header.Set("Authorization", "Bearer "+adminToken)
+	}
+	return req, nil
+}
+
+func responseError(action string, resp *http.Response, body []byte) error {
+	return fmt.Errorf("InfluxDB 3 %s failed (status %d): %s", action, resp.StatusCode, body)
+}
+
+func (d *dbCreator) DBExists(dbName string) bool {
+	req, err := d.newRequest(http.MethodGet, "/api/v3/configure/database?format=json", nil)
+	if err != nil {
+		fatal("could not create InfluxDB 3 database-list request: %v", err)
+		return false
+	}
+	resp, err := d.client.Do(req)
+	if err != nil {
+		fatal("could not list InfluxDB 3 databases: %v", err)
+		return false
+	}
+	defer resp.Body.Close()
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		fatal("could not read InfluxDB 3 database list: %v", err)
+		return false
+	}
+	if resp.StatusCode != http.StatusOK {
+		fatal("%v", responseError("database list", resp, body))
+		return false
+	}
+
+	var rows []map[string]interface{}
+	if err := json.Unmarshal(body, &rows); err != nil {
+		fatal("could not decode InfluxDB 3 database list: %v", err)
+		return false
+	}
+	for _, row := range rows {
+		if name, ok := row["iox::database"].(string); ok && name == dbName {
+			return true
+		}
+	}
+	return false
+}
+
+func (d *dbCreator) RemoveOldDB(dbName string) error {
+	params := url.Values{}
+	params.Set("db", dbName)
+	params.Set("hard_delete_at", "now")
+	req, err := d.newRequest(http.MethodDelete, "/api/v3/configure/database?"+params.Encode(), nil)
+	if err != nil {
+		return err
+	}
+	resp, err := d.client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return err
+	}
+	if resp.StatusCode != http.StatusOK {
+		return responseError("database deletion", resp, body)
+	}
+	return nil
+}
+
+func (d *dbCreator) CreateDB(dbName string) error {
+	body, err := json.Marshal(map[string]string{"db": dbName})
+	if err != nil {
+		return err
+	}
+	req, err := d.newRequest(http.MethodPost, "/api/v3/configure/database", bytes.NewReader(body))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := d.client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	responseBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return err
+	}
+	if resp.StatusCode != http.StatusOK {
+		return responseError("database creation", resp, responseBody)
+	}
+	return nil
+}

--- a/cmd/tsbs_load_influx3/creator_test.go
+++ b/cmd/tsbs_load_influx3/creator_test.go
@@ -1,0 +1,68 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestDBCreatorLifecycle(t *testing.T) {
+	var deleted, created bool
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.Header.Get("Authorization"); got != "Bearer admin-token" {
+			t.Errorf("unexpected authorization: %q", got)
+		}
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/api/v3/configure/database":
+			fmt.Fprint(w, `[{"iox::database":"benchmark"}]`)
+		case r.Method == http.MethodDelete && r.URL.Path == "/api/v3/configure/database":
+			if r.URL.Query().Get("db") != "benchmark" || r.URL.Query().Get("hard_delete_at") != "now" {
+				t.Errorf("unexpected delete query: %s", r.URL.RawQuery)
+			}
+			deleted = true
+		case r.Method == http.MethodPost && r.URL.Path == "/api/v3/configure/database":
+			var payload map[string]string
+			if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+				t.Fatal(err)
+			}
+			if payload["db"] != "benchmark" {
+				t.Errorf("unexpected create payload: %+v", payload)
+			}
+			created = true
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	oldURLs, oldToken := daemonURLs, adminToken
+	defer func() { daemonURLs, adminToken = oldURLs, oldToken }()
+	daemonURLs = []string{server.URL}
+	adminToken = "admin-token"
+	creator := &dbCreator{}
+	creator.Init()
+	if !creator.DBExists("benchmark") {
+		t.Fatal("expected database to exist")
+	}
+	if err := creator.RemoveOldDB("benchmark"); err != nil {
+		t.Fatal(err)
+	}
+	if err := creator.CreateDB("benchmark"); err != nil {
+		t.Fatal(err)
+	}
+	if !deleted || !created {
+		t.Fatalf("lifecycle incomplete: deleted=%v created=%v", deleted, created)
+	}
+}
+
+func TestDBCreatorBypass(t *testing.T) {
+	oldConfig := config
+	defer func() { config = oldConfig }()
+	config.DoCreateDB = false
+	config.DoAbortOnExist = false
+	if got := (&benchmark{}).GetDBCreator(); got != nil {
+		t.Fatalf("expected lifecycle bypass, got %T", got)
+	}
+}

--- a/cmd/tsbs_load_influx3/http_writer.go
+++ b/cmd/tsbs_load_influx3/http_writer.go
@@ -1,0 +1,111 @@
+package main
+
+import (
+	"fmt"
+	"net/http"
+	"net/url"
+	"strconv"
+	"time"
+
+	"github.com/valyala/fasthttp"
+)
+
+const (
+	httpClientName        = "tsbs_load_influx3"
+	headerContentEncoding = "Content-Encoding"
+	headerGzip            = "gzip"
+	headerAuthorization   = "Authorization"
+)
+
+type HTTPWriterConfig struct {
+	Host          string
+	Database      string
+	Token         string
+	AcceptPartial bool
+	NoSync        bool
+	DebugInfo     string
+}
+
+type HTTPWriter struct {
+	client fasthttp.Client
+	c      HTTPWriterConfig
+	url    []byte
+}
+
+type retryableWriteError struct {
+	status     int
+	retryAfter time.Duration
+	body       string
+}
+
+func (e *retryableWriteError) Error() string {
+	return fmt.Sprintf("transient InfluxDB 3 write response (status %d): %s", e.status, e.body)
+}
+
+func NewHTTPWriter(c HTTPWriterConfig) *HTTPWriter {
+	params := url.Values{}
+	params.Set("db", c.Database)
+	params.Set("precision", "nanosecond")
+	params.Set("accept_partial", strconv.FormatBool(c.AcceptPartial))
+	params.Set("no_sync", strconv.FormatBool(c.NoSync))
+	return &HTTPWriter{
+		client: fasthttp.Client{Name: httpClientName},
+		c:      c,
+		url:    []byte(c.Host + "/api/v3/write_lp?" + params.Encode()),
+	}
+}
+
+func (w *HTTPWriter) initializeReq(req *fasthttp.Request, body []byte, isGzip bool) {
+	req.Header.SetContentType("text/plain")
+	req.Header.SetMethod(fasthttp.MethodPost)
+	req.Header.SetRequestURIBytes(w.url)
+	if isGzip {
+		req.Header.Set(headerContentEncoding, headerGzip)
+	}
+	if w.c.Token != "" {
+		req.Header.Set(headerAuthorization, "Bearer "+w.c.Token)
+	}
+	req.SetBody(body)
+}
+
+func parseRetryAfter(value string, now time.Time) time.Duration {
+	if seconds, err := strconv.Atoi(value); err == nil && seconds >= 0 {
+		return time.Duration(seconds) * time.Second
+	}
+	if retryAt, err := http.ParseTime(value); err == nil && retryAt.After(now) {
+		return retryAt.Sub(now)
+	}
+	return 0
+}
+
+func (w *HTTPWriter) executeReq(req *fasthttp.Request, resp *fasthttp.Response) (int64, error) {
+	start := time.Now()
+	err := w.client.Do(req, resp)
+	latency := time.Since(start).Nanoseconds()
+	if err != nil {
+		return latency, err
+	}
+
+	status := resp.StatusCode()
+	if status == fasthttp.StatusNoContent {
+		return latency, nil
+	}
+	if status == fasthttp.StatusTooManyRequests || status == fasthttp.StatusServiceUnavailable {
+		return latency, &retryableWriteError{
+			status:     status,
+			retryAfter: parseRetryAfter(string(resp.Header.Peek("Retry-After")), time.Now()),
+			body:       string(resp.Body()),
+		}
+	}
+	return latency, fmt.Errorf("[DebugInfo: %s] invalid InfluxDB 3 write response (status %d): %s", w.c.DebugInfo, status, resp.Body())
+}
+
+func (w *HTTPWriter) WriteLineProtocol(body []byte, isGzip bool) (int64, error) {
+	req := fasthttp.AcquireRequest()
+	defer fasthttp.ReleaseRequest(req)
+	w.initializeReq(req, body, isGzip)
+
+	resp := fasthttp.AcquireResponse()
+	defer fasthttp.ReleaseResponse(resp)
+	return w.executeReq(req, resp)
+}

--- a/cmd/tsbs_load_influx3/http_writer_test.go
+++ b/cmd/tsbs_load_influx3/http_writer_test.go
@@ -1,0 +1,93 @@
+package main
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestHTTPWriterRequest(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/v3/write_lp" {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+		wantParams := url.Values{
+			"db":             {"benchmark"},
+			"precision":      {"nanosecond"},
+			"accept_partial": {"false"},
+			"no_sync":        {"false"},
+		}
+		if got := r.URL.Query(); got.Encode() != wantParams.Encode() {
+			t.Errorf("unexpected query params: got %s want %s", got.Encode(), wantParams.Encode())
+		}
+		if got := r.Header.Get("Authorization"); got != "Bearer write-token" {
+			t.Errorf("unexpected authorization: %q", got)
+		}
+		if got := r.Header.Get("Content-Encoding"); got != "gzip" {
+			t.Errorf("unexpected content encoding: %q", got)
+		}
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer server.Close()
+
+	writer := NewHTTPWriter(HTTPWriterConfig{
+		Host: server.URL, Database: "benchmark", Token: "write-token",
+	})
+	latency, err := writer.WriteLineProtocol([]byte("compressed"), true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if latency <= 0 {
+		t.Fatalf("unexpected latency: %d", latency)
+	}
+}
+
+func TestHTTPWriterErrors(t *testing.T) {
+	tests := []struct {
+		name      string
+		status    int
+		retryable bool
+	}{
+		{name: "too many requests", status: http.StatusTooManyRequests, retryable: true},
+		{name: "unavailable", status: http.StatusServiceUnavailable, retryable: true},
+		{name: "bad request", status: http.StatusBadRequest},
+		{name: "server error", status: http.StatusInternalServerError},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Retry-After", "2")
+				w.WriteHeader(tt.status)
+				fmt.Fprint(w, "write failed")
+			}))
+			defer server.Close()
+
+			writer := NewHTTPWriter(HTTPWriterConfig{Host: server.URL, Database: "benchmark"})
+			_, err := writer.WriteLineProtocol([]byte("cpu usage=1i"), false)
+			if err == nil || !strings.Contains(err.Error(), "write failed") {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			retryErr, ok := err.(*retryableWriteError)
+			if ok != tt.retryable {
+				t.Fatalf("retryable=%v want %v", ok, tt.retryable)
+			}
+			if ok && retryErr.retryAfter != 2*time.Second {
+				t.Fatalf("retry after=%s", retryErr.retryAfter)
+			}
+		})
+	}
+}
+
+func TestParseRetryAfter(t *testing.T) {
+	now := time.Date(2026, 8, 7, 0, 0, 0, 0, time.UTC)
+	if got := parseRetryAfter("3", now); got != 3*time.Second {
+		t.Fatalf("seconds retry-after: got %s", got)
+	}
+	if got := parseRetryAfter(now.Add(5*time.Second).Format(http.TimeFormat), now); got != 5*time.Second {
+		t.Fatalf("date retry-after: got %s", got)
+	}
+}

--- a/cmd/tsbs_load_influx3/main.go
+++ b/cmd/tsbs_load_influx3/main.go
@@ -1,0 +1,105 @@
+// tsbs_load_influx3 loads line protocol into InfluxDB 3 Core or Enterprise.
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"log"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/blagojts/viper"
+	"github.com/spf13/pflag"
+	"github.com/timescale/tsbs/internal/utils"
+	"github.com/timescale/tsbs/load"
+	"github.com/timescale/tsbs/pkg/targets"
+	"github.com/timescale/tsbs/pkg/targets/constants"
+	"github.com/timescale/tsbs/pkg/targets/initializers"
+)
+
+var (
+	daemonURLs    []string
+	backoff       time.Duration
+	useGzip       bool
+	authToken     string
+	adminToken    string
+	acceptPartial bool
+	noSync        bool
+)
+
+var (
+	loader  load.BenchmarkRunner
+	config  load.BenchmarkRunnerConfig
+	bufPool sync.Pool
+	target  targets.ImplementedTarget
+)
+
+var fatal = log.Fatalf
+
+func init() {
+	target = initializers.GetTarget(constants.FormatInflux3)
+	config = load.BenchmarkRunnerConfig{}
+	config.AddToFlagSet(pflag.CommandLine)
+	target.TargetSpecificFlags("", pflag.CommandLine)
+	pflag.Parse()
+
+	if err := utils.SetupConfigFile(); err != nil {
+		panic(fmt.Errorf("fatal error config file: %s", err))
+	}
+	if err := viper.Unmarshal(&config); err != nil {
+		panic(fmt.Errorf("unable to decode config: %s", err))
+	}
+
+	for _, daemonURL := range strings.Split(viper.GetString("urls"), ",") {
+		daemonURL = strings.TrimRight(strings.TrimSpace(daemonURL), "/")
+		if daemonURL != "" {
+			daemonURLs = append(daemonURLs, daemonURL)
+		}
+	}
+	if len(daemonURLs) == 0 {
+		log.Fatal("missing 'urls' flag")
+	}
+
+	backoff = viper.GetDuration("backoff")
+	useGzip = viper.GetBool("gzip")
+	authToken = viper.GetString("auth-token")
+	adminToken = viper.GetString("admin-token")
+	if adminToken == "" {
+		adminToken = authToken
+	}
+	acceptPartial = viper.GetBool("accept-partial")
+	noSync = viper.GetBool("no-sync")
+
+	config.HashWorkers = false
+	loader = load.GetBenchmarkRunner(config)
+}
+
+type benchmark struct{}
+
+func (b *benchmark) GetDataSource() targets.DataSource {
+	return &fileDataSource{scanner: bufio.NewScanner(load.GetBufferedReader(config.FileName))}
+}
+
+func (b *benchmark) GetBatchFactory() targets.BatchFactory { return &factory{} }
+
+func (b *benchmark) GetPointIndexer(_ uint) targets.PointIndexer {
+	return &targets.ConstantIndexer{}
+}
+
+func (b *benchmark) GetProcessor() targets.Processor { return &processor{} }
+
+func (b *benchmark) GetDBCreator() targets.DBCreator {
+	if !config.DoCreateDB && !config.DoAbortOnExist {
+		return nil
+	}
+	return &dbCreator{}
+}
+
+func main() {
+	bufPool = sync.Pool{New: func() interface{} {
+		return bytes.NewBuffer(make([]byte, 0, 4*1024*1024))
+	}}
+	loader.RunBenchmark(&benchmark{})
+}

--- a/cmd/tsbs_load_influx3/process.go
+++ b/cmd/tsbs_load_influx3/process.go
@@ -1,0 +1,106 @@
+package main
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/timescale/tsbs/pkg/targets"
+	"github.com/valyala/fasthttp"
+)
+
+const backingOffChanCap = 100
+
+var printFn = fmt.Printf
+
+type processor struct {
+	backingOffChan chan bool
+	backingOffDone chan struct{}
+	httpWriter     *HTTPWriter
+}
+
+func (p *processor) Init(worker int, _, _ bool) {
+	daemonURL := daemonURLs[worker%len(daemonURLs)]
+	p.initWithHTTPWriter(worker, NewHTTPWriter(HTTPWriterConfig{
+		Host:          daemonURL,
+		Database:      loader.DatabaseName(),
+		Token:         authToken,
+		AcceptPartial: acceptPartial,
+		NoSync:        noSync,
+		DebugInfo:     fmt.Sprintf("worker #%d, dest url: %s", worker, daemonURL),
+	}))
+}
+
+func (p *processor) initWithHTTPWriter(worker int, writer *HTTPWriter) {
+	p.backingOffChan = make(chan bool, backingOffChanCap)
+	p.backingOffDone = make(chan struct{})
+	p.httpWriter = writer
+	go p.processBackoffMessages(worker)
+}
+
+func (p *processor) Close(_ bool) {
+	close(p.backingOffChan)
+	<-p.backingOffDone
+}
+
+func (p *processor) ProcessBatch(input targets.Batch, doLoad bool) (uint64, uint64) {
+	b := input.(*batch)
+	if doLoad {
+		for {
+			var err error
+			if useGzip {
+				compressed := bufPool.Get().(*bytes.Buffer)
+				fasthttp.WriteGzip(compressed, b.buf.Bytes())
+				_, err = p.httpWriter.WriteLineProtocol(compressed.Bytes(), true)
+				compressed.Reset()
+				bufPool.Put(compressed)
+			} else {
+				_, err = p.httpWriter.WriteLineProtocol(b.buf.Bytes(), false)
+			}
+
+			var retryable *retryableWriteError
+			if errors.As(err, &retryable) {
+				p.backingOffChan <- true
+				delay := retryable.retryAfter
+				if delay <= 0 {
+					delay = backoff
+				}
+				time.Sleep(delay)
+				continue
+			}
+			p.backingOffChan <- false
+			if err != nil {
+				fatal("Error writing: %s\n", err.Error())
+			}
+			break
+		}
+	}
+
+	metricCount, rowCount := b.metrics, uint64(b.rows)
+	b.buf.Reset()
+	bufPool.Put(b.buf)
+	return metricCount, rowCount
+}
+
+func (p *processor) processBackoffMessages(worker int) {
+	var total time.Duration
+	var started time.Time
+	backingOff := false
+	for current := range p.backingOffChan {
+		if current && !backingOff {
+			started = time.Now()
+			backingOff = true
+		} else if !current && backingOff {
+			duration := time.Since(started)
+			printFn("[worker %d] backoff took %.02fsec\n", worker, duration.Seconds())
+			total += duration
+			backingOff = false
+		}
+	}
+	if backingOff {
+		total += time.Since(started)
+	}
+	printFn("[worker %d] backoffs took a total of %fsec of runtime\n", worker, total.Seconds())
+	p.backingOffDone <- struct{}{}
+}

--- a/cmd/tsbs_load_influx3/scan.go
+++ b/cmd/tsbs_load_influx3/scan.go
@@ -1,0 +1,56 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"strings"
+
+	"github.com/timescale/tsbs/pkg/data"
+	"github.com/timescale/tsbs/pkg/data/usecases/common"
+	"github.com/timescale/tsbs/pkg/targets"
+)
+
+const errNotThreeTuplesFmt = "parse error: line does not have 3 tuples, has %d"
+
+var newLine = []byte("\n")
+
+type fileDataSource struct{ scanner *bufio.Scanner }
+
+func (d *fileDataSource) NextItem() data.LoadedPoint {
+	ok := d.scanner.Scan()
+	if !ok && d.scanner.Err() == nil {
+		return data.LoadedPoint{}
+	}
+	if !ok {
+		fatal("scan error: %v", d.scanner.Err())
+		return data.LoadedPoint{}
+	}
+	return data.NewLoadedPoint(d.scanner.Bytes())
+}
+
+func (d *fileDataSource) Headers() *common.GeneratedDataHeaders { return nil }
+
+type batch struct {
+	buf     *bytes.Buffer
+	rows    uint
+	metrics uint64
+}
+
+func (b *batch) Len() uint { return b.rows }
+
+func (b *batch) Append(item data.LoadedPoint) {
+	line := item.Data.([]byte)
+	parts := strings.Split(string(line), " ")
+	if len(parts) != 3 {
+		fatal(errNotThreeTuplesFmt, len(parts))
+		return
+	}
+	b.rows++
+	b.metrics += uint64(len(strings.Split(parts[1], ",")))
+	b.buf.Write(line)
+	b.buf.Write(newLine)
+}
+
+type factory struct{}
+
+func (f *factory) New() targets.Batch { return &batch{buf: bufPool.Get().(*bytes.Buffer)} }

--- a/cmd/tsbs_load_influx3/scan_test.go
+++ b/cmd/tsbs_load_influx3/scan_test.go
@@ -1,0 +1,21 @@
+package main
+
+import (
+	"bytes"
+	"sync"
+	"testing"
+
+	"github.com/timescale/tsbs/pkg/data"
+)
+
+func TestBatchAppend(t *testing.T) {
+	bufPool = sync.Pool{New: func() interface{} { return &bytes.Buffer{} }}
+	b := (&factory{}).New().(*batch)
+	b.Append(data.NewLoadedPoint([]byte("cpu,hostname=host_0 usage_user=1i,usage_idle=2i 123")))
+	if b.rows != 1 || b.metrics != 2 {
+		t.Fatalf("unexpected counts: rows=%d metrics=%d", b.rows, b.metrics)
+	}
+	if got := b.buf.String(); got != "cpu,hostname=host_0 usage_user=1i,usage_idle=2i 123\n" {
+		t.Fatalf("unexpected batch: %q", got)
+	}
+}

--- a/cmd/tsbs_run_queries_influx3/http_client.go
+++ b/cmd/tsbs_run_queries_influx3/http_client.go
@@ -1,0 +1,95 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"time"
+
+	"github.com/timescale/tsbs/pkg/query"
+)
+
+type HTTPClient struct {
+	client *http.Client
+	host   string
+}
+
+type HTTPClientDoOptions struct {
+	Debug          int
+	PrintResponses bool
+	Database       string
+	Token          string
+}
+
+type queryRequest struct {
+	Database string                 `json:"db"`
+	Query    string                 `json:"q"`
+	Format   string                 `json:"format"`
+	Params   map[string]interface{} `json:"params,omitempty"`
+}
+
+func NewHTTPClient(host string) *HTTPClient {
+	transport := &http.Transport{MaxIdleConnsPerHost: 1024}
+	return &HTTPClient{client: &http.Client{Transport: transport}, host: host}
+}
+
+func (c *HTTPClient) Do(q *query.HTTP, opts *HTTPClientDoOptions) (float64, error) {
+	payload, err := json.Marshal(queryRequest{
+		Database: opts.Database,
+		Query:    string(q.RawQuery),
+		Format:   "json",
+	})
+	if err != nil {
+		return 0, err
+	}
+	req, err := http.NewRequest(http.MethodPost, c.host+string(q.Path), bytes.NewReader(payload))
+	if err != nil {
+		return 0, err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json")
+	if opts.Token != "" {
+		req.Header.Set("Authorization", "Bearer "+opts.Token)
+	}
+
+	if opts.Debug > 0 {
+		fmt.Fprintf(os.Stderr, "debug: %s -- %s\n", q.HumanLabel, q.HumanDescription)
+		if opts.Debug >= 3 {
+			fmt.Fprintf(os.Stderr, "debug:   SQL: %s\n", q.RawQuery)
+		}
+	}
+
+	start := time.Now()
+	resp, err := c.client.Do(req)
+	if err != nil {
+		return 0, err
+	}
+	defer resp.Body.Close()
+	body, readErr := io.ReadAll(resp.Body)
+	lag := float64(time.Since(start).Nanoseconds()) / 1e6
+	if readErr != nil {
+		return lag, readErr
+	}
+	if resp.StatusCode != http.StatusOK {
+		return lag, fmt.Errorf("InfluxDB 3 query failed (status %d): %s", resp.StatusCode, body)
+	}
+
+	if opts.Debug > 0 {
+		fmt.Fprintf(os.Stderr, "debug: %s in %7.2fms\n", q.HumanLabel, lag)
+		if opts.Debug >= 4 {
+			fmt.Fprintf(os.Stderr, "debug:   response: %s\n", body)
+		}
+	}
+	if opts.PrintResponses {
+		var pretty bytes.Buffer
+		if err := json.Indent(&pretty, body, "", "  "); err != nil {
+			fmt.Printf("ID %d SQL: %s\n%s\n", q.GetID(), q.RawQuery, body)
+		} else {
+			fmt.Printf("ID %d SQL: %s\n%s\n", q.GetID(), q.RawQuery, pretty.Bytes())
+		}
+	}
+	return lag, nil
+}

--- a/cmd/tsbs_run_queries_influx3/http_client_test.go
+++ b/cmd/tsbs_run_queries_influx3/http_client_test.go
@@ -1,0 +1,67 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/timescale/tsbs/pkg/query"
+)
+
+func testQuery() *query.HTTP {
+	q := query.NewHTTP()
+	q.HumanLabel = []byte("test query")
+	q.HumanDescription = []byte("test query description")
+	q.Method = []byte(http.MethodPost)
+	q.Path = []byte("/api/v3/query_sql")
+	q.RawQuery = []byte("SELECT * FROM cpu")
+	return q
+}
+
+func TestHTTPClientDo(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost || r.URL.Path != "/api/v3/query_sql" {
+			t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+		}
+		if got := r.Header.Get("Authorization"); got != "Bearer query-token" {
+			t.Errorf("unexpected authorization: %q", got)
+		}
+		var request queryRequest
+		if err := json.NewDecoder(r.Body).Decode(&request); err != nil {
+			t.Fatal(err)
+		}
+		if request.Database != "benchmark" || request.Query != "SELECT * FROM cpu" || request.Format != "json" {
+			t.Errorf("unexpected request body: %+v", request)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `[{"usage_user":42}]`)
+	}))
+	defer server.Close()
+
+	q := testQuery()
+	defer q.Release()
+	lag, err := NewHTTPClient(server.URL).Do(q, &HTTPClientDoOptions{Database: "benchmark", Token: "query-token"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if lag <= 0 {
+		t.Fatalf("unexpected latency: %f", lag)
+	}
+}
+
+func TestHTTPClientDoError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "bad SQL", http.StatusBadRequest)
+	}))
+	defer server.Close()
+
+	q := testQuery()
+	defer q.Release()
+	_, err := NewHTTPClient(server.URL).Do(q, &HTTPClientDoOptions{Database: "benchmark"})
+	if err == nil || !strings.Contains(err.Error(), "bad SQL") || !strings.Contains(err.Error(), "400") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}

--- a/cmd/tsbs_run_queries_influx3/main.go
+++ b/cmd/tsbs_run_queries_influx3/main.go
@@ -1,0 +1,75 @@
+// tsbs_run_queries_influx3 benchmarks InfluxDB 3 SQL requests read from stdin.
+package main
+
+import (
+	"fmt"
+	"log"
+	"strings"
+
+	"github.com/blagojts/viper"
+	"github.com/spf13/pflag"
+	"github.com/timescale/tsbs/internal/utils"
+	"github.com/timescale/tsbs/pkg/query"
+)
+
+var (
+	daemonURLs []string
+	authToken  string
+	runner     *query.BenchmarkRunner
+)
+
+func init() {
+	var config query.BenchmarkRunnerConfig
+	config.AddToFlagSet(pflag.CommandLine)
+	pflag.String("urls", "http://localhost:8181", "InfluxDB 3 URLs, comma-separated. Will be used in a round-robin fashion.")
+	pflag.String("auth-token", "", "InfluxDB 3 token used for queries.")
+	pflag.Parse()
+
+	if err := utils.SetupConfigFile(); err != nil {
+		panic(fmt.Errorf("fatal error config file: %s", err))
+	}
+	if err := viper.Unmarshal(&config); err != nil {
+		panic(fmt.Errorf("unable to decode config: %s", err))
+	}
+
+	for _, daemonURL := range strings.Split(viper.GetString("urls"), ",") {
+		daemonURL = strings.TrimRight(strings.TrimSpace(daemonURL), "/")
+		if daemonURL != "" {
+			daemonURLs = append(daemonURLs, daemonURL)
+		}
+	}
+	if len(daemonURLs) == 0 {
+		log.Fatal("missing 'urls' flag")
+	}
+	authToken = viper.GetString("auth-token")
+	runner = query.NewBenchmarkRunner(config)
+}
+
+func main() { runner.Run(&query.HTTPPool, newProcessor) }
+
+type processor struct {
+	client *HTTPClient
+	opts   *HTTPClientDoOptions
+}
+
+func newProcessor() query.Processor { return &processor{} }
+
+func (p *processor) Init(worker int) {
+	p.opts = &HTTPClientDoOptions{
+		Debug:          runner.DebugLevel(),
+		PrintResponses: runner.DoPrintResponses(),
+		Database:       runner.DatabaseName(),
+		Token:          authToken,
+	}
+	p.client = NewHTTPClient(daemonURLs[worker%len(daemonURLs)])
+}
+
+func (p *processor) ProcessQuery(q query.Query, _ bool) ([]*query.Stat, error) {
+	lag, err := p.client.Do(q.(*query.HTTP), p.opts)
+	if err != nil {
+		return nil, err
+	}
+	stat := query.GetStat()
+	stat.Init(q.HumanLabelName(), lag)
+	return []*query.Stat{stat}, nil
+}

--- a/docs/influx3.md
+++ b/docs/influx3.md
@@ -1,0 +1,93 @@
+# InfluxDB 3 Core and Enterprise
+
+TSBS supports the `cpu-only` workload on InfluxDB 3 Core and Enterprise through
+the native InfluxDB 3 HTTP APIs. Both products use the same TSBS commands and
+SQL query set. The examples below target InfluxDB 3.11.0 on its default port,
+8181.
+
+## Build
+
+```bash
+make tsbs_generate_data tsbs_generate_queries \
+  tsbs_load_influx3 tsbs_run_queries_influx3
+```
+
+## Generate and load data
+
+Keep a Core dataset within its configured retention period. A 72-hour dataset
+is a useful default for an unmodified Core installation.
+
+```bash
+tsbs_generate_data \
+  --use-case=cpu-only \
+  --seed=123 \
+  --scale=1000 \
+  --timestamp-start=2026-01-01T00:00:00Z \
+  --timestamp-end=2026-01-04T00:00:00Z \
+  --log-interval=10s \
+  --format=influx3 | gzip > /tmp/influx3-data.gz
+
+gunzip -c /tmp/influx3-data.gz | tsbs_load_influx3 \
+  --urls=http://localhost:8181 \
+  --db-name=benchmark \
+  --auth-token="$INFLUXDB3_AUTH_TOKEN" \
+  --admin-token="$INFLUXDB3_ADMIN_TOKEN" \
+  --workers=4 \
+  --batch-size=10000
+```
+
+The loader sends line protocol to `/api/v3/write_lp` with nanosecond
+precision. Gzip is enabled, invalid batches are rejected atomically, and
+durable WAL acknowledgement is used by default. Use `--no-sync` only for a
+separately labelled durability/performance experiment, and use
+`--accept-partial` only if partial batch acceptance is intentional.
+
+By default the loader creates the benchmark database, replacing one with the
+same name. Set `--do-abort-on-exist` to stop instead of replacing it.
+Database lifecycle calls use `/api/v3/configure/database`. If `--admin-token`
+is omitted, it falls back to `--auth-token`. To use a pre-created database and
+a database-scoped write token, pass `--do-create-db=false` and
+`--do-abort-on-exist=false`; no admin token is then required.
+
+Multiple comma-separated `--urls` are assigned to workers round-robin. Use
+only endpoints that address the same Core instance or Enterprise cluster.
+
+## Generate and run queries
+
+InfluxDB 3 queries are native SQL requests sent to `/api/v3/query_sql`. The
+generated last-point query uses ordered aggregates such as
+`last_value(usage_user ORDER BY time)`, grouped by hostname.
+
+```bash
+tsbs_generate_queries \
+  --use-case=cpu-only \
+  --seed=123 \
+  --scale=1000 \
+  --timestamp-start=2026-01-01T00:00:00Z \
+  --timestamp-end=2026-01-04T00:00:01Z \
+  --queries=1000 \
+  --query-type=lastpoint \
+  --format=influx3 | gzip > /tmp/queries_influx3_lastpoint.gz
+
+gunzip -c /tmp/queries_influx3_lastpoint.gz | \
+  tsbs_run_queries_influx3 \
+    --urls=http://localhost:8181 \
+    --db-name=benchmark \
+    --auth-token="$INFLUXDB3_AUTH_TOKEN" \
+    --workers=4
+```
+
+The supported CPU query types are the standard TSBS devops set, including
+time-window aggregates, grouped aggregates, last point per host, and high-CPU
+filters. `scripts/generate_queries.sh` can generate several types by setting
+`FORMATS=influx3`; the helper scripts `scripts/load/load_influx3.sh` and
+`scripts/run_queries/run_queries_influx3.sh` run the load and query phases.
+
+## Comparing Core and Enterprise
+
+Use identical generated files, client concurrency, batch sizes, durability
+settings, and query order for both products. Record the exact 3.11 patch
+version and the storage engine used by each Enterprise database: upgraded
+Enterprise installations can retain an older engine while new 3.11 databases
+use the newer engine by default. Do not combine `--no-sync` results with the
+default durable-write results.

--- a/internal/inputs/generator_queries_test.go
+++ b/internal/inputs/generator_queries_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/timescale/tsbs/cmd/tsbs_generate_queries/databases/clickhouse"
 	"github.com/timescale/tsbs/cmd/tsbs_generate_queries/databases/cratedb"
 	"github.com/timescale/tsbs/cmd/tsbs_generate_queries/databases/influx"
+	"github.com/timescale/tsbs/cmd/tsbs_generate_queries/databases/influx3"
 	"github.com/timescale/tsbs/cmd/tsbs_generate_queries/databases/mongo"
 	"github.com/timescale/tsbs/cmd/tsbs_generate_queries/databases/questdb"
 	"github.com/timescale/tsbs/cmd/tsbs_generate_queries/databases/siridb"
@@ -285,6 +286,13 @@ func TestGetUseCaseGenerator(t *testing.T) {
 		t.Fatalf("Error creating influx query generator")
 	}
 	checkType(constants.FormatInflux, indb)
+
+	bi3 := influx3.BaseGenerator{}
+	indb3, err := bi3.NewDevops(tsStart, tsEnd, scale)
+	if err != nil {
+		t.Fatalf("Error creating influx3 query generator")
+	}
+	checkType(constants.FormatInflux3, indb3)
 
 	bs := siridb.BaseGenerator{}
 	siri, err := bs.NewDevops(tsStart, tsEnd, scale)

--- a/pkg/query/factories/init_factories.go
+++ b/pkg/query/factories/init_factories.go
@@ -7,6 +7,7 @@ import (
 	"github.com/timescale/tsbs/cmd/tsbs_generate_queries/databases/cratedb"
 	"github.com/timescale/tsbs/cmd/tsbs_generate_queries/databases/greptime"
 	"github.com/timescale/tsbs/cmd/tsbs_generate_queries/databases/influx"
+	"github.com/timescale/tsbs/cmd/tsbs_generate_queries/databases/influx3"
 	"github.com/timescale/tsbs/cmd/tsbs_generate_queries/databases/mongo"
 	"github.com/timescale/tsbs/cmd/tsbs_generate_queries/databases/questdb"
 	"github.com/timescale/tsbs/cmd/tsbs_generate_queries/databases/siridb"
@@ -25,6 +26,7 @@ func InitQueryFactories(config *config.QueryGeneratorConfig) map[string]interfac
 	}
 	factories[constants.FormatCrateDB] = &cratedb.BaseGenerator{}
 	factories[constants.FormatInflux] = &influx.BaseGenerator{}
+	factories[constants.FormatInflux3] = &influx3.BaseGenerator{}
 	factories[constants.FormatTimescaleDB] = &timescaledb.BaseGenerator{
 		UseJSON:       config.TimescaleUseJSON,
 		UseTags:       config.TimescaleUseTags,

--- a/pkg/query/http.go
+++ b/pkg/query/http.go
@@ -73,6 +73,7 @@ func (q *HTTP) Release() {
 	q.Method = q.Method[:0]
 	q.Path = q.Path[:0]
 	q.Body = q.Body[:0]
+	q.RawQuery = q.RawQuery[:0]
 	q.StartTimestamp = 0
 	q.EndTimestamp = 0
 

--- a/pkg/query/http_test.go
+++ b/pkg/query/http_test.go
@@ -14,6 +14,9 @@ func TestNewHTTP(t *testing.T) {
 		if got := len(q.Body); got != 0 {
 			t.Errorf("new query has non-0 body: got %d", got)
 		}
+		if got := len(q.RawQuery); got != 0 {
+			t.Errorf("new query has non-0 raw query: got %d", got)
+		}
 		if got := q.StartTimestamp; got != 0 {
 			t.Errorf("new query has non-0 start time: got %d", got)
 		}
@@ -28,6 +31,7 @@ func TestNewHTTP(t *testing.T) {
 	q.Method = []byte("POST")
 	q.Path = []byte("/home")
 	q.Body = []byte("bazbazbaz")
+	q.RawQuery = []byte("select 1")
 	q.StartTimestamp = 1
 	q.EndTimestamp = 5
 	q.SetID(1)

--- a/pkg/targets/constants/constants.go
+++ b/pkg/targets/constants/constants.go
@@ -14,8 +14,9 @@ const (
 	FormatVictoriaMetrics = "victoriametrics"
 	FormatTimestream      = "timestream"
 	FormatQuestDB         = "questdb"
-	FormatInflux2          = "influx2"
-	FormatGreptime          = "greptime"
+	FormatInflux2         = "influx2"
+	FormatInflux3         = "influx3"
+	FormatGreptime        = "greptime"
 )
 
 func SupportedFormats() []string {
@@ -33,6 +34,7 @@ func SupportedFormats() []string {
 		FormatTimestream,
 		FormatQuestDB,
 		FormatInflux2,
+		FormatInflux3,
 		FormatGreptime,
 	}
 }

--- a/pkg/targets/influx3/implemented_target.go
+++ b/pkg/targets/influx3/implemented_target.go
@@ -1,0 +1,42 @@
+package influx3
+
+import (
+	"time"
+
+	"github.com/blagojts/viper"
+	"github.com/spf13/pflag"
+	"github.com/timescale/tsbs/pkg/data/serialize"
+	"github.com/timescale/tsbs/pkg/data/source"
+	"github.com/timescale/tsbs/pkg/targets"
+	"github.com/timescale/tsbs/pkg/targets/constants"
+	"github.com/timescale/tsbs/pkg/targets/influx"
+)
+
+// NewTarget returns the InfluxDB 3 target.
+func NewTarget() targets.ImplementedTarget {
+	return &influx3Target{}
+}
+
+type influx3Target struct{}
+
+func (t *influx3Target) TargetSpecificFlags(flagPrefix string, flagSet *pflag.FlagSet) {
+	flagSet.String(flagPrefix+"urls", "http://localhost:8181", "InfluxDB 3 URLs, comma-separated. Will be used in a round-robin fashion.")
+	flagSet.Duration(flagPrefix+"backoff", time.Second, "Time to wait before retrying a transient write failure.")
+	flagSet.Bool(flagPrefix+"gzip", true, "Whether to gzip write requests.")
+	flagSet.String(flagPrefix+"auth-token", "", "InfluxDB 3 token used for writes.")
+	flagSet.String(flagPrefix+"admin-token", "", "InfluxDB 3 admin token used for database lifecycle operations. Defaults to auth-token.")
+	flagSet.Bool(flagPrefix+"accept-partial", false, "Whether InfluxDB 3 may accept valid lines from an otherwise invalid batch.")
+	flagSet.Bool(flagPrefix+"no-sync", false, "Acknowledge writes before the WAL is persisted. This reduces durability.")
+}
+
+func (t *influx3Target) TargetName() string {
+	return constants.FormatInflux3
+}
+
+func (t *influx3Target) Serializer() serialize.PointSerializer {
+	return &influx.Serializer{}
+}
+
+func (t *influx3Target) Benchmark(string, *source.DataSourceConfig, *viper.Viper) (targets.Benchmark, error) {
+	panic("not implemented")
+}

--- a/pkg/targets/influx3/implemented_target_test.go
+++ b/pkg/targets/influx3/implemented_target_test.go
@@ -1,0 +1,32 @@
+package influx3
+
+import (
+	"bytes"
+	"testing"
+	"time"
+
+	"github.com/timescale/tsbs/pkg/data"
+	"github.com/timescale/tsbs/pkg/targets/constants"
+)
+
+func TestTarget(t *testing.T) {
+	target := NewTarget()
+	if got := target.TargetName(); got != constants.FormatInflux3 {
+		t.Fatalf("unexpected target name: got %q", got)
+	}
+
+	p := data.NewPoint()
+	p.SetMeasurementName([]byte("cpu"))
+	p.AppendTag([]byte("hostname"), "host_0")
+	p.AppendField([]byte("usage_user"), int64(42))
+	timestamp := time.Unix(0, 123).UTC()
+	p.SetTimestamp(&timestamp)
+
+	var buf bytes.Buffer
+	if err := target.Serializer().Serialize(p, &buf); err != nil {
+		t.Fatal(err)
+	}
+	if got, want := buf.String(), "cpu,hostname=host_0 usage_user=42i 123\n"; got != want {
+		t.Fatalf("unexpected serialization: got %q want %q", got, want)
+	}
+}

--- a/pkg/targets/initializers/target_initializers.go
+++ b/pkg/targets/initializers/target_initializers.go
@@ -10,6 +10,7 @@ import (
 	"github.com/timescale/tsbs/pkg/targets/crate"
 	"github.com/timescale/tsbs/pkg/targets/influx"
 	"github.com/timescale/tsbs/pkg/targets/influx2"
+	"github.com/timescale/tsbs/pkg/targets/influx3"
 	"github.com/timescale/tsbs/pkg/targets/mongo"
 	"github.com/timescale/tsbs/pkg/targets/prometheus"
 	"github.com/timescale/tsbs/pkg/targets/questdb"
@@ -48,6 +49,8 @@ func GetTarget(format string) targets.ImplementedTarget {
 		return questdb.NewTarget()
 	case constants.FormatInflux2:
 		return influx2.NewTarget()
+	case constants.FormatInflux3:
+		return influx3.NewTarget()
 	case constants.FormatGreptime:
 		// Reuses influx's target.
 		return influx.NewTarget()

--- a/scripts/load/load_influx3.sh
+++ b/scripts/load/load_influx3.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+# Ensure loader is available
+EXE_FILE_NAME=${EXE_FILE_NAME:-$(which tsbs_load_influx3)}
+if [[ -z "$EXE_FILE_NAME" ]]; then
+    echo "tsbs_load_influx3 not available. It is not specified explicitly and not found in \$PATH"
+    exit 1
+fi
+
+DATA_FILE_NAME=${DATA_FILE_NAME:-influx3-data.gz}
+DATABASE_PORT=${DATABASE_PORT:-8181}
+INFLUXDB3_URL=${INFLUXDB3_URL:-http://${DATABASE_HOST:-localhost}:${DATABASE_PORT}}
+INFLUXDB3_AUTH_TOKEN=${INFLUXDB3_AUTH_TOKEN:-}
+INFLUXDB3_ADMIN_TOKEN=${INFLUXDB3_ADMIN_TOKEN:-${INFLUXDB3_AUTH_TOKEN}}
+INFLUXDB3_ACCEPT_PARTIAL=${INFLUXDB3_ACCEPT_PARTIAL:-false}
+INFLUXDB3_NO_SYNC=${INFLUXDB3_NO_SYNC:-false}
+
+EXE_DIR=${EXE_DIR:-$(dirname "$0")}
+source "${EXE_DIR}/load_common.sh"
+set +x
+
+gzip -dc "${DATA_FILE}" | "$EXE_FILE_NAME" \
+    --db-name="${DATABASE_NAME}" \
+    --do-create-db="${DO_CREATE_DB}" \
+    --backoff="${BACKOFF_SECS}" \
+    --workers="${NUM_WORKERS}" \
+    --batch-size="${BATCH_SIZE}" \
+    --reporting-period="${REPORTING_PERIOD}" \
+    --urls="${INFLUXDB3_URL}" \
+    --auth-token="${INFLUXDB3_AUTH_TOKEN}" \
+    --admin-token="${INFLUXDB3_ADMIN_TOKEN}" \
+    --accept-partial="${INFLUXDB3_ACCEPT_PARTIAL}" \
+    --no-sync="${INFLUXDB3_NO_SYNC}"

--- a/scripts/run_queries/run_queries_influx3.sh
+++ b/scripts/run_queries/run_queries_influx3.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+
+EXE_FILE_NAME=${EXE_FILE_NAME:-$(which tsbs_run_queries_influx3)}
+if [[ -z "$EXE_FILE_NAME" ]]; then
+    echo "tsbs_run_queries_influx3 not available. It is not specified explicitly and not found in \$PATH"
+    exit 1
+fi
+
+BULK_DATA_DIR=${BULK_DATA_DIR:-/tmp/bulk_queries}
+MAX_QUERIES=${MAX_QUERIES:-0}
+NUM_WORKERS=${NUM_WORKERS:-$(grep -c ^processor /proc/cpuinfo 2>/dev/null || echo 4)}
+DATABASE_NAME=${DATABASE_NAME:-benchmark}
+INFLUXDB3_URL=${INFLUXDB3_URL:-http://localhost:8181}
+INFLUXDB3_AUTH_TOKEN=${INFLUXDB3_AUTH_TOKEN:-}
+
+run_file() {
+    local full_data_file_name=$1
+    local data_file_name
+    local no_ext_data_file_name
+    local out_full_file_name
+    data_file_name=$(basename -- "${full_data_file_name}")
+    no_ext_data_file_name="${data_file_name%.*}"
+    out_full_file_name="$(dirname "${full_data_file_name}")/result_${no_ext_data_file_name}.out"
+
+    echo "Running ${data_file_name}"
+    if [[ "${data_file_name##*.}" == "gz" ]]; then
+        gzip -dc "${full_data_file_name}"
+    else
+        command cat "${full_data_file_name}"
+    fi | "$EXE_FILE_NAME" \
+        --max-queries="${MAX_QUERIES}" \
+        --workers="${NUM_WORKERS}" \
+        --db-name="${DATABASE_NAME}" \
+        --urls="${INFLUXDB3_URL}" \
+        --auth-token="${INFLUXDB3_AUTH_TOKEN}" | tee "${out_full_file_name}"
+}
+
+if [[ "$#" -gt 0 ]]; then
+    for full_data_file_name in "$@"; do
+        run_file "${full_data_file_name}"
+    done
+else
+    for full_data_file_name in "${BULK_DATA_DIR}"/queries_influx3*; do
+        [[ -e "${full_data_file_name}" ]] || continue
+        run_file "${full_data_file_name}"
+    done
+fi


### PR DESCRIPTION
## What changed

- add an `influx3` target and line-protocol data generation
- add `tsbs_load_influx3` using the native `/api/v3/write_lp` API, including Core/Enterprise database lifecycle support, gzip, authentication, durability controls, and retry handling
- add native SQL query generation and `tsbs_run_queries_influx3` using `/api/v3/query_sql`
- implement the CPU-only TSBS query set, including ordered `last_value(... ORDER BY time)` last-point queries
- add build integration, helper scripts, tests, and Core/Enterprise usage documentation

## Why

InfluxDB 3 has breaking API and query-language differences from the existing InfluxDB v1/v2 TSBS integrations. Dedicated commands keep the v1/v2 behavior intact while allowing comparable load and query benchmarks against InfluxDB 3.11 Core and Enterprise.

## User impact

Users can generate `cpu-only` data with `--format=influx3`, load it with `tsbs_load_influx3`, and execute native SQL query workloads with `tsbs_run_queries_influx3`. Durable writes are the default; `--no-sync` is available for explicitly labelled throughput experiments. A separate admin token is optional for database lifecycle operations.

## Validation

- `go test ./pkg/targets/influx3 ./pkg/query ./cmd/tsbs_generate_queries/databases/influx3 ./cmd/tsbs_load_influx3 ./cmd/tsbs_run_queries_influx3 ./internal/inputs`
- `go test ./pkg/... ./internal/...`
- `go build ./cmd/tsbs_generate_data ./cmd/tsbs_generate_queries ./cmd/tsbs_load_influx3 ./cmd/tsbs_run_queries_influx3`
- generated sample InfluxDB 3 line protocol and query streams
- `bash -n scripts/load/load_influx3.sh scripts/run_queries/run_queries_influx3.sh`
- `git diff --check`

The full race-enabled `make test` could not complete in the development environment because the filesystem ran out of space while populating the Go build cache.