### PR TITLE
Add GreptimeDB TSBS benchmark skill

### DIFF
--- a/.agents/skills/benchmark-greptimedb/SKILL.md
+++ b/.agents/skills/benchmark-greptimedb/SKILL.md
@@ -1,13 +1,14 @@
 ---
 name: benchmark-greptimedb
-description: Run repeatable GreptimeDB benchmarks with TSBS, including targeted TSBS builds, data and query generation, ingestion, individual or repeated query workloads, isolated local GreptimeDB lifecycle management, external endpoint testing, durable logs, and ingestion/query summaries. Use for GreptimeDB performance tests, TSBS smoke tests, ingestion-rate measurements, query-latency comparisons, or rerunning selected TSBS queries against an existing database.
+description: Run repeatable GreptimeDB benchmarks with TSBS, including shared dataset reuse, targeted TSBS builds, query generation, ingestion, individual or repeated query workloads, isolated local GreptimeDB lifecycle management, external endpoint testing, durable logs, and ingestion/query summaries. Use for GreptimeDB performance tests, TSBS smoke tests, ingestion-rate measurements, query-latency comparisons, or rerunning selected TSBS queries against an existing database.
 ---
 
 # Benchmark GreptimeDB
 
 Use the bundled runner for deterministic execution and log parsing. Read
 `references/workload.md` when selecting workload sizes, query types, or database
-modes.
+modes. Use `$generate-tsbs-data` for standalone data generation, cache
+inspection, or non-Greptime serialization formats.
 
 ## Collect required inputs
 
@@ -30,6 +31,9 @@ Invoke `scripts/benchmark.py` from the repository root. Examples:
 python3 .agents/skills/benchmark-greptimedb/scripts/benchmark.py all \
   --profile smoke --greptime-bin /absolute/path/to/greptime
 
+python3 .agents/skills/benchmark-greptimedb/scripts/benchmark.py generate \
+  --profile smoke --only data --dataset-root /shared/tsbs-data
+
 python3 .agents/skills/benchmark-greptimedb/scripts/benchmark.py load \
   --run-dir .benchmarks/greptimedb/RUN_ID \
   --endpoint http://127.0.0.1:4000 --database benchmark \
@@ -45,7 +49,8 @@ python3 .agents/skills/benchmark-greptimedb/scripts/benchmark.py summarize \
 ```
 
 Repeat `--query-type` to select multiple query types. Use `--regenerate` only
-when intentionally replacing generated data or query input. Use `--rebuild`
+when intentionally replacing a shared data variant or query input. Use
+`--dataset-id` or `--dataset-path` to pin a reusable dataset. Use `--rebuild`
 only when existing TSBS binaries must be rebuilt.
 
 ## Protect databases
@@ -66,7 +71,8 @@ After a run, read `summary.md` and report:
 
 - metrics/second and rows/second for every ingestion attempt;
 - weighted mean latency in milliseconds for every query type;
-- failed or unparsable attempts and their log paths; and
+- failed or unparsable attempts and their log paths;
+- the dataset ID and checksum; and
 - the run directory so the user can inspect raw logs and `summary.json`.
 
 Never discard failed-run artifacts. Managed mode stops only the process it

--- a/.agents/skills/benchmark-greptimedb/SKILL.md
+++ b/.agents/skills/benchmark-greptimedb/SKILL.md
@@ -1,0 +1,73 @@
+---
+name: benchmark-greptimedb
+description: Run repeatable GreptimeDB benchmarks with TSBS, including targeted TSBS builds, data and query generation, ingestion, individual or repeated query workloads, isolated local GreptimeDB lifecycle management, external endpoint testing, durable logs, and ingestion/query summaries. Use for GreptimeDB performance tests, TSBS smoke tests, ingestion-rate measurements, query-latency comparisons, or rerunning selected TSBS queries against an existing database.
+---
+
+# Benchmark GreptimeDB
+
+Use the bundled runner for deterministic execution and log parsing. Read
+`references/workload.md` when selecting workload sizes, query types, or database
+modes.
+
+## Collect required inputs
+
+1. Ask which stage to run: `all`, `generate`, `load`, `query`, or `summarize`.
+2. For `all`, `load`, or `query`, ask for exactly one connection:
+   - a GreptimeDB binary path for an isolated managed instance; or
+   - an HTTP endpoint for an existing instance.
+3. For an external load, ask for the database name and one database mode:
+   `create`, `reuse`, or `reset`. Never infer `reset`.
+4. For a query against an existing database without a prior run manifest, ask
+   for its timestamp range and host scale so generated queries match the data.
+5. Default to the `manual` profile unless the user requests `smoke` or explicit
+   overrides.
+
+## Run benchmarks
+
+Invoke `scripts/benchmark.py` from the repository root. Examples:
+
+```bash
+python3 .agents/skills/benchmark-greptimedb/scripts/benchmark.py all \
+  --profile smoke --greptime-bin /absolute/path/to/greptime
+
+python3 .agents/skills/benchmark-greptimedb/scripts/benchmark.py load \
+  --run-dir .benchmarks/greptimedb/RUN_ID \
+  --endpoint http://127.0.0.1:4000 --database benchmark \
+  --database-mode reuse
+
+python3 .agents/skills/benchmark-greptimedb/scripts/benchmark.py query \
+  --run-dir .benchmarks/greptimedb/RUN_ID \
+  --endpoint http://127.0.0.1:4000 --database benchmark \
+  --query-type cpu-max-all-1 --repeat 3
+
+python3 .agents/skills/benchmark-greptimedb/scripts/benchmark.py summarize \
+  --run-dir .benchmarks/greptimedb/RUN_ID
+```
+
+Repeat `--query-type` to select multiple query types. Use `--regenerate` only
+when intentionally replacing generated data or query input. Use `--rebuild`
+only when existing TSBS binaries must be rebuilt.
+
+## Protect databases
+
+- Prefer `reuse` to load into an existing database without dropping it. This
+  maps to TSBS `--do-create-db=false` and can duplicate data if repeated.
+- Use `create` for a missing database; it aborts if the database exists.
+- Use `reset` only after the user explicitly authorizes dropping the named
+  database. Pass `--confirm-reset DATABASE`, which must exactly match
+  `--database`.
+- Treat `query` and `summarize` as non-mutating database operations.
+- Do not claim external authentication support; the current TSBS query runner
+  does not send GreptimeDB Basic authentication.
+
+## Report results
+
+After a run, read `summary.md` and report:
+
+- metrics/second and rows/second for every ingestion attempt;
+- weighted mean latency in milliseconds for every query type;
+- failed or unparsable attempts and their log paths; and
+- the run directory so the user can inspect raw logs and `summary.json`.
+
+Never discard failed-run artifacts. Managed mode stops only the process it
+started and retains its data for later query-only runs.

--- a/.agents/skills/benchmark-greptimedb/SKILL.md
+++ b/.agents/skills/benchmark-greptimedb/SKILL.md
@@ -1,79 +1,72 @@
 ---
 name: benchmark-greptimedb
-description: Run repeatable GreptimeDB benchmarks with TSBS, including shared dataset reuse, targeted TSBS builds, query generation, ingestion, individual or repeated query workloads, isolated local GreptimeDB lifecycle management, external endpoint testing, durable logs, and ingestion/query summaries. Use for GreptimeDB performance tests, TSBS smoke tests, ingestion-rate measurements, query-latency comparisons, or rerunning selected TSBS queries against an existing database.
+description: Run repeatable GreptimeDB TSBS benchmarks with shared datasets, complete immutable query sets, reusable managed database workspaces, independent run logs, ingestion rates, and query-latency summaries. Use for GreptimeDB smoke or performance tests, ingestion measurements, query comparisons, managed local instances, or external GreptimeDB endpoints.
 ---
 
 # Benchmark GreptimeDB
 
-Use the bundled runner for deterministic execution and log parsing. Read
-`references/workload.md` when selecting workload sizes, query types, or database
-modes. Use `$generate-tsbs-data` for standalone data generation, cache
-inspection, or non-Greptime serialization formats.
+Use `scripts/benchmark.py` for execution and log parsing. Read
+`references/workload.md` before selecting workload sizes, query types, database
+modes, or shared workspace identifiers. Use `$generate-tsbs-data` for standalone
+dataset generation, inspection, or non-Greptime serialization formats.
 
-## Collect required inputs
+## Collect inputs
 
-1. Ask which stage to run: `all`, `generate`, `load`, `query`, or `summarize`.
-2. For `all`, `load`, or `query`, ask for exactly one connection:
-   - a GreptimeDB binary path for an isolated managed instance; or
-   - an HTTP endpoint for an existing instance.
-3. For an external load, ask for the database name and one database mode:
-   `create`, `reuse`, or `reset`. Never infer `reset`.
-4. For a query against an existing database without a prior run manifest, ask
-   for its timestamp range and host scale so generated queries match the data.
-5. Default to the `manual` profile unless the user requests `smoke` or explicit
-   overrides.
+1. Select a stage: `all`, `generate`, `load`, `query`, or `summarize`.
+2. For `all`, `load`, or `query`, select exactly one target:
+   - managed: an executable GreptimeDB binary plus a reusable `--database-id`;
+   - external: an HTTP endpoint.
+3. Select the SQL `--database`. For external loads, also select `create`,
+   `reuse`, or explicitly confirmed `reset`. Never infer reset authorization.
+4. Use the `manual` profile unless the user requests `smoke` or overrides.
 
 ## Run benchmarks
 
-Invoke `scripts/benchmark.py` from the repository root. Examples:
+Run from the repository root:
 
 ```bash
 python3 .agents/skills/benchmark-greptimedb/scripts/benchmark.py all \
-  --profile smoke --greptime-bin /absolute/path/to/greptime
+  --profile smoke --greptime-bin /absolute/path/to/greptime \
+  --database-id smoke-db
 
 python3 .agents/skills/benchmark-greptimedb/scripts/benchmark.py generate \
-  --profile smoke --only data --dataset-root /shared/tsbs-data
-
-python3 .agents/skills/benchmark-greptimedb/scripts/benchmark.py load \
-  --run-dir .benchmarks/greptimedb/RUN_ID \
-  --endpoint http://127.0.0.1:4000 --database benchmark \
-  --database-mode reuse
+  --profile smoke --only queries \
+  --run-root .benchmarks/greptimedb/runs \
+  --query-root .benchmarks/queries
 
 python3 .agents/skills/benchmark-greptimedb/scripts/benchmark.py query \
-  --run-dir .benchmarks/greptimedb/RUN_ID \
-  --endpoint http://127.0.0.1:4000 --database benchmark \
-  --query-type cpu-max-all-1 --repeat 3
+  --profile smoke --endpoint http://127.0.0.1:4000 --database benchmark \
+  --query-type cpu-max-all-1 --query-type lastpoint
 
 python3 .agents/skills/benchmark-greptimedb/scripts/benchmark.py summarize \
-  --run-dir .benchmarks/greptimedb/RUN_ID
+  --run-dir .benchmarks/greptimedb/runs/RUN_ID
 ```
 
-Repeat `--query-type` to select multiple query types. Use `--regenerate` only
-when intentionally replacing a shared data variant or query input. Use
-`--dataset-id` or `--dataset-path` to pin a reusable dataset. Use `--rebuild`
-only when existing TSBS binaries must be rebuilt.
+Repeat `--query-type` to define query-set membership; omit it for every
+supported type. `--queries=N` assigns that count to every selected type and
+therefore selects a different immutable query set. Each selected query file is
+executed once. Start another run to make another measurement.
+
+Query-only commands prepare logical dataset metadata without generating data.
+Use `--dataset-id` or `--dataset-path` to pin a dataset. Shared query sets live
+under `--query-root` and are reused only after exact manifest, membership,
+size, and checksum validation.
 
 ## Protect databases
 
-- Prefer `reuse` to load into an existing database without dropping it. This
-  maps to TSBS `--do-create-db=false` and can duplicate data if repeated.
-- Use `create` for a missing database; it aborts if the database exists.
-- Use `reset` only after the user explicitly authorizes dropping the named
-  database. Pass `--confirm-reset DATABASE`, which must exactly match
-  `--database`.
-- Treat `query` and `summarize` as non-mutating database operations.
-- Do not claim external authentication support; the current TSBS query runner
-  does not send GreptimeDB Basic authentication.
+- Give every managed workspace a stable `--database-id`; `--database-root`
+  defaults to `.benchmarks/greptimedb/databases`.
+- Keep one SQL database and one loaded dataset per managed workspace. Reuse a
+  matching binding without loading duplicate data.
+- Rebind only with `--database-mode reset --confirm-reset DATABASE`, after the
+  user explicitly authorizes dropping that SQL database.
+- Managed workspaces are locked while GreptimeDB uses them.
+- For external loads, `reuse` can duplicate data. Prefer query-only runs after
+  one successful load.
 
 ## Report results
 
-After a run, read `summary.md` and report:
-
-- metrics/second and rows/second for every ingestion attempt;
-- weighted mean latency in milliseconds for every query type;
-- failed or unparsable attempts and their log paths;
-- the dataset ID and checksum; and
-- the run directory so the user can inspect raw logs and `summary.json`.
-
-Never discard failed-run artifacts. Managed mode stops only the process it
-started and retains its data for later query-only runs.
+Read `summary.md` and report the dataset ID and checksum, query-set ID and
+manifest checksum, database ID or external target, metrics/second and
+rows/second for ingestion, weighted mean latency per query type, failures and
+their log paths, and the run directory. Preserve failed-run diagnostics.

--- a/.agents/skills/benchmark-greptimedb/agents/openai.yaml
+++ b/.agents/skills/benchmark-greptimedb/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "Benchmark GreptimeDB"
-  short_description: "Run and summarize GreptimeDB TSBS benchmarks"
-  default_prompt: "Use $benchmark-greptimedb to run a TSBS benchmark against GreptimeDB and summarize the results."
+  short_description: "Run reusable GreptimeDB TSBS benchmarks"
+  default_prompt: "Use $benchmark-greptimedb to run a shared-workspace TSBS benchmark against GreptimeDB and summarize the results."

--- a/.agents/skills/benchmark-greptimedb/agents/openai.yaml
+++ b/.agents/skills/benchmark-greptimedb/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Benchmark GreptimeDB"
+  short_description: "Run and summarize GreptimeDB TSBS benchmarks"
+  default_prompt: "Use $benchmark-greptimedb to run a TSBS benchmark against GreptimeDB and summarize the results."

--- a/.agents/skills/benchmark-greptimedb/references/workload.md
+++ b/.agents/skills/benchmark-greptimedb/references/workload.md
@@ -6,6 +6,11 @@ Both profiles use seed `123`, a `10s` data interval, the `cpu-only` data use
 case, the `devops` query use case, Influx line protocol input, and GreptimeDB
 query format.
 
+Data is resolved through `$generate-tsbs-data` and normally lives under
+`.benchmarks/datasets/<dataset-id>/formats/influx/data`. The run manifest pins
+the dataset path and SHA-256 checksum. GreptimeDB and InfluxDB 3 may consume the
+same `influx` format variant; their query inputs remain database-specific.
+
 | Setting | `manual` (default) | `smoke` |
 | --- | --- | --- |
 | Start | `2023-06-11T00:00:00Z` | `2023-06-11T00:00:00Z` |

--- a/.agents/skills/benchmark-greptimedb/references/workload.md
+++ b/.agents/skills/benchmark-greptimedb/references/workload.md
@@ -1,0 +1,53 @@
+# GreptimeDB TSBS workload reference
+
+## Profiles
+
+Both profiles use seed `123`, a `10s` data interval, the `cpu-only` data use
+case, the `devops` query use case, Influx line protocol input, and GreptimeDB
+query format.
+
+| Setting | `manual` (default) | `smoke` |
+| --- | --- | --- |
+| Start | `2023-06-11T00:00:00Z` | `2023-06-11T00:00:00Z` |
+| End | `2023-06-14T00:00:00Z` | `2023-06-12T00:00:00Z` |
+| Hosts (`scale`) | 4000 | 10 |
+| Load workers | 6 | 2 |
+| Query workers | 1 | 1 |
+| Batch size | 3000 | 3000 |
+
+The query generator receives the end timestamp plus one second, matching the
+original benchmark manual.
+
+## Query types and manual counts
+
+| Query type | Count |
+| --- | ---: |
+| `cpu-max-all-1` | 100 |
+| `cpu-max-all-8` | 100 |
+| `double-groupby-1` | 50 |
+| `double-groupby-5` | 50 |
+| `double-groupby-all` | 50 |
+| `groupby-orderby-limit` | 50 |
+| `high-cpu-1` | 100 |
+| `high-cpu-all` | 50 |
+| `lastpoint` | 10 |
+| `single-groupby-1-1-1` | 100 |
+| `single-groupby-1-1-12` | 100 |
+| `single-groupby-1-8-1` | 100 |
+| `single-groupby-5-1-1` | 100 |
+| `single-groupby-5-1-12` | 100 |
+| `single-groupby-5-8-1` | 100 |
+
+The smoke profile runs 10 queries of every type.
+
+## Database modes
+
+- `create`: pass `--do-create-db=true --do-abort-on-exist=true`. Create a
+  missing database and fail rather than drop an existing database.
+- `reuse`: pass `--do-create-db=false`. Load into the named existing database
+  without creating or dropping it.
+- `reset`: pass `--do-create-db=true`, allowing TSBS to drop and recreate the
+  database. Require `--confirm-reset` to exactly match the database name.
+
+Repeated `reuse` loads can duplicate data. Prefer query-only repetitions after
+one successful ingestion.

--- a/.agents/skills/benchmark-greptimedb/references/workload.md
+++ b/.agents/skills/benchmark-greptimedb/references/workload.md
@@ -1,58 +1,64 @@
 # GreptimeDB TSBS workload reference
 
+## Shared workspace
+
+```text
+.benchmarks/
+├── datasets/<dataset-id>/...
+├── queries/<dataset-id>/greptime/<query-set-id>/
+│   ├── manifest.json
+│   └── queries/<query-type>.dat
+└── greptimedb/
+    ├── databases/<database-id>/{manifest.json,data/,logs/}
+    └── runs/<run-id>/{manifest.json,logs/,results/,summary.json,summary.md}
+```
+
+A query-set identity includes the logical dataset identity and specification,
+Greptime query format, use case, seed, timestamp range, and the sorted
+query-type-to-count map. A subset is a complete set with only those files.
+Generation publishes the directory atomically; generator commands and stderr
+remain in the initiating run rather than the shared set.
+
 ## Profiles
 
-Both profiles use seed `123`, a `10s` data interval, the `cpu-only` data use
-case, the `devops` query use case, Influx line protocol input, and GreptimeDB
-query format.
-
-Data is resolved through `$generate-tsbs-data` and normally lives under
-`.benchmarks/datasets/<dataset-id>/formats/influx/data`. The run manifest pins
-the dataset path and SHA-256 checksum. GreptimeDB and InfluxDB 3 may consume the
-same `influx` format variant; their query inputs remain database-specific.
+Both profiles use seed `123`, interval `10s`, data use case `cpu-only`, query
+use case `devops`, Influx line protocol data, and Greptime query format.
 
 | Setting | `manual` (default) | `smoke` |
 | --- | --- | --- |
 | Start | `2023-06-11T00:00:00Z` | `2023-06-11T00:00:00Z` |
 | End | `2023-06-14T00:00:00Z` | `2023-06-12T00:00:00Z` |
-| Hosts (`scale`) | 4000 | 10 |
+| Hosts | 4000 | 10 |
 | Load workers | 6 | 2 |
 | Query workers | 1 | 1 |
 | Batch size | 3000 | 3000 |
 
-The query generator receives the end timestamp plus one second, matching the
-original benchmark manual.
+The query generator receives the end timestamp plus one second.
 
-## Query types and manual counts
+## Query counts
 
-| Query type | Count |
-| --- | ---: |
-| `cpu-max-all-1` | 100 |
-| `cpu-max-all-8` | 100 |
-| `double-groupby-1` | 50 |
-| `double-groupby-5` | 50 |
-| `double-groupby-all` | 50 |
-| `groupby-orderby-limit` | 50 |
-| `high-cpu-1` | 100 |
-| `high-cpu-all` | 50 |
-| `lastpoint` | 10 |
-| `single-groupby-1-1-1` | 100 |
-| `single-groupby-1-1-12` | 100 |
-| `single-groupby-1-8-1` | 100 |
-| `single-groupby-5-1-1` | 100 |
-| `single-groupby-5-1-12` | 100 |
-| `single-groupby-5-8-1` | 100 |
+| Query type | Manual | Smoke |
+| --- | ---: | ---: |
+| `cpu-max-all-1` | 100 | 10 |
+| `cpu-max-all-8` | 100 | 10 |
+| `double-groupby-1` | 50 | 10 |
+| `double-groupby-5` | 50 | 10 |
+| `double-groupby-all` | 50 | 10 |
+| `groupby-orderby-limit` | 50 | 10 |
+| `high-cpu-1` | 100 | 10 |
+| `high-cpu-all` | 50 | 10 |
+| `lastpoint` | 10 | 10 |
+| `single-groupby-1-1-1` | 100 | 10 |
+| `single-groupby-1-1-12` | 100 | 10 |
+| `single-groupby-1-8-1` | 100 | 10 |
+| `single-groupby-5-1-1` | 100 | 10 |
+| `single-groupby-5-1-12` | 100 | 10 |
+| `single-groupby-5-8-1` | 100 | 10 |
 
-The smoke profile runs 10 queries of every type.
+## Database state
 
-## Database modes
-
-- `create`: pass `--do-create-db=true --do-abort-on-exist=true`. Create a
-  missing database and fail rather than drop an existing database.
-- `reuse`: pass `--do-create-db=false`. Load into the named existing database
-  without creating or dropping it.
-- `reset`: pass `--do-create-db=true`, allowing TSBS to drop and recreate the
-  database. Require `--confirm-reset` to exactly match the database name.
-
-Repeated `reuse` loads can duplicate data. Prefer query-only repetitions after
-one successful ingestion.
+Managed workspace manifests bind `database_id`, SQL database name, and one
+loaded dataset specification/checksum. A matching dataset is reused. A
+different dataset requires a successfully confirmed reset before the binding
+changes. External `create`, `reuse`, and `reset` map to the corresponding TSBS
+loader flags; external reuse may duplicate data.

--- a/.agents/skills/benchmark-greptimedb/scripts/benchmark.py
+++ b/.agents/skills/benchmark-greptimedb/scripts/benchmark.py
@@ -1,0 +1,624 @@
+#!/usr/bin/env python3
+"""Run staged GreptimeDB TSBS benchmarks with durable logs and summaries."""
+
+from __future__ import annotations
+
+import argparse
+import contextlib
+import datetime as dt
+import json
+import os
+import signal
+import socket
+import subprocess
+import sys
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+from pathlib import Path
+from typing import Any, Iterator, Sequence
+
+from summarize import write_summary
+
+
+SCRIPT_PATH = Path(__file__).resolve()
+REPO_ROOT = SCRIPT_PATH.parents[4]
+DEFAULT_OUTPUT_ROOT = REPO_ROOT / ".benchmarks" / "greptimedb"
+
+QUERY_COUNTS_MANUAL = {
+    "cpu-max-all-1": 100,
+    "cpu-max-all-8": 100,
+    "double-groupby-1": 50,
+    "double-groupby-5": 50,
+    "double-groupby-all": 50,
+    "groupby-orderby-limit": 50,
+    "high-cpu-1": 100,
+    "high-cpu-all": 50,
+    "lastpoint": 10,
+    "single-groupby-1-1-1": 100,
+    "single-groupby-1-1-12": 100,
+    "single-groupby-1-8-1": 100,
+    "single-groupby-5-1-1": 100,
+    "single-groupby-5-1-12": 100,
+    "single-groupby-5-8-1": 100,
+}
+QUERY_TYPES = tuple(QUERY_COUNTS_MANUAL)
+
+PROFILES = {
+    "manual": {
+        "start": "2023-06-11T00:00:00Z",
+        "end": "2023-06-14T00:00:00Z",
+        "scale": 4000,
+        "seed": 123,
+        "log_interval": "10s",
+        "load_workers": 6,
+        "query_workers": 1,
+        "batch_size": 3000,
+        "query_counts": QUERY_COUNTS_MANUAL,
+    },
+    "smoke": {
+        "start": "2023-06-11T00:00:00Z",
+        "end": "2023-06-12T00:00:00Z",
+        "scale": 10,
+        "seed": 123,
+        "log_interval": "10s",
+        "load_workers": 2,
+        "query_workers": 1,
+        "batch_size": 3000,
+        "query_counts": {query_type: 10 for query_type in QUERY_TYPES},
+    },
+}
+
+BINARIES = {
+    "data": "tsbs_generate_data",
+    "queries": "tsbs_generate_queries",
+    "load": "tsbs_load_greptime",
+    "query": "tsbs_run_queries_influx",
+}
+BUILT_THIS_PROCESS: set[str] = set()
+
+
+class BenchmarkError(RuntimeError):
+    """Raised for an actionable benchmark failure."""
+
+
+def utc_now() -> str:
+    return dt.datetime.now(dt.timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def new_run_dir() -> Path:
+    DEFAULT_OUTPUT_ROOT.mkdir(parents=True, exist_ok=True)
+    base = dt.datetime.now(dt.timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    candidate = DEFAULT_OUTPUT_ROOT / base
+    suffix = 1
+    while candidate.exists():
+        candidate = DEFAULT_OUTPUT_ROOT / f"{base}-{suffix:02d}"
+        suffix += 1
+    return candidate
+
+
+def add_one_second(timestamp: str) -> str:
+    parsed = dt.datetime.fromisoformat(timestamp.replace("Z", "+00:00"))
+    return (parsed + dt.timedelta(seconds=1)).isoformat().replace("+00:00", "Z")
+
+
+def save_manifest(run_dir: Path, manifest: dict[str, Any]) -> None:
+    manifest["updated_at"] = utc_now()
+    temp = run_dir / "manifest.json.tmp"
+    temp.write_text(json.dumps(manifest, indent=2) + "\n", encoding="utf-8")
+    os.replace(temp, run_dir / "manifest.json")
+
+
+def prepare_run(args: argparse.Namespace) -> tuple[Path, dict[str, Any]]:
+    run_dir = args.run_dir.resolve() if args.run_dir else new_run_dir()
+    for directory in ("data", "queries", "logs", "results", "greptimedb/data", "greptimedb/logs"):
+        (run_dir / directory).mkdir(parents=True, exist_ok=True)
+    manifest_path = run_dir / "manifest.json"
+    if manifest_path.exists():
+        manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    else:
+        profile = args.profile or "manual"
+        manifest = {
+            "run_id": run_dir.name,
+            "created_at": utc_now(),
+            "profile": profile,
+            "database": getattr(args, "database", "benchmark"),
+            "workload": json.loads(json.dumps(PROFILES[profile])),
+            "events": {"loads": [], "queries": []},
+        }
+
+    workload = manifest["workload"]
+    for attr in ("start", "end", "scale", "seed", "log_interval", "load_workers", "query_workers", "batch_size"):
+        value = getattr(args, attr, None)
+        if value is not None:
+            workload[attr] = value
+    if getattr(args, "queries", None) is not None:
+        selected = args.query_type or QUERY_TYPES
+        for query_type in selected:
+            workload["query_counts"][query_type] = args.queries
+    if hasattr(args, "database"):
+        manifest["database"] = args.database
+    save_manifest(run_dir, manifest)
+    return run_dir, manifest
+
+
+def relative(run_dir: Path, path: Path) -> str:
+    return str(path.relative_to(run_dir))
+
+
+def display_command(command: Sequence[str]) -> str:
+    return " ".join(subprocess.list2cmdline([part]) for part in command)
+
+
+def run_tee(
+    command: Sequence[str],
+    log_path: Path,
+    *,
+    stdout_path: Path | None = None,
+    append: bool = False,
+) -> None:
+    mode = "a" if append else "w"
+    log_path.parent.mkdir(parents=True, exist_ok=True)
+    with log_path.open(mode, encoding="utf-8") as log:
+        header = f"$ {display_command(command)}\n"
+        log.write(header)
+        log.flush()
+        print(header, end="")
+        if stdout_path is None:
+            process = subprocess.Popen(
+                command,
+                cwd=REPO_ROOT,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.STDOUT,
+                text=True,
+                bufsize=1,
+            )
+            assert process.stdout is not None
+            for line in process.stdout:
+                sys.stdout.write(line)
+                log.write(line)
+            process.stdout.close()
+            return_code = process.wait()
+        else:
+            stdout_path.parent.mkdir(parents=True, exist_ok=True)
+            temporary_output = stdout_path.with_name(stdout_path.name + ".tmp")
+            with temporary_output.open("wb") as output:
+                process = subprocess.Popen(
+                    command,
+                    cwd=REPO_ROOT,
+                    stdout=output,
+                    stderr=subprocess.PIPE,
+                    text=True,
+                    bufsize=1,
+                )
+                assert process.stderr is not None
+                for line in process.stderr:
+                    sys.stdout.write(line)
+                    log.write(line)
+                process.stderr.close()
+                return_code = process.wait()
+        if return_code:
+            if stdout_path is not None:
+                temporary_output.unlink(missing_ok=True)
+            raise BenchmarkError(f"command failed with exit code {return_code}; see {log_path}")
+        if stdout_path is not None:
+            os.replace(temporary_output, stdout_path)
+
+
+def binary_needs_build(run_dir: Path, name: str, target: Path, rebuild: bool) -> bool:
+    marker = run_dir / "results" / f"built-{name}"
+    return name not in BUILT_THIS_PROCESS and (rebuild or not (target.exists() and marker.exists()))
+
+
+def ensure_binaries(run_dir: Path, stages: Sequence[str], rebuild: bool) -> None:
+    for stage in stages:
+        name = BINARIES[stage]
+        target = REPO_ROOT / "bin" / name
+        marker = run_dir / "results" / f"built-{name}"
+        if not binary_needs_build(run_dir, name, target, rebuild):
+            continue
+        target.parent.mkdir(parents=True, exist_ok=True)
+        run_tee(
+            ["go", "build", "-o", str(target), f"./cmd/{name}"],
+            run_dir / "logs" / "build.log",
+            append=True,
+        )
+        marker.parent.mkdir(parents=True, exist_ok=True)
+        marker.write_text(utc_now() + "\n", encoding="utf-8")
+        BUILT_THIS_PROCESS.add(name)
+
+
+def data_path(run_dir: Path) -> Path:
+    return run_dir / "data" / "influx-data.lp"
+
+
+def query_path(run_dir: Path, query_type: str) -> Path:
+    return run_dir / "queries" / f"greptime-queries-{query_type}.dat"
+
+
+def generate_data(run_dir: Path, manifest: dict[str, Any], regenerate: bool, rebuild: bool) -> None:
+    output = data_path(run_dir)
+    if output.exists() and not regenerate:
+        print(f"Reusing generated data: {output}")
+        return
+    ensure_binaries(run_dir, ["data"], rebuild)
+    workload = manifest["workload"]
+    command = [
+        str(REPO_ROOT / "bin" / BINARIES["data"]),
+        "--use-case=cpu-only",
+        f"--seed={workload['seed']}",
+        f"--scale={workload['scale']}",
+        f"--timestamp-start={workload['start']}",
+        f"--timestamp-end={workload['end']}",
+        f"--log-interval={workload['log_interval']}",
+        "--format=influx",
+    ]
+    run_tee(command, run_dir / "logs" / "generate-data.log", stdout_path=output)
+    manifest["generated_data"] = relative(run_dir, output)
+    save_manifest(run_dir, manifest)
+
+
+def generate_queries(
+    run_dir: Path,
+    manifest: dict[str, Any],
+    query_types: Sequence[str],
+    regenerate: bool,
+    rebuild: bool,
+) -> None:
+    ensure_binaries(run_dir, ["queries"], rebuild)
+    workload = manifest["workload"]
+    for query_type in query_types:
+        output = query_path(run_dir, query_type)
+        if output.exists() and not regenerate:
+            print(f"Reusing generated queries: {output}")
+            continue
+        command = [
+            str(REPO_ROOT / "bin" / BINARIES["queries"]),
+            "--use-case=devops",
+            f"--seed={workload['seed']}",
+            f"--scale={workload['scale']}",
+            f"--timestamp-start={workload['start']}",
+            f"--timestamp-end={add_one_second(workload['end'])}",
+            f"--queries={workload['query_counts'][query_type]}",
+            f"--query-type={query_type}",
+            "--format=greptime",
+        ]
+        run_tee(command, run_dir / "logs" / f"generate-query-{query_type}.log", stdout_path=output)
+    manifest["generated_query_types"] = sorted(
+        query_type for query_type in QUERY_TYPES if query_path(run_dir, query_type).exists()
+    )
+    save_manifest(run_dir, manifest)
+
+
+def database_mode_args(mode: str, database: str, confirmation: str | None) -> list[str]:
+    if mode == "create":
+        return ["--do-create-db=true", "--do-abort-on-exist=true"]
+    if mode == "reuse":
+        return ["--do-create-db=false"]
+    if mode == "reset":
+        if confirmation != database:
+            raise BenchmarkError("reset requires --confirm-reset to exactly match --database")
+        return ["--do-create-db=true"]
+    raise BenchmarkError(f"unknown database mode: {mode}")
+
+
+def next_attempt(events: Sequence[dict[str, Any]], query_type: str | None = None) -> int:
+    matching = [event for event in events if query_type is None or event.get("query_type") == query_type]
+    return max((int(event["attempt"]) for event in matching), default=0) + 1
+
+
+def load_data(
+    args: argparse.Namespace,
+    run_dir: Path,
+    manifest: dict[str, Any],
+    endpoint: str,
+    managed: bool,
+) -> None:
+    generate_data(run_dir, manifest, args.regenerate, args.rebuild)
+    ensure_binaries(run_dir, ["load"], args.rebuild)
+    mode = args.database_mode or ("create" if managed else None)
+    if mode is None:
+        raise BenchmarkError("external loads require --database-mode=create|reuse|reset")
+    attempt = next_attempt(manifest["events"]["loads"])
+    log_path = run_dir / "logs" / f"load-run-{attempt:03d}.log"
+    result_path = run_dir / "results" / f"load-run-{attempt:03d}.json"
+    event = {
+        "attempt": attempt,
+        "database": args.database,
+        "database_mode": mode,
+        "log": relative(run_dir, log_path),
+        "status": "running",
+        "started_at": utc_now(),
+    }
+    manifest["events"]["loads"].append(event)
+    save_manifest(run_dir, manifest)
+    workload = manifest["workload"]
+    command = [
+        str(REPO_ROOT / "bin" / BINARIES["load"]),
+        f"--urls={endpoint}",
+        f"--file={data_path(run_dir)}",
+        f"--db-name={args.database}",
+        f"--batch-size={workload['batch_size']}",
+        "--gzip=false",
+        f"--workers={workload['load_workers']}",
+        "--reporting-period=10s",
+        f"--results-file={result_path}",
+        *database_mode_args(mode, args.database, args.confirm_reset),
+    ]
+    try:
+        run_tee(command, log_path)
+    except Exception:
+        event["status"] = "failed"
+        event["finished_at"] = utc_now()
+        save_manifest(run_dir, manifest)
+        raise
+    event["status"] = "completed"
+    event["finished_at"] = utc_now()
+    event["results"] = relative(run_dir, result_path)
+    save_manifest(run_dir, manifest)
+
+
+def run_queries(
+    args: argparse.Namespace,
+    run_dir: Path,
+    manifest: dict[str, Any],
+    endpoint: str,
+) -> None:
+    query_types = args.query_type or list(QUERY_TYPES)
+    generate_queries(run_dir, manifest, query_types, args.regenerate, args.rebuild)
+    ensure_binaries(run_dir, ["query"], args.rebuild)
+    workload = manifest["workload"]
+    for query_type in query_types:
+        for _ in range(args.repeat):
+            attempt = next_attempt(manifest["events"]["queries"], query_type)
+            log_path = run_dir / "logs" / f"query-{query_type}-run-{attempt:03d}.log"
+            result_path = run_dir / "results" / f"query-{query_type}-run-{attempt:03d}.json"
+            event = {
+                "query_type": query_type,
+                "attempt": attempt,
+                "database": args.database,
+                "log": relative(run_dir, log_path),
+                "status": "running",
+                "started_at": utc_now(),
+            }
+            manifest["events"]["queries"].append(event)
+            save_manifest(run_dir, manifest)
+            command = [
+                str(REPO_ROOT / "bin" / BINARIES["query"]),
+                f"--file={query_path(run_dir, query_type)}",
+                f"--db-name={args.database}",
+                f"--urls={endpoint}",
+                f"--workers={workload['query_workers']}",
+                "--print-interval=0",
+                f"--results-file={result_path}",
+            ]
+            try:
+                run_tee(command, log_path)
+            except Exception:
+                event["status"] = "failed"
+                event["finished_at"] = utc_now()
+                save_manifest(run_dir, manifest)
+                raise
+            event["status"] = "completed"
+            event["finished_at"] = utc_now()
+            event["results"] = relative(run_dir, result_path)
+            save_manifest(run_dir, manifest)
+
+
+def endpoint_ready(endpoint: str) -> bool:
+    data = urllib.parse.urlencode({"sql": "SHOW DATABASES"}).encode()
+    request = urllib.request.Request(
+        endpoint.rstrip("/") + "/v1/sql",
+        data=data,
+        headers={"Content-Type": "application/x-www-form-urlencoded"},
+    )
+    try:
+        with urllib.request.urlopen(request, timeout=2) as response:
+            return response.status == 200
+    except (OSError, urllib.error.URLError):
+        return False
+
+
+def check_port_available(port: int) -> None:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        try:
+            sock.bind(("127.0.0.1", port))
+        except OSError as exc:
+            raise BenchmarkError(f"managed GreptimeDB HTTP port {port} is unavailable") from exc
+
+
+@contextlib.contextmanager
+def connection(args: argparse.Namespace, run_dir: Path) -> Iterator[tuple[str, bool]]:
+    if bool(args.greptime_bin) == bool(args.endpoint):
+        raise BenchmarkError("provide exactly one of --greptime-bin or --endpoint")
+    if args.endpoint:
+        yield args.endpoint.rstrip("/"), False
+        return
+
+    binary = args.greptime_bin.resolve()
+    if not binary.is_file() or not os.access(binary, os.X_OK):
+        raise BenchmarkError(f"GreptimeDB binary is not executable: {binary}")
+    check_port_available(args.http_port)
+    endpoint = f"http://127.0.0.1:{args.http_port}"
+    process_log_path = run_dir / "logs" / "greptimedb-process.log"
+    process_log = process_log_path.open("a", encoding="utf-8")
+    command = [
+        str(binary),
+        "standalone",
+        "start",
+        "--http-addr",
+        f"127.0.0.1:{args.http_port}",
+        "--influxdb-enable",
+        "--data-home",
+        str(run_dir / "greptimedb" / "data"),
+        "--log-dir",
+        str(run_dir / "greptimedb" / "logs"),
+    ]
+    process_log.write(f"$ {display_command(command)}\n")
+    process_log.flush()
+    process = subprocess.Popen(
+        command,
+        cwd=run_dir,
+        stdout=process_log,
+        stderr=subprocess.STDOUT,
+        start_new_session=True,
+    )
+    try:
+        deadline = time.monotonic() + args.startup_timeout
+        while time.monotonic() < deadline:
+            if process.poll() is not None:
+                raise BenchmarkError(f"GreptimeDB exited during startup; see {process_log_path}")
+            if endpoint_ready(endpoint):
+                break
+            time.sleep(0.5)
+        else:
+            raise BenchmarkError(f"GreptimeDB was not ready within {args.startup_timeout}s; see {process_log_path}")
+        yield endpoint, True
+    finally:
+        if process.poll() is None:
+            os.killpg(process.pid, signal.SIGTERM)
+            try:
+                process.wait(timeout=15)
+            except subprocess.TimeoutExpired:
+                os.killpg(process.pid, signal.SIGKILL)
+                process.wait(timeout=5)
+        process_log.close()
+
+
+def add_run_options(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument("--run-dir", type=Path)
+    parser.add_argument("--profile", choices=sorted(PROFILES))
+    parser.add_argument("--start")
+    parser.add_argument("--end")
+    parser.add_argument("--scale", type=int)
+    parser.add_argument("--seed", type=int)
+    parser.add_argument("--log-interval")
+    parser.add_argument("--load-workers", type=int)
+    parser.add_argument("--query-workers", type=int)
+    parser.add_argument("--batch-size", type=int)
+    parser.add_argument("--queries", type=int, help="override the generated count for selected query types")
+    parser.add_argument("--query-type", action="append", choices=QUERY_TYPES)
+    parser.add_argument("--regenerate", action="store_true")
+    parser.add_argument("--rebuild", action="store_true")
+
+
+def add_connection_options(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument("--greptime-bin", type=Path)
+    parser.add_argument("--endpoint")
+    parser.add_argument("--http-port", type=int, default=4000)
+    parser.add_argument("--startup-timeout", type=int, default=60)
+    parser.add_argument("--database", default="benchmark")
+
+
+def add_load_options(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument("--database-mode", choices=("create", "reuse", "reset"))
+    parser.add_argument("--confirm-reset")
+
+
+def make_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    build = subparsers.add_parser("build", help="build the four GreptimeDB TSBS tools")
+    build.add_argument("--run-dir", type=Path)
+    build.add_argument("--rebuild", action="store_true")
+
+    generate = subparsers.add_parser("generate", help="generate data and/or queries")
+    add_run_options(generate)
+    generate.add_argument("--only", choices=("all", "data", "queries"), default="all")
+
+    load = subparsers.add_parser("load", help="load generated data")
+    add_run_options(load)
+    add_connection_options(load)
+    add_load_options(load)
+
+    query = subparsers.add_parser("query", help="run selected generated queries")
+    add_run_options(query)
+    add_connection_options(query)
+    query.add_argument("--repeat", type=int, default=1)
+
+    all_command = subparsers.add_parser("all", help="generate, load, query, and summarize")
+    add_run_options(all_command)
+    add_connection_options(all_command)
+    add_load_options(all_command)
+    all_command.add_argument("--repeat", type=int, default=1)
+
+    summarize = subparsers.add_parser("summarize", help="rebuild summaries from manifest logs")
+    summarize.add_argument("--run-dir", required=True, type=Path)
+    return parser
+
+
+def validate_args(args: argparse.Namespace) -> None:
+    for name in ("scale", "load_workers", "query_workers", "batch_size", "queries"):
+        value = getattr(args, name, None)
+        if value is not None and value <= 0:
+            raise BenchmarkError(f"--{name.replace('_', '-')} must be positive")
+    if getattr(args, "repeat", 1) <= 0:
+        raise BenchmarkError("--repeat must be positive")
+    if args.command in ("load", "query", "all"):
+        if bool(args.greptime_bin) == bool(args.endpoint):
+            raise BenchmarkError("provide exactly one of --greptime-bin or --endpoint")
+        if args.endpoint:
+            parsed = urllib.parse.urlparse(args.endpoint)
+            if parsed.scheme not in ("http", "https") or not parsed.netloc:
+                raise BenchmarkError("--endpoint must be an absolute HTTP or HTTPS URL")
+    if args.command in ("load", "all"):
+        if args.endpoint and args.database_mode is None:
+            raise BenchmarkError("external loads require --database-mode=create|reuse|reset")
+        if args.database_mode == "reset" and args.confirm_reset != args.database:
+            raise BenchmarkError("reset requires --confirm-reset to exactly match --database")
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = make_parser().parse_args(argv)
+    run_dir: Path | None = None
+    manifest: dict[str, Any] | None = None
+    try:
+        validate_args(args)
+        if args.command == "summarize":
+            run_dir = args.run_dir.resolve()
+            manifest = json.loads((run_dir / "manifest.json").read_text(encoding="utf-8"))
+            summary = write_summary(run_dir, manifest)
+            print(run_dir / "summary.md")
+            return 1 if summary["failures"] else 0
+
+        if args.command == "build":
+            run_dir = args.run_dir.resolve() if args.run_dir else new_run_dir()
+            (run_dir / "logs").mkdir(parents=True, exist_ok=True)
+            ensure_binaries(run_dir, list(BINARIES), args.rebuild)
+            print(run_dir)
+            return 0
+
+        run_dir, manifest = prepare_run(args)
+        query_types = args.query_type or list(QUERY_TYPES)
+        if args.command == "generate":
+            if args.only in ("all", "data"):
+                generate_data(run_dir, manifest, args.regenerate, args.rebuild)
+            if args.only in ("all", "queries"):
+                generate_queries(run_dir, manifest, query_types, args.regenerate, args.rebuild)
+        elif args.command in ("load", "query", "all"):
+            with connection(args, run_dir) as (endpoint, managed):
+                manifest["database"] = args.database
+                manifest["connection"] = {"mode": "managed" if managed else "external", "endpoint": endpoint}
+                save_manifest(run_dir, manifest)
+                if args.command in ("load", "all"):
+                    load_data(args, run_dir, manifest, endpoint, managed)
+                if args.command in ("query", "all"):
+                    run_queries(args, run_dir, manifest, endpoint)
+        summary = write_summary(run_dir, manifest)
+        print(f"Run directory: {run_dir}")
+        print(f"Summary: {run_dir / 'summary.md'}")
+        return 1 if summary["failures"] else 0
+    except (BenchmarkError, OSError, json.JSONDecodeError) as exc:
+        if run_dir is not None and manifest is not None:
+            try:
+                write_summary(run_dir, manifest)
+            except OSError:
+                pass
+        print(f"error: {exc}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.agents/skills/benchmark-greptimedb/scripts/benchmark.py
+++ b/.agents/skills/benchmark-greptimedb/scripts/benchmark.py
@@ -233,6 +233,19 @@ def query_path(run_dir: Path, query_type: str) -> Path:
     return run_dir / "queries" / f"greptime-queries-{query_type}.dat"
 
 
+def query_generation_spec(workload: dict[str, Any], query_type: str) -> dict[str, Any]:
+    return {
+        "use_case": "devops",
+        "seed": workload["seed"],
+        "scale": workload["scale"],
+        "timestamp_start": workload["start"],
+        "timestamp_end": add_one_second(workload["end"]),
+        "queries": workload["query_counts"][query_type],
+        "query_type": query_type,
+        "format": "greptime",
+    }
+
+
 def dataset_selection_args(
     args: argparse.Namespace,
     manifest: dict[str, Any],
@@ -349,23 +362,27 @@ def generate_queries(
 ) -> None:
     ensure_binaries(run_dir, ["queries"], rebuild)
     workload = manifest["workload"]
+    generation_specs = manifest.setdefault("query_generation_specs", {})
     for query_type in query_types:
         output = query_path(run_dir, query_type)
-        if output.exists() and not regenerate:
+        spec = query_generation_spec(workload, query_type)
+        if output.exists() and generation_specs.get(query_type) == spec and not regenerate:
             print(f"Reusing generated queries: {output}")
             continue
         command = [
             str(REPO_ROOT / "bin" / BINARIES["queries"]),
-            "--use-case=devops",
-            f"--seed={workload['seed']}",
-            f"--scale={workload['scale']}",
-            f"--timestamp-start={workload['start']}",
-            f"--timestamp-end={add_one_second(workload['end'])}",
-            f"--queries={workload['query_counts'][query_type]}",
-            f"--query-type={query_type}",
-            "--format=greptime",
+            f"--use-case={spec['use_case']}",
+            f"--seed={spec['seed']}",
+            f"--scale={spec['scale']}",
+            f"--timestamp-start={spec['timestamp_start']}",
+            f"--timestamp-end={spec['timestamp_end']}",
+            f"--queries={spec['queries']}",
+            f"--query-type={spec['query_type']}",
+            f"--format={spec['format']}",
         ]
         run_tee(command, run_dir / "logs" / f"generate-query-{query_type}.log", stdout_path=output)
+        generation_specs[query_type] = spec
+        save_manifest(run_dir, manifest)
     manifest["generated_query_types"] = sorted(
         query_type for query_type in QUERY_TYPES if query_path(run_dir, query_type).exists()
     )

--- a/.agents/skills/benchmark-greptimedb/scripts/benchmark.py
+++ b/.agents/skills/benchmark-greptimedb/scripts/benchmark.py
@@ -26,6 +26,8 @@ SCRIPT_PATH = Path(__file__).resolve()
 REPO_ROOT = SCRIPT_PATH.parents[4]
 DEFAULT_OUTPUT_ROOT = REPO_ROOT / ".benchmarks" / "greptimedb"
 DATASET_RUNNER = REPO_ROOT / ".agents" / "skills" / "generate-tsbs-data" / "scripts" / "generate.py"
+DEFAULT_DATABASE = "benchmark"
+DATA_WORKLOAD_OPTIONS = ("start", "end", "scale", "seed", "log_interval")
 
 QUERY_COUNTS_MANUAL = {
     "cpu-max-all-1": 100,
@@ -110,6 +112,19 @@ def save_manifest(run_dir: Path, manifest: dict[str, Any]) -> None:
     os.replace(temp, run_dir / "manifest.json")
 
 
+def resolve_database(args: argparse.Namespace) -> None:
+    """Resolve an omitted database before validation or benchmark work."""
+    if not hasattr(args, "database") or args.database is not None:
+        return
+    database = DEFAULT_DATABASE
+    if args.run_dir:
+        manifest_path = args.run_dir.resolve() / "manifest.json"
+        if manifest_path.exists():
+            manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+            database = manifest.get("database") or DEFAULT_DATABASE
+    args.database = database
+
+
 def prepare_run(args: argparse.Namespace) -> tuple[Path, dict[str, Any]]:
     run_dir = args.run_dir.resolve() if args.run_dir else new_run_dir()
     for directory in ("data", "queries", "logs", "results", "greptimedb/data", "greptimedb/logs"):
@@ -123,7 +138,7 @@ def prepare_run(args: argparse.Namespace) -> tuple[Path, dict[str, Any]]:
             "run_id": run_dir.name,
             "created_at": utc_now(),
             "profile": profile,
-            "database": getattr(args, "database", "benchmark"),
+            "database": getattr(args, "database", DEFAULT_DATABASE),
             "workload": json.loads(json.dumps(PROFILES[profile])),
             "events": {"loads": [], "queries": []},
         }
@@ -289,7 +304,11 @@ def generate_data(
 ) -> Path:
     legacy = run_dir / "data" / "influx-data.lp"
     if legacy.exists() and not manifest.get("dataset") and not (
-        args.dataset_root or args.dataset_id or args.dataset_path or args.regenerate
+        args.dataset_root
+        or args.dataset_id
+        or args.dataset_path
+        or args.regenerate
+        or any(getattr(args, option) is not None for option in DATA_WORKLOAD_OPTIONS)
     ):
         print(f"Reusing legacy generated data: {legacy}")
         manifest["generated_data"] = relative(run_dir, legacy)
@@ -610,7 +629,10 @@ def add_connection_options(parser: argparse.ArgumentParser) -> None:
     parser.add_argument("--endpoint")
     parser.add_argument("--http-port", type=int, default=4000)
     parser.add_argument("--startup-timeout", type=int, default=60)
-    parser.add_argument("--database", default="benchmark")
+    parser.add_argument(
+        "--database",
+        help=f"database name (inherits an existing run; defaults to {DEFAULT_DATABASE} for a new run)",
+    )
 
 
 def add_load_options(parser: argparse.ArgumentParser) -> None:
@@ -677,6 +699,7 @@ def main(argv: Sequence[str] | None = None) -> int:
     run_dir: Path | None = None
     manifest: dict[str, Any] | None = None
     try:
+        resolve_database(args)
         validate_args(args)
         if args.command == "summarize":
             run_dir = args.run_dir.resolve()

--- a/.agents/skills/benchmark-greptimedb/scripts/benchmark.py
+++ b/.agents/skills/benchmark-greptimedb/scripts/benchmark.py
@@ -1,17 +1,22 @@
 #!/usr/bin/env python3
-"""Run staged GreptimeDB TSBS benchmarks with durable logs and summaries."""
+"""Run GreptimeDB TSBS benchmarks using shared, validated artifacts."""
 
 from __future__ import annotations
 
 import argparse
 import contextlib
 import datetime as dt
+import fcntl
+import hashlib
 import json
 import os
+import re
+import shutil
 import signal
 import socket
 import subprocess
 import sys
+import tempfile
 import time
 import urllib.error
 import urllib.parse
@@ -24,60 +29,40 @@ from summarize import write_summary
 
 SCRIPT_PATH = Path(__file__).resolve()
 REPO_ROOT = SCRIPT_PATH.parents[4]
-DEFAULT_OUTPUT_ROOT = REPO_ROOT / ".benchmarks" / "greptimedb"
+BENCHMARK_ROOT = REPO_ROOT / ".benchmarks"
+DEFAULT_RUN_ROOT = BENCHMARK_ROOT / "greptimedb" / "runs"
+DEFAULT_QUERY_ROOT = BENCHMARK_ROOT / "queries"
+DEFAULT_DATABASE_ROOT = BENCHMARK_ROOT / "greptimedb" / "databases"
+DEFAULT_DATASET_ROOT = BENCHMARK_ROOT / "datasets"
 DATASET_RUNNER = REPO_ROOT / ".agents" / "skills" / "generate-tsbs-data" / "scripts" / "generate.py"
 DEFAULT_DATABASE = "benchmark"
+SCHEMA_VERSION = 1
+ID_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]*$")
 DATA_WORKLOAD_OPTIONS = ("start", "end", "scale", "seed", "log_interval")
 
 QUERY_COUNTS_MANUAL = {
-    "cpu-max-all-1": 100,
-    "cpu-max-all-8": 100,
-    "double-groupby-1": 50,
-    "double-groupby-5": 50,
-    "double-groupby-all": 50,
-    "groupby-orderby-limit": 50,
-    "high-cpu-1": 100,
-    "high-cpu-all": 50,
-    "lastpoint": 10,
-    "single-groupby-1-1-1": 100,
-    "single-groupby-1-1-12": 100,
-    "single-groupby-1-8-1": 100,
-    "single-groupby-5-1-1": 100,
-    "single-groupby-5-1-12": 100,
-    "single-groupby-5-8-1": 100,
+    "cpu-max-all-1": 100, "cpu-max-all-8": 100, "double-groupby-1": 50,
+    "double-groupby-5": 50, "double-groupby-all": 50, "groupby-orderby-limit": 50,
+    "high-cpu-1": 100, "high-cpu-all": 50, "lastpoint": 10,
+    "single-groupby-1-1-1": 100, "single-groupby-1-1-12": 100,
+    "single-groupby-1-8-1": 100, "single-groupby-5-1-1": 100,
+    "single-groupby-5-1-12": 100, "single-groupby-5-8-1": 100,
 }
 QUERY_TYPES = tuple(QUERY_COUNTS_MANUAL)
-
 PROFILES = {
     "manual": {
-        "start": "2023-06-11T00:00:00Z",
-        "end": "2023-06-14T00:00:00Z",
-        "scale": 4000,
-        "seed": 123,
-        "log_interval": "10s",
-        "load_workers": 6,
-        "query_workers": 1,
-        "batch_size": 3000,
-        "query_counts": QUERY_COUNTS_MANUAL,
+        "start": "2023-06-11T00:00:00Z", "end": "2023-06-14T00:00:00Z",
+        "scale": 4000, "seed": 123, "log_interval": "10s", "load_workers": 6,
+        "query_workers": 1, "batch_size": 3000, "query_counts": QUERY_COUNTS_MANUAL,
     },
     "smoke": {
-        "start": "2023-06-11T00:00:00Z",
-        "end": "2023-06-12T00:00:00Z",
-        "scale": 10,
-        "seed": 123,
-        "log_interval": "10s",
-        "load_workers": 2,
-        "query_workers": 1,
-        "batch_size": 3000,
+        "start": "2023-06-11T00:00:00Z", "end": "2023-06-12T00:00:00Z",
+        "scale": 10, "seed": 123, "log_interval": "10s", "load_workers": 2,
+        "query_workers": 1, "batch_size": 3000,
         "query_counts": {query_type: 10 for query_type in QUERY_TYPES},
     },
 }
-
-BINARIES = {
-    "queries": "tsbs_generate_queries",
-    "load": "tsbs_load_greptime",
-    "query": "tsbs_run_queries_influx",
-}
+BINARIES = {"queries": "tsbs_generate_queries", "load": "tsbs_load_greptime", "query": "tsbs_run_queries_influx"}
 BUILT_THIS_PROCESS: set[str] = set()
 
 
@@ -89,13 +74,44 @@ def utc_now() -> str:
     return dt.datetime.now(dt.timezone.utc).isoformat().replace("+00:00", "Z")
 
 
-def new_run_dir() -> Path:
-    DEFAULT_OUTPUT_ROOT.mkdir(parents=True, exist_ok=True)
+def canonical_json(value: Any) -> str:
+    return json.dumps(value, sort_keys=True, separators=(",", ":"), ensure_ascii=True)
+
+
+def sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as stream:
+        for chunk in iter(lambda: stream.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def save_json(path: Path, value: Any) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temporary = path.with_name(f"{path.name}.tmp-{os.getpid()}")
+    temporary.write_text(json.dumps(value, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    os.replace(temporary, path)
+
+
+def read_json(path: Path) -> dict[str, Any]:
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except FileNotFoundError as exc:
+        raise BenchmarkError(f"missing manifest: {path}") from exc
+    except json.JSONDecodeError as exc:
+        raise BenchmarkError(f"invalid JSON manifest {path}: {exc}") from exc
+    if not isinstance(value, dict):
+        raise BenchmarkError(f"manifest must be an object: {path}")
+    return value
+
+
+def new_run_dir(run_root: Path = DEFAULT_RUN_ROOT) -> Path:
+    run_root.mkdir(parents=True, exist_ok=True)
     base = dt.datetime.now(dt.timezone.utc).strftime("%Y%m%dT%H%M%SZ")
-    candidate = DEFAULT_OUTPUT_ROOT / base
+    candidate = run_root / base
     suffix = 1
     while candidate.exists():
-        candidate = DEFAULT_OUTPUT_ROOT / f"{base}-{suffix:02d}"
+        candidate = run_root / f"{base}-{suffix:02d}"
         suffix += 1
     return candidate
 
@@ -105,57 +121,76 @@ def add_one_second(timestamp: str) -> str:
     return (parsed + dt.timedelta(seconds=1)).isoformat().replace("+00:00", "Z")
 
 
+def validate_run_manifest(manifest: dict[str, Any], path: Path) -> None:
+    required = {"schema_version", "kind", "run_id", "created_at", "profile", "workload", "events"}
+    if manifest.get("schema_version") != SCHEMA_VERSION or manifest.get("kind") != "greptimedb-run":
+        raise BenchmarkError(f"unsupported run manifest schema: {path}")
+    if not required.issubset(manifest) or not isinstance(manifest["workload"], dict):
+        raise BenchmarkError(f"malformed run manifest: {path}")
+    events = manifest["events"]
+    if not isinstance(events, dict) or not isinstance(events.get("loads"), list) or not isinstance(events.get("queries"), list):
+        raise BenchmarkError(f"malformed run events: {path}")
+    workload = manifest["workload"]
+    workload_fields = ("start", "end", "scale", "seed", "log_interval", "load_workers", "query_workers", "batch_size", "query_counts")
+    if not all(field in workload for field in workload_fields) or not isinstance(workload["query_counts"], dict):
+        raise BenchmarkError(f"malformed run workload: {path}")
+
+
 def save_manifest(run_dir: Path, manifest: dict[str, Any]) -> None:
     manifest["updated_at"] = utc_now()
-    temp = run_dir / "manifest.json.tmp"
-    temp.write_text(json.dumps(manifest, indent=2) + "\n", encoding="utf-8")
-    os.replace(temp, run_dir / "manifest.json")
+    save_json(run_dir / "manifest.json", manifest)
 
 
 def resolve_database(args: argparse.Namespace) -> None:
-    """Resolve an omitted database before validation or benchmark work."""
     if not hasattr(args, "database") or args.database is not None:
         return
-    database = DEFAULT_DATABASE
-    if args.run_dir:
-        manifest_path = args.run_dir.resolve() / "manifest.json"
-        if manifest_path.exists():
-            manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
-            database = manifest.get("database") or DEFAULT_DATABASE
-    args.database = database
+    args.database = DEFAULT_DATABASE
+    if args.run_dir and (args.run_dir.resolve() / "manifest.json").exists():
+        manifest = read_json(args.run_dir.resolve() / "manifest.json")
+        validate_run_manifest(manifest, args.run_dir.resolve() / "manifest.json")
+        args.database = manifest.get("database", DEFAULT_DATABASE)
 
 
 def prepare_run(args: argparse.Namespace) -> tuple[Path, dict[str, Any]]:
-    run_dir = args.run_dir.resolve() if args.run_dir else new_run_dir()
-    for directory in ("data", "queries", "logs", "results", "greptimedb/data", "greptimedb/logs"):
-        (run_dir / directory).mkdir(parents=True, exist_ok=True)
+    run_root = (args.run_root or DEFAULT_RUN_ROOT).expanduser().resolve()
+    run_dir = args.run_dir.expanduser().resolve() if args.run_dir else new_run_dir(run_root)
+    (run_dir / "logs").mkdir(parents=True, exist_ok=True)
+    (run_dir / "results").mkdir(parents=True, exist_ok=True)
     manifest_path = run_dir / "manifest.json"
     if manifest_path.exists():
-        manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+        manifest = read_json(manifest_path)
+        validate_run_manifest(manifest, manifest_path)
+        workload_options = ("profile", "start", "end", "scale", "seed", "log_interval", "load_workers", "query_workers", "batch_size", "queries", "query_type")
+        if any(getattr(args, name, None) is not None for name in workload_options):
+            requested = build_workload(args, manifest["workload"])
+            if requested != manifest["workload"]:
+                raise BenchmarkError("run workload is immutable; create a new run for different settings")
     else:
         profile = args.profile or "manual"
         manifest = {
-            "run_id": run_dir.name,
-            "created_at": utc_now(),
-            "profile": profile,
-            "database": getattr(args, "database", DEFAULT_DATABASE),
-            "workload": json.loads(json.dumps(PROFILES[profile])),
-            "events": {"loads": [], "queries": []},
+            "schema_version": SCHEMA_VERSION, "kind": "greptimedb-run", "run_id": run_dir.name,
+            "created_at": utc_now(), "profile": profile, "database": getattr(args, "database", DEFAULT_DATABASE),
+            "workload": build_workload(args), "events": {"loads": [], "queries": []},
         }
+    if hasattr(args, "database") and manifest.get("database") != args.database and manifest_path.exists():
+        raise BenchmarkError("--database conflicts with the database pinned by this run")
+    save_manifest(run_dir, manifest)
+    return run_dir, manifest
 
-    workload = manifest["workload"]
+
+def build_workload(args: argparse.Namespace, base: dict[str, Any] | None = None) -> dict[str, Any]:
+    if base is not None and not args.profile:
+        workload = json.loads(json.dumps(base))
+    else:
+        workload = json.loads(json.dumps(PROFILES[args.profile or "manual"]))
     for attr in ("start", "end", "scale", "seed", "log_interval", "load_workers", "query_workers", "batch_size"):
         value = getattr(args, attr, None)
         if value is not None:
             workload[attr] = value
-    if getattr(args, "queries", None) is not None:
-        selected = args.query_type or QUERY_TYPES
-        for query_type in selected:
-            workload["query_counts"][query_type] = args.queries
-    if hasattr(args, "database"):
-        manifest["database"] = args.database
-    save_manifest(run_dir, manifest)
-    return run_dir, manifest
+    selected = sorted(set(args.query_type or workload["query_counts"]))
+    count_override = getattr(args, "queries", None)
+    workload["query_counts"] = {query_type: count_override if count_override is not None else workload["query_counts"][query_type] for query_type in selected}
+    return workload
 
 
 def relative(run_dir: Path, path: Path) -> str:
@@ -166,53 +201,27 @@ def display_command(command: Sequence[str]) -> str:
     return " ".join(subprocess.list2cmdline([part]) for part in command)
 
 
-def run_tee(
-    command: Sequence[str],
-    log_path: Path,
-    *,
-    stdout_path: Path | None = None,
-    append: bool = False,
-) -> None:
+def run_tee(command: Sequence[str], log_path: Path, *, stdout_path: Path | None = None, append: bool = False) -> None:
     mode = "a" if append else "w"
     log_path.parent.mkdir(parents=True, exist_ok=True)
     with log_path.open(mode, encoding="utf-8") as log:
         header = f"$ {display_command(command)}\n"
-        log.write(header)
-        log.flush()
-        print(header, end="")
+        log.write(header); log.flush(); print(header, end="")
         if stdout_path is None:
-            process = subprocess.Popen(
-                command,
-                cwd=REPO_ROOT,
-                stdout=subprocess.PIPE,
-                stderr=subprocess.STDOUT,
-                text=True,
-                bufsize=1,
-            )
+            process = subprocess.Popen(command, cwd=REPO_ROOT, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True, bufsize=1)
             assert process.stdout is not None
             for line in process.stdout:
-                sys.stdout.write(line)
-                log.write(line)
-            process.stdout.close()
-            return_code = process.wait()
+                sys.stdout.write(line); log.write(line)
+            process.stdout.close(); return_code = process.wait()
         else:
             stdout_path.parent.mkdir(parents=True, exist_ok=True)
             temporary_output = stdout_path.with_name(stdout_path.name + ".tmp")
             with temporary_output.open("wb") as output:
-                process = subprocess.Popen(
-                    command,
-                    cwd=REPO_ROOT,
-                    stdout=output,
-                    stderr=subprocess.PIPE,
-                    text=True,
-                    bufsize=1,
-                )
+                process = subprocess.Popen(command, cwd=REPO_ROOT, stdout=output, stderr=subprocess.PIPE, text=True, bufsize=1)
                 assert process.stderr is not None
                 for line in process.stderr:
-                    sys.stdout.write(line)
-                    log.write(line)
-                process.stderr.close()
-                return_code = process.wait()
+                    sys.stdout.write(line); log.write(line)
+                process.stderr.close(); return_code = process.wait()
         if return_code:
             if stdout_path is not None:
                 temporary_output.unlink(missing_ok=True)
@@ -228,43 +237,16 @@ def binary_needs_build(run_dir: Path, name: str, target: Path, rebuild: bool) ->
 
 def ensure_binaries(run_dir: Path, stages: Sequence[str], rebuild: bool) -> None:
     for stage in stages:
-        name = BINARIES[stage]
-        target = REPO_ROOT / "bin" / name
+        name = BINARIES[stage]; target = REPO_ROOT / "bin" / name
         marker = run_dir / "results" / f"built-{name}"
         if not binary_needs_build(run_dir, name, target, rebuild):
             continue
         target.parent.mkdir(parents=True, exist_ok=True)
-        run_tee(
-            ["go", "build", "-o", str(target), f"./cmd/{name}"],
-            run_dir / "logs" / "build.log",
-            append=True,
-        )
-        marker.parent.mkdir(parents=True, exist_ok=True)
-        marker.write_text(utc_now() + "\n", encoding="utf-8")
-        BUILT_THIS_PROCESS.add(name)
+        run_tee(["go", "build", "-o", str(target), f"./cmd/{name}"], run_dir / "logs" / "build.log", append=True)
+        marker.write_text(utc_now() + "\n", encoding="utf-8"); BUILT_THIS_PROCESS.add(name)
 
 
-def query_path(run_dir: Path, query_type: str) -> Path:
-    return run_dir / "queries" / f"greptime-queries-{query_type}.dat"
-
-
-def query_generation_spec(workload: dict[str, Any], query_type: str) -> dict[str, Any]:
-    return {
-        "use_case": "devops",
-        "seed": workload["seed"],
-        "scale": workload["scale"],
-        "timestamp_start": workload["start"],
-        "timestamp_end": add_one_second(workload["end"]),
-        "queries": workload["query_counts"][query_type],
-        "query_type": query_type,
-        "format": "greptime",
-    }
-
-
-def dataset_selection_args(
-    args: argparse.Namespace,
-    manifest: dict[str, Any],
-) -> list[str]:
+def dataset_selection_args(args: argparse.Namespace, manifest: dict[str, Any]) -> list[str]:
     pinned = manifest.get("dataset")
     if pinned:
         pinned_path = Path(pinned["dataset_path"]).resolve()
@@ -283,141 +265,187 @@ def dataset_selection_args(
     return result
 
 
-def validate_dataset_result(
-    manifest: dict[str, Any],
-    dataset: dict[str, Any],
-    regenerate: bool,
-) -> None:
-    if dataset["spec"]["use_case"] != "cpu-only":
+def prepare_dataset(args: argparse.Namespace, run_dir: Path, manifest: dict[str, Any], *, materialize: bool) -> dict[str, Any]:
+    workload = manifest["workload"]
+    result_path = run_dir / "results" / ("dataset.json" if materialize else "logical-dataset.json")
+    command = [sys.executable, str(DATASET_RUNNER), "generate" if materialize else "prepare"]
+    if materialize:
+        command.extend(["--format", "influx"])
+    command.extend(["--use-case", "cpu-only", "--result-file", str(result_path), *dataset_selection_args(args, manifest)])
+    if not manifest.get("dataset"):
+        command.extend(["--seed", str(workload["seed"]), "--scale", str(workload["scale"]), "--start", workload["start"], "--end", workload["end"], "--log-interval", workload["log_interval"]])
+    if materialize and args.regenerate:
+        command.append("--regenerate")
+    if materialize and args.rebuild:
+        command.append("--rebuild")
+    run_tee(command, run_dir / "logs" / ("generate-data.log" if materialize else "prepare-dataset.log"))
+    dataset = read_json(result_path)
+    if dataset["spec"].get("use_case") != "cpu-only":
         raise BenchmarkError("GreptimeDB benchmark requires a cpu-only dataset")
     pinned = manifest.get("dataset")
-    if pinned and pinned.get("sha256") != dataset.get("sha256") and not regenerate:
-        raise BenchmarkError(
-            "the pinned dataset checksum changed; use --regenerate only if replacement was intentional"
-        )
-
-
-def generate_data(
-    args: argparse.Namespace,
-    run_dir: Path,
-    manifest: dict[str, Any],
-) -> Path:
-    legacy = run_dir / "data" / "influx-data.lp"
-    if legacy.exists() and not manifest.get("dataset") and not (
-        args.dataset_root
-        or args.dataset_id
-        or args.dataset_path
-        or args.regenerate
-        or any(getattr(args, option) is not None for option in DATA_WORKLOAD_OPTIONS)
-    ):
-        print(f"Reusing legacy generated data: {legacy}")
-        manifest["generated_data"] = relative(run_dir, legacy)
-        save_manifest(run_dir, manifest)
-        return legacy
-
-    workload = manifest["workload"]
-    selecting_unpinned = not manifest.get("dataset") and bool(args.dataset_id or args.dataset_path)
-    result_path = run_dir / "results" / "dataset.json"
-    command = [
-        sys.executable,
-        str(DATASET_RUNNER),
-        "generate",
-        "--format",
-        "influx",
-        "--use-case",
-        "cpu-only",
-        "--result-file",
-        str(result_path),
-        *dataset_selection_args(args, manifest),
-    ]
-    if selecting_unpinned:
-        if args.profile:
-            command.extend(["--profile", args.profile])
-        for option, value in (
-            ("--seed", args.seed),
-            ("--scale", args.scale),
-            ("--start", args.start),
-            ("--end", args.end),
-            ("--log-interval", args.log_interval),
-        ):
-            if value is not None:
-                command.extend([option, str(value)])
-    else:
-        command.extend(
-            [
-                "--seed",
-                str(workload["seed"]),
-                "--scale",
-                str(workload["scale"]),
-                "--start",
-                workload["start"],
-                "--end",
-                workload["end"],
-                "--log-interval",
-                workload["log_interval"],
-            ]
-        )
-    if args.regenerate:
-        command.append("--regenerate")
-    if args.rebuild:
-        command.append("--rebuild")
-    run_tee(command, run_dir / "logs" / "generate-data.log")
-    dataset = json.loads(result_path.read_text(encoding="utf-8"))
-    validate_dataset_result(manifest, dataset, args.regenerate)
-    for name in ("start", "end", "scale", "seed", "log_interval"):
+    if pinned and pinned.get("dataset_id") != dataset.get("dataset_id"):
+        raise BenchmarkError("prepared dataset differs from the dataset pinned by this run")
+    for name in DATA_WORKLOAD_OPTIONS:
         workload[name] = dataset["spec"][name]
     manifest["dataset"] = dataset
-    manifest["generated_data"] = dataset["data_path"]
     save_manifest(run_dir, manifest)
+    return dataset
+
+
+def generate_data(args: argparse.Namespace, run_dir: Path, manifest: dict[str, Any]) -> Path:
+    dataset = prepare_dataset(args, run_dir, manifest, materialize=True)
     return Path(dataset["data_path"])
 
 
-def generate_queries(
-    run_dir: Path,
-    manifest: dict[str, Any],
-    query_types: Sequence[str],
-    regenerate: bool,
-    rebuild: bool,
-) -> None:
-    ensure_binaries(run_dir, ["queries"], rebuild)
-    workload = manifest["workload"]
-    generation_specs = manifest.setdefault("query_generation_specs", {})
-    for query_type in query_types:
-        output = query_path(run_dir, query_type)
-        spec = query_generation_spec(workload, query_type)
-        if output.exists() and generation_specs.get(query_type) == spec and not regenerate:
-            print(f"Reusing generated queries: {output}")
-            continue
-        command = [
-            str(REPO_ROOT / "bin" / BINARIES["queries"]),
-            f"--use-case={spec['use_case']}",
-            f"--seed={spec['seed']}",
-            f"--scale={spec['scale']}",
-            f"--timestamp-start={spec['timestamp_start']}",
-            f"--timestamp-end={spec['timestamp_end']}",
-            f"--queries={spec['queries']}",
-            f"--query-type={spec['query_type']}",
-            f"--format={spec['format']}",
-        ]
-        run_tee(command, run_dir / "logs" / f"generate-query-{query_type}.log", stdout_path=output)
-        generation_specs[query_type] = spec
-        save_manifest(run_dir, manifest)
-    manifest["generated_query_types"] = sorted(
-        query_type for query_type in QUERY_TYPES if query_path(run_dir, query_type).exists()
-    )
-    save_manifest(run_dir, manifest)
+def query_set_spec(dataset: dict[str, Any], workload: dict[str, Any]) -> dict[str, Any]:
+    counts = {name: int(count) for name, count in sorted(workload["query_counts"].items())}
+    return {
+        "dataset": {"dataset_id": dataset["dataset_id"], "spec": dataset["spec"]},
+        "format": "greptime", "use_case": "devops", "seed": workload["seed"],
+        "scale": workload["scale"], "timestamp_start": workload["start"],
+        "timestamp_end": add_one_second(workload["end"]), "query_counts": counts,
+    }
+
+
+def query_set_id(spec: dict[str, Any]) -> str:
+    digest = hashlib.sha256(canonical_json({"schema_version": SCHEMA_VERSION, "spec": spec}).encode()).hexdigest()
+    return f"greptime-{digest[:16]}"
+
+
+def query_set_path(query_root: Path, dataset_id: str, set_id: str) -> Path:
+    return query_root / dataset_id / "greptime" / set_id
+
+
+def query_file_path(query_dir: Path, query_type: str) -> Path:
+    return query_dir / "queries" / f"{query_type}.dat"
+
+
+def validate_query_set(query_dir: Path, expected_spec: dict[str, Any]) -> dict[str, Any]:
+    manifest_path = query_dir / "manifest.json"; manifest = read_json(manifest_path)
+    required = {"schema_version", "kind", "query_set_id", "created_at", "spec", "generator", "files"}
+    if manifest.get("schema_version") != SCHEMA_VERSION or manifest.get("kind") != "greptimedb-query-set" or not required.issubset(manifest):
+        raise BenchmarkError(f"malformed query-set manifest: {manifest_path}")
+    if not isinstance(manifest["spec"], dict) or manifest["spec"] != expected_spec or manifest["query_set_id"] != query_set_id(expected_spec):
+        raise BenchmarkError(f"query-set specification mismatch: {query_dir}")
+    expected_types = set(expected_spec["query_counts"]); files = manifest["files"]
+    if not isinstance(files, dict) or set(files) != expected_types:
+        raise BenchmarkError(f"query-set membership mismatch: {query_dir}")
+    actual_names = {path.stem for path in (query_dir / "queries").glob("*.dat")}
+    if actual_names != expected_types:
+        raise BenchmarkError(f"query-set artifacts do not match membership: {query_dir}")
+    for query_type, metadata in files.items():
+        if not isinstance(metadata, dict) or metadata.get("path") != f"queries/{query_type}.dat" or not isinstance(metadata.get("bytes"), int) or not isinstance(metadata.get("sha256"), str):
+            raise BenchmarkError(f"malformed query artifact metadata: {query_dir}")
+        path = query_file_path(query_dir, query_type)
+        if not path.is_file() or path.stat().st_size != metadata.get("bytes") or sha256_file(path) != metadata.get("sha256"):
+            raise BenchmarkError(f"query artifact checksum mismatch: {path}")
+    return manifest
+
+
+def git_revision() -> str | None:
+    try:
+        return subprocess.run(["git", "rev-parse", "HEAD"], cwd=REPO_ROOT, check=True, capture_output=True, text=True).stdout.strip()
+    except (OSError, subprocess.CalledProcessError):
+        return None
+
+
+def generate_queries(args: argparse.Namespace, run_dir: Path, manifest: dict[str, Any]) -> Path:
+    dataset = manifest.get("dataset") or prepare_dataset(args, run_dir, manifest, materialize=False)
+    spec = query_set_spec(dataset, manifest["workload"]); set_id = query_set_id(spec)
+    root = (args.query_root or DEFAULT_QUERY_ROOT).expanduser().resolve()
+    destination = query_set_path(root, dataset["dataset_id"], set_id)
+    if destination.exists():
+        set_manifest = validate_query_set(destination, spec); reused = True
+    else:
+        ensure_binaries(run_dir, ["queries"], args.rebuild)
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        temporary = Path(tempfile.mkdtemp(prefix=f".{set_id}-", dir=destination.parent))
+        try:
+            files: dict[str, dict[str, Any]] = {}
+            for query_type, count in spec["query_counts"].items():
+                output = query_file_path(temporary, query_type)
+                command = [str(REPO_ROOT / "bin" / BINARIES["queries"]), f"--use-case={spec['use_case']}", f"--seed={spec['seed']}", f"--scale={spec['scale']}", f"--timestamp-start={spec['timestamp_start']}", f"--timestamp-end={spec['timestamp_end']}", f"--queries={count}", f"--query-type={query_type}", f"--format={spec['format']}"]
+                run_tee(command, run_dir / "logs" / f"generate-query-{query_type}.log", stdout_path=output)
+                files[query_type] = {"path": f"queries/{query_type}.dat", "bytes": output.stat().st_size, "sha256": sha256_file(output)}
+            binary = REPO_ROOT / "bin" / BINARIES["queries"]
+            set_manifest = {"schema_version": SCHEMA_VERSION, "kind": "greptimedb-query-set", "query_set_id": set_id, "created_at": utc_now(), "spec": spec, "generator": {"binary": "bin/tsbs_generate_queries", "binary_sha256": sha256_file(binary), "git_revision": git_revision()}, "files": files}
+            save_json(temporary / "manifest.json", set_manifest)
+            try:
+                os.replace(temporary, destination)
+            except OSError:
+                if not destination.exists():
+                    raise
+                validate_query_set(destination, spec)
+            reused = False
+        finally:
+            if temporary.exists():
+                shutil.rmtree(temporary)
+    set_manifest = validate_query_set(destination, spec)
+    manifest_checksum = sha256_file(destination / "manifest.json")
+    pinned = {"query_set_id": set_id, "query_set_path": str(destination), "manifest_sha256": manifest_checksum, "spec": spec, "reused": reused}
+    existing = manifest.get("query_set")
+    if existing and {k: existing.get(k) for k in ("query_set_id", "manifest_sha256", "spec")} != {k: pinned[k] for k in ("query_set_id", "manifest_sha256", "spec")}:
+        raise BenchmarkError("query set conflicts with the query set pinned by this run")
+    manifest["query_set"] = pinned; save_manifest(run_dir, manifest)
+    return destination
 
 
 def database_mode_args(mode: str, database: str, confirmation: str | None) -> list[str]:
-    if mode == "create":
-        return ["--do-create-db=true", "--do-abort-on-exist=true"]
-    if mode == "reuse":
-        return ["--do-create-db=false"]
+    if mode == "create": return ["--do-create-db=true", "--do-abort-on-exist=true"]
+    if mode == "reuse": return ["--do-create-db=false"]
     if mode == "reset":
-        if confirmation != database:
-            raise BenchmarkError("reset requires --confirm-reset to exactly match --database")
+        if confirmation != database: raise BenchmarkError("reset requires --confirm-reset to exactly match --database")
         return ["--do-create-db=true"]
     raise BenchmarkError(f"unknown database mode: {mode}")
+
+
+def database_workspace(args: argparse.Namespace) -> Path:
+    root = (args.database_root or DEFAULT_DATABASE_ROOT).expanduser().resolve()
+    return root / args.database_id
+
+
+def validate_database_manifest(path: Path, expected_id: str | None = None) -> dict[str, Any]:
+    manifest = read_json(path / "manifest.json")
+    required = {"schema_version", "kind", "database_id", "created_at", "database", "binding"}
+    if manifest.get("schema_version") != SCHEMA_VERSION or manifest.get("kind") != "greptimedb-database" or not required.issubset(manifest):
+        raise BenchmarkError(f"malformed database manifest: {path / 'manifest.json'}")
+    if expected_id is not None and manifest["database_id"] != expected_id:
+        raise BenchmarkError(f"database workspace identity mismatch: {path}")
+    if not isinstance(manifest["database_id"], str) or not isinstance(manifest["database"], str):
+        raise BenchmarkError(f"malformed database manifest: {path / 'manifest.json'}")
+    binding = manifest["binding"]
+    binding_fields = {"dataset_id", "spec", "format", "bytes", "sha256"}
+    if binding is not None and (not isinstance(binding, dict) or set(binding) != binding_fields or not isinstance(binding.get("spec"), dict)):
+        raise BenchmarkError(f"malformed database binding: {path / 'manifest.json'}")
+    return manifest
+
+
+def prepare_database_workspace(args: argparse.Namespace) -> tuple[Path, dict[str, Any]]:
+    path = database_workspace(args); manifest_path = path / "manifest.json"
+    if manifest_path.exists():
+        manifest = validate_database_manifest(path, args.database_id)
+        if manifest["database"] != args.database:
+            raise BenchmarkError("managed workspace is bound to a different SQL database")
+    else:
+        (path / "data").mkdir(parents=True, exist_ok=True); (path / "logs").mkdir(parents=True, exist_ok=True)
+        manifest = {"schema_version": SCHEMA_VERSION, "kind": "greptimedb-database", "database_id": args.database_id, "created_at": utc_now(), "updated_at": utc_now(), "database": args.database, "binding": None}
+        save_json(manifest_path, manifest)
+    return path, manifest
+
+
+@contextlib.contextmanager
+def lock_database(path: Path) -> Iterator[None]:
+    descriptor = os.open(path, os.O_RDONLY)
+    try:
+        try: fcntl.flock(descriptor, fcntl.LOCK_EX | fcntl.LOCK_NB)
+        except BlockingIOError as exc: raise BenchmarkError(f"managed database workspace is locked: {path}") from exc
+        yield
+    finally:
+        fcntl.flock(descriptor, fcntl.LOCK_UN); os.close(descriptor)
+
+
+def dataset_binding(dataset: dict[str, Any]) -> dict[str, Any]:
+    return {"dataset_id": dataset["dataset_id"], "spec": dataset["spec"], "format": dataset["format"], "bytes": dataset["bytes"], "sha256": dataset["sha256"]}
 
 
 def next_attempt(events: Sequence[dict[str, Any]], query_type: str | None = None) -> int:
@@ -425,324 +453,160 @@ def next_attempt(events: Sequence[dict[str, Any]], query_type: str | None = None
     return max((int(event["attempt"]) for event in matching), default=0) + 1
 
 
-def load_data(
-    args: argparse.Namespace,
-    run_dir: Path,
-    manifest: dict[str, Any],
-    endpoint: str,
-    managed: bool,
-) -> None:
-    input_path = generate_data(args, run_dir, manifest)
-    ensure_binaries(run_dir, ["load"], args.rebuild)
+def load_data(args: argparse.Namespace, run_dir: Path, manifest: dict[str, Any], endpoint: str, managed: bool, database_manifest: dict[str, Any] | None = None, database_path: Path | None = None) -> None:
+    input_path = generate_data(args, run_dir, manifest); dataset = manifest["dataset"]
     mode = args.database_mode or ("create" if managed else None)
-    if mode is None:
-        raise BenchmarkError("external loads require --database-mode=create|reuse|reset")
-    attempt = next_attempt(manifest["events"]["loads"])
-    log_path = run_dir / "logs" / f"load-run-{attempt:03d}.log"
-    result_path = run_dir / "results" / f"load-run-{attempt:03d}.json"
-    event = {
-        "attempt": attempt,
-        "database": args.database,
-        "database_mode": mode,
-        "log": relative(run_dir, log_path),
-        "status": "running",
-        "started_at": utc_now(),
-    }
-    manifest["events"]["loads"].append(event)
-    save_manifest(run_dir, manifest)
+    if mode is None: raise BenchmarkError("external loads require --database-mode=create|reuse|reset")
+    binding = dataset_binding(dataset)
+    if managed and database_manifest is not None:
+        current = database_manifest["binding"]
+        if current == binding and mode != "reset":
+            manifest["events"]["loads"].append({"attempt": next_attempt(manifest["events"]["loads"]), "database": args.database, "database_mode": "reuse", "status": "reused", "dataset_id": dataset["dataset_id"], "started_at": utc_now(), "finished_at": utc_now()}); save_manifest(run_dir, manifest); return
+        if current is not None and current != binding and mode != "reset":
+            raise BenchmarkError("managed database contains a different dataset; use a confirmed reset to rebind it")
+    ensure_binaries(run_dir, ["load"], args.rebuild)
+    attempt = next_attempt(manifest["events"]["loads"]); log_path = run_dir / "logs" / f"load-run-{attempt:03d}.log"; result_path = run_dir / "results" / f"load-run-{attempt:03d}.json"
+    event = {"attempt": attempt, "database": args.database, "database_mode": mode, "dataset_id": dataset["dataset_id"], "log": relative(run_dir, log_path), "status": "running", "started_at": utc_now()}
+    manifest["events"]["loads"].append(event); save_manifest(run_dir, manifest)
     workload = manifest["workload"]
-    command = [
-        str(REPO_ROOT / "bin" / BINARIES["load"]),
-        f"--urls={endpoint}",
-        f"--file={input_path}",
-        f"--db-name={args.database}",
-        f"--batch-size={workload['batch_size']}",
-        "--gzip=false",
-        f"--workers={workload['load_workers']}",
-        "--reporting-period=10s",
-        f"--results-file={result_path}",
-        *database_mode_args(mode, args.database, args.confirm_reset),
-    ]
-    try:
-        run_tee(command, log_path)
+    command = [str(REPO_ROOT / "bin" / BINARIES["load"]), f"--urls={endpoint}", f"--file={input_path}", f"--db-name={args.database}", f"--batch-size={workload['batch_size']}", "--gzip=false", f"--workers={workload['load_workers']}", "--reporting-period=10s", f"--results-file={result_path}", *database_mode_args(mode, args.database, args.confirm_reset)]
+    try: run_tee(command, log_path)
     except Exception:
-        event["status"] = "failed"
-        event["finished_at"] = utc_now()
-        save_manifest(run_dir, manifest)
-        raise
-    event["status"] = "completed"
-    event["finished_at"] = utc_now()
-    event["results"] = relative(run_dir, result_path)
-    save_manifest(run_dir, manifest)
+        event.update(status="failed", finished_at=utc_now()); save_manifest(run_dir, manifest); raise
+    event.update(status="completed", finished_at=utc_now(), results=relative(run_dir, result_path)); save_manifest(run_dir, manifest)
+    if managed and database_manifest is not None and database_path is not None:
+        database_manifest["binding"] = binding; database_manifest["updated_at"] = utc_now(); save_json(database_path / "manifest.json", database_manifest)
 
 
-def run_queries(
-    args: argparse.Namespace,
-    run_dir: Path,
-    manifest: dict[str, Any],
-    endpoint: str,
-) -> None:
-    query_types = args.query_type or list(QUERY_TYPES)
-    generate_queries(run_dir, manifest, query_types, args.regenerate, args.rebuild)
-    ensure_binaries(run_dir, ["query"], args.rebuild)
-    workload = manifest["workload"]
-    for query_type in query_types:
-        for _ in range(args.repeat):
-            attempt = next_attempt(manifest["events"]["queries"], query_type)
-            log_path = run_dir / "logs" / f"query-{query_type}-run-{attempt:03d}.log"
-            result_path = run_dir / "results" / f"query-{query_type}-run-{attempt:03d}.json"
-            event = {
-                "query_type": query_type,
-                "attempt": attempt,
-                "database": args.database,
-                "log": relative(run_dir, log_path),
-                "status": "running",
-                "started_at": utc_now(),
-            }
-            manifest["events"]["queries"].append(event)
-            save_manifest(run_dir, manifest)
-            command = [
-                str(REPO_ROOT / "bin" / BINARIES["query"]),
-                f"--file={query_path(run_dir, query_type)}",
-                f"--db-name={args.database}",
-                f"--urls={endpoint}",
-                f"--workers={workload['query_workers']}",
-                "--print-interval=0",
-                f"--results-file={result_path}",
-            ]
-            try:
-                run_tee(command, log_path)
-            except Exception:
-                event["status"] = "failed"
-                event["finished_at"] = utc_now()
-                save_manifest(run_dir, manifest)
-                raise
-            event["status"] = "completed"
-            event["finished_at"] = utc_now()
-            event["results"] = relative(run_dir, result_path)
-            save_manifest(run_dir, manifest)
+def run_queries(args: argparse.Namespace, run_dir: Path, manifest: dict[str, Any], endpoint: str, database_manifest: dict[str, Any] | None = None) -> None:
+    query_dir = generate_queries(args, run_dir, manifest); set_manifest = validate_query_set(query_dir, manifest["query_set"]["spec"])
+    if database_manifest is not None:
+        binding = database_manifest.get("binding")
+        if binding is None or binding["dataset_id"] != manifest["dataset"]["dataset_id"] or binding["spec"] != manifest["dataset"]["spec"]:
+            raise BenchmarkError("managed database is not loaded with the query set's dataset")
+    ensure_binaries(run_dir, ["query"], args.rebuild); workload = manifest["workload"]
+    for query_type in set_manifest["spec"]["query_counts"]:
+        attempt = next_attempt(manifest["events"]["queries"], query_type); log_path = run_dir / "logs" / f"query-{query_type}-run-{attempt:03d}.log"; result_path = run_dir / "results" / f"query-{query_type}-run-{attempt:03d}.json"
+        metadata = set_manifest["files"][query_type]
+        event = {"query_type": query_type, "attempt": attempt, "database": args.database, "query_set_id": set_manifest["query_set_id"], "file": metadata["path"], "file_bytes": metadata["bytes"], "file_sha256": metadata["sha256"], "log": relative(run_dir, log_path), "status": "running", "started_at": utc_now()}
+        manifest["events"]["queries"].append(event); save_manifest(run_dir, manifest)
+        command = [str(REPO_ROOT / "bin" / BINARIES["query"]), f"--file={query_file_path(query_dir, query_type)}", f"--db-name={args.database}", f"--urls={endpoint}", f"--workers={workload['query_workers']}", "--print-interval=0", f"--results-file={result_path}"]
+        try: run_tee(command, log_path)
+        except Exception:
+            event.update(status="failed", finished_at=utc_now()); save_manifest(run_dir, manifest); raise
+        event.update(status="completed", finished_at=utc_now(), results=relative(run_dir, result_path)); save_manifest(run_dir, manifest)
 
 
 def endpoint_ready(endpoint: str) -> bool:
-    data = urllib.parse.urlencode({"sql": "SHOW DATABASES"}).encode()
-    request = urllib.request.Request(
-        endpoint.rstrip("/") + "/v1/sql",
-        data=data,
-        headers={"Content-Type": "application/x-www-form-urlencoded"},
-    )
+    data = urllib.parse.urlencode({"sql": "SHOW DATABASES"}).encode(); request = urllib.request.Request(endpoint.rstrip("/") + "/v1/sql", data=data, headers={"Content-Type": "application/x-www-form-urlencoded"})
     try:
-        with urllib.request.urlopen(request, timeout=2) as response:
-            return response.status == 200
-    except (OSError, urllib.error.URLError):
-        return False
+        with urllib.request.urlopen(request, timeout=2) as response: return response.status == 200
+    except (OSError, urllib.error.URLError): return False
 
 
 def check_port_available(port: int) -> None:
     with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
-        try:
-            sock.bind(("127.0.0.1", port))
-        except OSError as exc:
-            raise BenchmarkError(f"managed GreptimeDB HTTP port {port} is unavailable") from exc
+        try: sock.bind(("127.0.0.1", port))
+        except OSError as exc: raise BenchmarkError(f"managed GreptimeDB HTTP port {port} is unavailable") from exc
 
 
 @contextlib.contextmanager
-def connection(args: argparse.Namespace, run_dir: Path) -> Iterator[tuple[str, bool]]:
-    if bool(args.greptime_bin) == bool(args.endpoint):
-        raise BenchmarkError("provide exactly one of --greptime-bin or --endpoint")
+def connection(args: argparse.Namespace, run_dir: Path) -> Iterator[tuple[str, bool, dict[str, Any] | None, Path | None]]:
+    if bool(args.greptime_bin) == bool(args.endpoint): raise BenchmarkError("provide exactly one of --greptime-bin or --endpoint")
     if args.endpoint:
-        yield args.endpoint.rstrip("/"), False
-        return
-
-    binary = args.greptime_bin.resolve()
-    if not binary.is_file() or not os.access(binary, os.X_OK):
-        raise BenchmarkError(f"GreptimeDB binary is not executable: {binary}")
-    check_port_available(args.http_port)
-    endpoint = f"http://127.0.0.1:{args.http_port}"
-    process_log_path = run_dir / "logs" / "greptimedb-process.log"
-    process_log = process_log_path.open("a", encoding="utf-8")
-    command = [
-        str(binary),
-        "standalone",
-        "start",
-        "--http-addr",
-        f"127.0.0.1:{args.http_port}",
-        "--influxdb-enable",
-        "--data-home",
-        str(run_dir / "greptimedb" / "data"),
-        "--log-dir",
-        str(run_dir / "greptimedb" / "logs"),
-    ]
-    process_log.write(f"$ {display_command(command)}\n")
-    process_log.flush()
-    process = subprocess.Popen(
-        command,
-        cwd=run_dir,
-        stdout=process_log,
-        stderr=subprocess.STDOUT,
-        start_new_session=True,
-    )
-    try:
-        deadline = time.monotonic() + args.startup_timeout
-        while time.monotonic() < deadline:
-            if process.poll() is not None:
-                raise BenchmarkError(f"GreptimeDB exited during startup; see {process_log_path}")
-            if endpoint_ready(endpoint):
-                break
-            time.sleep(0.5)
-        else:
-            raise BenchmarkError(f"GreptimeDB was not ready within {args.startup_timeout}s; see {process_log_path}")
-        yield endpoint, True
-    finally:
-        if process.poll() is None:
-            os.killpg(process.pid, signal.SIGTERM)
-            try:
-                process.wait(timeout=15)
-            except subprocess.TimeoutExpired:
-                os.killpg(process.pid, signal.SIGKILL)
-                process.wait(timeout=5)
-        process_log.close()
+        yield args.endpoint.rstrip("/"), False, None, None; return
+    workspace, database_manifest = prepare_database_workspace(args)
+    with lock_database(workspace):
+        binary = args.greptime_bin.resolve()
+        if not binary.is_file() or not os.access(binary, os.X_OK): raise BenchmarkError(f"GreptimeDB binary is not executable: {binary}")
+        check_port_available(args.http_port); endpoint = f"http://127.0.0.1:{args.http_port}"; process_log_path = run_dir / "logs" / "greptimedb-process.log"; process_log = process_log_path.open("a", encoding="utf-8")
+        command = [str(binary), "standalone", "start", "--http-addr", f"127.0.0.1:{args.http_port}", "--influxdb-enable", "--data-home", str(workspace / "data"), "--log-dir", str(workspace / "logs")]
+        process_log.write(f"$ {display_command(command)}\n"); process_log.flush(); process = subprocess.Popen(command, cwd=workspace, stdout=process_log, stderr=subprocess.STDOUT, start_new_session=True)
+        try:
+            deadline = time.monotonic() + args.startup_timeout
+            while time.monotonic() < deadline:
+                if process.poll() is not None: raise BenchmarkError(f"GreptimeDB exited during startup; see {process_log_path}")
+                if endpoint_ready(endpoint): break
+                time.sleep(0.5)
+            else: raise BenchmarkError(f"GreptimeDB was not ready within {args.startup_timeout}s; see {process_log_path}")
+            yield endpoint, True, database_manifest, workspace
+        finally:
+            if process.poll() is None:
+                os.killpg(process.pid, signal.SIGTERM)
+                try: process.wait(timeout=15)
+                except subprocess.TimeoutExpired: os.killpg(process.pid, signal.SIGKILL); process.wait(timeout=5)
+            process_log.close()
 
 
 def add_run_options(parser: argparse.ArgumentParser) -> None:
-    parser.add_argument("--run-dir", type=Path)
-    parser.add_argument("--profile", choices=sorted(PROFILES))
-    parser.add_argument("--start")
-    parser.add_argument("--end")
-    parser.add_argument("--scale", type=int)
-    parser.add_argument("--seed", type=int)
-    parser.add_argument("--log-interval")
-    parser.add_argument("--load-workers", type=int)
-    parser.add_argument("--query-workers", type=int)
-    parser.add_argument("--batch-size", type=int)
-    parser.add_argument("--queries", type=int, help="override the generated count for selected query types")
-    parser.add_argument("--query-type", action="append", choices=QUERY_TYPES)
-    parser.add_argument("--regenerate", action="store_true")
-    parser.add_argument("--rebuild", action="store_true")
-    parser.add_argument("--dataset-root", type=Path)
-    dataset = parser.add_mutually_exclusive_group()
-    dataset.add_argument("--dataset-id")
-    dataset.add_argument("--dataset-path", type=Path)
+    parser.add_argument("--run-dir", type=Path); parser.add_argument("--run-root", type=Path)
+    parser.add_argument("--profile", choices=sorted(PROFILES)); parser.add_argument("--start"); parser.add_argument("--end"); parser.add_argument("--scale", type=int); parser.add_argument("--seed", type=int); parser.add_argument("--log-interval")
+    parser.add_argument("--load-workers", type=int); parser.add_argument("--query-workers", type=int); parser.add_argument("--batch-size", type=int); parser.add_argument("--queries", type=int, help="count for every selected query type")
+    parser.add_argument("--query-type", action="append", choices=QUERY_TYPES); parser.add_argument("--query-root", type=Path); parser.add_argument("--regenerate", action="store_true"); parser.add_argument("--rebuild", action="store_true"); parser.add_argument("--dataset-root", type=Path)
+    dataset = parser.add_mutually_exclusive_group(); dataset.add_argument("--dataset-id"); dataset.add_argument("--dataset-path", type=Path)
 
 
 def add_connection_options(parser: argparse.ArgumentParser) -> None:
-    parser.add_argument("--greptime-bin", type=Path)
-    parser.add_argument("--endpoint")
-    parser.add_argument("--http-port", type=int, default=4000)
-    parser.add_argument("--startup-timeout", type=int, default=60)
-    parser.add_argument(
-        "--database",
-        help=f"database name (inherits an existing run; defaults to {DEFAULT_DATABASE} for a new run)",
-    )
+    parser.add_argument("--greptime-bin", type=Path); parser.add_argument("--endpoint"); parser.add_argument("--http-port", type=int, default=4000); parser.add_argument("--startup-timeout", type=int, default=60); parser.add_argument("--database", help=f"SQL database name (default: {DEFAULT_DATABASE})"); parser.add_argument("--database-id"); parser.add_argument("--database-root", type=Path)
 
 
 def add_load_options(parser: argparse.ArgumentParser) -> None:
-    parser.add_argument("--database-mode", choices=("create", "reuse", "reset"))
-    parser.add_argument("--confirm-reset")
+    parser.add_argument("--database-mode", choices=("create", "reuse", "reset")); parser.add_argument("--confirm-reset")
 
 
 def make_parser() -> argparse.ArgumentParser:
-    parser = argparse.ArgumentParser(description=__doc__)
-    subparsers = parser.add_subparsers(dest="command", required=True)
-
-    build = subparsers.add_parser("build", help="build the three GreptimeDB-specific TSBS tools")
-    build.add_argument("--run-dir", type=Path)
-    build.add_argument("--rebuild", action="store_true")
-
-    generate = subparsers.add_parser("generate", help="generate data and/or queries")
-    add_run_options(generate)
-    generate.add_argument("--only", choices=("all", "data", "queries"), default="all")
-
-    load = subparsers.add_parser("load", help="load generated data")
-    add_run_options(load)
-    add_connection_options(load)
-    add_load_options(load)
-
-    query = subparsers.add_parser("query", help="run selected generated queries")
-    add_run_options(query)
-    add_connection_options(query)
-    query.add_argument("--repeat", type=int, default=1)
-
-    all_command = subparsers.add_parser("all", help="generate, load, query, and summarize")
-    add_run_options(all_command)
-    add_connection_options(all_command)
-    add_load_options(all_command)
-    all_command.add_argument("--repeat", type=int, default=1)
-
-    summarize = subparsers.add_parser("summarize", help="rebuild summaries from manifest logs")
-    summarize.add_argument("--run-dir", required=True, type=Path)
+    parser = argparse.ArgumentParser(description=__doc__); subparsers = parser.add_subparsers(dest="command", required=True)
+    build = subparsers.add_parser("build"); build.add_argument("--run-dir", type=Path); build.add_argument("--run-root", type=Path); build.add_argument("--rebuild", action="store_true")
+    generate = subparsers.add_parser("generate"); add_run_options(generate); generate.add_argument("--only", choices=("all", "data", "queries"), default="all")
+    load = subparsers.add_parser("load"); add_run_options(load); add_connection_options(load); add_load_options(load)
+    query = subparsers.add_parser("query"); add_run_options(query); add_connection_options(query)
+    all_command = subparsers.add_parser("all"); add_run_options(all_command); add_connection_options(all_command); add_load_options(all_command)
+    summarize = subparsers.add_parser("summarize"); summarize.add_argument("--run-dir", required=True, type=Path)
     return parser
 
 
 def validate_args(args: argparse.Namespace) -> None:
     for name in ("scale", "load_workers", "query_workers", "batch_size", "queries"):
         value = getattr(args, name, None)
-        if value is not None and value <= 0:
-            raise BenchmarkError(f"--{name.replace('_', '-')} must be positive")
-    if getattr(args, "repeat", 1) <= 0:
-        raise BenchmarkError("--repeat must be positive")
+        if value is not None and value <= 0: raise BenchmarkError(f"--{name.replace('_', '-')} must be positive")
+    for name in ("dataset_id", "database_id"):
+        value = getattr(args, name, None)
+        if value and not ID_RE.fullmatch(value): raise BenchmarkError(f"--{name.replace('_', '-')} contains invalid characters")
     if args.command in ("load", "query", "all"):
-        if bool(args.greptime_bin) == bool(args.endpoint):
-            raise BenchmarkError("provide exactly one of --greptime-bin or --endpoint")
+        if bool(args.greptime_bin) == bool(args.endpoint): raise BenchmarkError("provide exactly one of --greptime-bin or --endpoint")
+        if args.greptime_bin and not args.database_id: raise BenchmarkError("managed GreptimeDB requires --database-id")
+        if args.endpoint and args.database_id: raise BenchmarkError("--database-id is only valid with managed GreptimeDB")
         if args.endpoint:
             parsed = urllib.parse.urlparse(args.endpoint)
-            if parsed.scheme not in ("http", "https") or not parsed.netloc:
-                raise BenchmarkError("--endpoint must be an absolute HTTP or HTTPS URL")
+            if parsed.scheme not in ("http", "https") or not parsed.netloc: raise BenchmarkError("--endpoint must be an absolute HTTP or HTTPS URL")
     if args.command in ("load", "all"):
-        if args.endpoint and args.database_mode is None:
-            raise BenchmarkError("external loads require --database-mode=create|reuse|reset")
-        if args.database_mode == "reset" and args.confirm_reset != args.database:
-            raise BenchmarkError("reset requires --confirm-reset to exactly match --database")
+        if args.endpoint and args.database_mode is None: raise BenchmarkError("external loads require --database-mode=create|reuse|reset")
+        if args.database_mode == "reset" and args.confirm_reset != args.database: raise BenchmarkError("reset requires --confirm-reset to exactly match --database")
 
 
 def main(argv: Sequence[str] | None = None) -> int:
-    args = make_parser().parse_args(argv)
-    run_dir: Path | None = None
-    manifest: dict[str, Any] | None = None
+    args = make_parser().parse_args(argv); run_dir: Path | None = None; manifest: dict[str, Any] | None = None
     try:
-        resolve_database(args)
-        validate_args(args)
+        resolve_database(args); validate_args(args)
         if args.command == "summarize":
-            run_dir = args.run_dir.resolve()
-            manifest = json.loads((run_dir / "manifest.json").read_text(encoding="utf-8"))
-            summary = write_summary(run_dir, manifest)
-            print(run_dir / "summary.md")
-            return 1 if summary["failures"] else 0
-
+            run_dir = args.run_dir.resolve(); manifest = read_json(run_dir / "manifest.json"); validate_run_manifest(manifest, run_dir / "manifest.json"); summary = write_summary(run_dir, manifest); print(run_dir / "summary.md"); return 1 if summary["failures"] else 0
         if args.command == "build":
-            run_dir = args.run_dir.resolve() if args.run_dir else new_run_dir()
-            (run_dir / "logs").mkdir(parents=True, exist_ok=True)
-            ensure_binaries(run_dir, list(BINARIES), args.rebuild)
-            print(run_dir)
-            return 0
-
+            run_dir = args.run_dir.resolve() if args.run_dir else new_run_dir((args.run_root or DEFAULT_RUN_ROOT).resolve()); (run_dir / "logs").mkdir(parents=True, exist_ok=True); (run_dir / "results").mkdir(parents=True, exist_ok=True); ensure_binaries(run_dir, list(BINARIES), args.rebuild); print(run_dir); return 0
         run_dir, manifest = prepare_run(args)
-        query_types = args.query_type or list(QUERY_TYPES)
         if args.command == "generate":
-            if args.only in ("all", "data"):
-                generate_data(args, run_dir, manifest)
-            if args.only in ("all", "queries"):
-                generate_queries(run_dir, manifest, query_types, args.regenerate, args.rebuild)
+            if args.only in ("all", "data"): generate_data(args, run_dir, manifest)
+            if args.only in ("all", "queries"): generate_queries(args, run_dir, manifest)
         elif args.command in ("load", "query", "all"):
-            with connection(args, run_dir) as (endpoint, managed):
-                manifest["database"] = args.database
-                manifest["connection"] = {"mode": "managed" if managed else "external", "endpoint": endpoint}
-                save_manifest(run_dir, manifest)
-                if args.command in ("load", "all"):
-                    load_data(args, run_dir, manifest, endpoint, managed)
-                if args.command in ("query", "all"):
-                    run_queries(args, run_dir, manifest, endpoint)
-        summary = write_summary(run_dir, manifest)
-        print(f"Run directory: {run_dir}")
-        print(f"Summary: {run_dir / 'summary.md'}")
-        return 1 if summary["failures"] else 0
-    except (BenchmarkError, OSError, json.JSONDecodeError) as exc:
+            with connection(args, run_dir) as (endpoint, managed, database_manifest, database_path):
+                manifest["target"] = {"mode": "managed" if managed else "external", "endpoint": endpoint, "database": args.database, "database_id": args.database_id if managed else None}; save_manifest(run_dir, manifest)
+                if args.command in ("load", "all"): load_data(args, run_dir, manifest, endpoint, managed, database_manifest, database_path)
+                if args.command in ("query", "all"): run_queries(args, run_dir, manifest, endpoint, database_manifest)
+        summary = write_summary(run_dir, manifest); print(f"Run directory: {run_dir}"); print(f"Summary: {run_dir / 'summary.md'}"); return 1 if summary["failures"] else 0
+    except (BenchmarkError, OSError, json.JSONDecodeError, KeyError, TypeError) as exc:
         if run_dir is not None and manifest is not None:
-            try:
-                write_summary(run_dir, manifest)
-            except OSError:
-                pass
-        print(f"error: {exc}", file=sys.stderr)
-        return 1
+            try: write_summary(run_dir, manifest)
+            except OSError: pass
+        print(f"error: {exc}", file=sys.stderr); return 1
 
 
 if __name__ == "__main__":

--- a/.agents/skills/benchmark-greptimedb/scripts/benchmark.py
+++ b/.agents/skills/benchmark-greptimedb/scripts/benchmark.py
@@ -25,6 +25,7 @@ from summarize import write_summary
 SCRIPT_PATH = Path(__file__).resolve()
 REPO_ROOT = SCRIPT_PATH.parents[4]
 DEFAULT_OUTPUT_ROOT = REPO_ROOT / ".benchmarks" / "greptimedb"
+DATASET_RUNNER = REPO_ROOT / ".agents" / "skills" / "generate-tsbs-data" / "scripts" / "generate.py"
 
 QUERY_COUNTS_MANUAL = {
     "cpu-max-all-1": 100,
@@ -71,7 +72,6 @@ PROFILES = {
 }
 
 BINARIES = {
-    "data": "tsbs_generate_data",
     "queries": "tsbs_generate_queries",
     "load": "tsbs_load_greptime",
     "query": "tsbs_run_queries_influx",
@@ -229,34 +229,115 @@ def ensure_binaries(run_dir: Path, stages: Sequence[str], rebuild: bool) -> None
         BUILT_THIS_PROCESS.add(name)
 
 
-def data_path(run_dir: Path) -> Path:
-    return run_dir / "data" / "influx-data.lp"
-
-
 def query_path(run_dir: Path, query_type: str) -> Path:
     return run_dir / "queries" / f"greptime-queries-{query_type}.dat"
 
 
-def generate_data(run_dir: Path, manifest: dict[str, Any], regenerate: bool, rebuild: bool) -> None:
-    output = data_path(run_dir)
-    if output.exists() and not regenerate:
-        print(f"Reusing generated data: {output}")
-        return
-    ensure_binaries(run_dir, ["data"], rebuild)
+def dataset_selection_args(
+    args: argparse.Namespace,
+    manifest: dict[str, Any],
+) -> list[str]:
+    pinned = manifest.get("dataset")
+    if pinned:
+        pinned_path = Path(pinned["dataset_path"]).resolve()
+        if args.dataset_path and args.dataset_path.resolve() != pinned_path:
+            raise BenchmarkError("--dataset-path conflicts with the dataset pinned by this run")
+        if args.dataset_id and args.dataset_id != pinned["dataset_id"]:
+            raise BenchmarkError("--dataset-id conflicts with the dataset pinned by this run")
+        return ["--dataset-path", str(pinned_path)]
+    if args.dataset_path:
+        return ["--dataset-path", str(args.dataset_path.resolve())]
+    result: list[str] = []
+    if args.dataset_root:
+        result.extend(["--dataset-root", str(args.dataset_root.resolve())])
+    if args.dataset_id:
+        result.extend(["--dataset-id", args.dataset_id])
+    return result
+
+
+def validate_dataset_result(
+    manifest: dict[str, Any],
+    dataset: dict[str, Any],
+    regenerate: bool,
+) -> None:
+    if dataset["spec"]["use_case"] != "cpu-only":
+        raise BenchmarkError("GreptimeDB benchmark requires a cpu-only dataset")
+    pinned = manifest.get("dataset")
+    if pinned and pinned.get("sha256") != dataset.get("sha256") and not regenerate:
+        raise BenchmarkError(
+            "the pinned dataset checksum changed; use --regenerate only if replacement was intentional"
+        )
+
+
+def generate_data(
+    args: argparse.Namespace,
+    run_dir: Path,
+    manifest: dict[str, Any],
+) -> Path:
+    legacy = run_dir / "data" / "influx-data.lp"
+    if legacy.exists() and not manifest.get("dataset") and not (
+        args.dataset_root or args.dataset_id or args.dataset_path or args.regenerate
+    ):
+        print(f"Reusing legacy generated data: {legacy}")
+        manifest["generated_data"] = relative(run_dir, legacy)
+        save_manifest(run_dir, manifest)
+        return legacy
+
     workload = manifest["workload"]
+    selecting_unpinned = not manifest.get("dataset") and bool(args.dataset_id or args.dataset_path)
+    result_path = run_dir / "results" / "dataset.json"
     command = [
-        str(REPO_ROOT / "bin" / BINARIES["data"]),
-        "--use-case=cpu-only",
-        f"--seed={workload['seed']}",
-        f"--scale={workload['scale']}",
-        f"--timestamp-start={workload['start']}",
-        f"--timestamp-end={workload['end']}",
-        f"--log-interval={workload['log_interval']}",
-        "--format=influx",
+        sys.executable,
+        str(DATASET_RUNNER),
+        "generate",
+        "--format",
+        "influx",
+        "--use-case",
+        "cpu-only",
+        "--result-file",
+        str(result_path),
+        *dataset_selection_args(args, manifest),
     ]
-    run_tee(command, run_dir / "logs" / "generate-data.log", stdout_path=output)
-    manifest["generated_data"] = relative(run_dir, output)
+    if selecting_unpinned:
+        if args.profile:
+            command.extend(["--profile", args.profile])
+        for option, value in (
+            ("--seed", args.seed),
+            ("--scale", args.scale),
+            ("--start", args.start),
+            ("--end", args.end),
+            ("--log-interval", args.log_interval),
+        ):
+            if value is not None:
+                command.extend([option, str(value)])
+    else:
+        command.extend(
+            [
+                "--seed",
+                str(workload["seed"]),
+                "--scale",
+                str(workload["scale"]),
+                "--start",
+                workload["start"],
+                "--end",
+                workload["end"],
+                "--log-interval",
+                workload["log_interval"],
+            ]
+        )
+    if args.regenerate:
+        command.append("--regenerate")
+    if args.rebuild:
+        command.append("--rebuild")
+    run_tee(command, run_dir / "logs" / "generate-data.log")
+    dataset = json.loads(result_path.read_text(encoding="utf-8"))
+    validate_dataset_result(manifest, dataset, args.regenerate)
+    for name in ("start", "end", "scale", "seed", "log_interval"):
+        workload[name] = dataset["spec"][name]
+    manifest["dataset"] = dataset
+    manifest["generated_data"] = dataset["data_path"]
     save_manifest(run_dir, manifest)
+    return Path(dataset["data_path"])
 
 
 def generate_queries(
@@ -315,7 +396,7 @@ def load_data(
     endpoint: str,
     managed: bool,
 ) -> None:
-    generate_data(run_dir, manifest, args.regenerate, args.rebuild)
+    input_path = generate_data(args, run_dir, manifest)
     ensure_binaries(run_dir, ["load"], args.rebuild)
     mode = args.database_mode or ("create" if managed else None)
     if mode is None:
@@ -337,7 +418,7 @@ def load_data(
     command = [
         str(REPO_ROOT / "bin" / BINARIES["load"]),
         f"--urls={endpoint}",
-        f"--file={data_path(run_dir)}",
+        f"--file={input_path}",
         f"--db-name={args.database}",
         f"--batch-size={workload['batch_size']}",
         "--gzip=false",
@@ -501,6 +582,10 @@ def add_run_options(parser: argparse.ArgumentParser) -> None:
     parser.add_argument("--query-type", action="append", choices=QUERY_TYPES)
     parser.add_argument("--regenerate", action="store_true")
     parser.add_argument("--rebuild", action="store_true")
+    parser.add_argument("--dataset-root", type=Path)
+    dataset = parser.add_mutually_exclusive_group()
+    dataset.add_argument("--dataset-id")
+    dataset.add_argument("--dataset-path", type=Path)
 
 
 def add_connection_options(parser: argparse.ArgumentParser) -> None:
@@ -520,7 +605,7 @@ def make_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description=__doc__)
     subparsers = parser.add_subparsers(dest="command", required=True)
 
-    build = subparsers.add_parser("build", help="build the four GreptimeDB TSBS tools")
+    build = subparsers.add_parser("build", help="build the three GreptimeDB-specific TSBS tools")
     build.add_argument("--run-dir", type=Path)
     build.add_argument("--rebuild", action="store_true")
 
@@ -594,7 +679,7 @@ def main(argv: Sequence[str] | None = None) -> int:
         query_types = args.query_type or list(QUERY_TYPES)
         if args.command == "generate":
             if args.only in ("all", "data"):
-                generate_data(run_dir, manifest, args.regenerate, args.rebuild)
+                generate_data(args, run_dir, manifest)
             if args.only in ("all", "queries"):
                 generate_queries(run_dir, manifest, query_types, args.regenerate, args.rebuild)
         elif args.command in ("load", "query", "all"):

--- a/.agents/skills/benchmark-greptimedb/scripts/summarize.py
+++ b/.agents/skills/benchmark-greptimedb/scripts/summarize.py
@@ -75,6 +75,8 @@ def build_summary(run_dir: Path, manifest: dict[str, Any]) -> dict[str, Any]:
     query_runs: list[dict[str, Any]] = []
 
     for event in manifest.get("events", {}).get("loads", []):
+        if event.get("status") == "reused":
+            continue
         base = {
             "attempt": event["attempt"],
             "database": event["database"],

--- a/.agents/skills/benchmark-greptimedb/scripts/summarize.py
+++ b/.agents/skills/benchmark-greptimedb/scripts/summarize.py
@@ -1,0 +1,214 @@
+#!/usr/bin/env python3
+"""Parse TSBS logs and write GreptimeDB benchmark summaries."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+from pathlib import Path
+from typing import Any
+
+
+METRIC_RE = re.compile(
+    r"loaded\s+(?P<count>\d+)\s+metrics\s+in\s+(?P<seconds>[0-9.]+)sec.*?"
+    r"mean rate\s+(?P<rate>[0-9.]+)\s+metrics/sec"
+)
+ROW_RE = re.compile(
+    r"loaded\s+(?P<count>\d+)\s+rows\s+in\s+(?P<seconds>[0-9.]+)sec.*?"
+    r"mean rate\s+(?P<rate>[0-9.]+)\s+rows/sec"
+)
+QUERY_RE = re.compile(
+    r"all queries\s*:\s*\n\s*"
+    r"min:.*?mean:\s*(?P<mean>[0-9.]+)ms,.*?count:\s*(?P<count>\d+)",
+    re.DOTALL,
+)
+
+
+class SummaryError(ValueError):
+    """Raised when a completed TSBS log cannot be parsed."""
+
+
+def parse_load_log(text: str) -> dict[str, Any]:
+    metric_matches = list(METRIC_RE.finditer(text))
+    if not metric_matches:
+        raise SummaryError("load log has no final metric summary")
+    metric = metric_matches[-1]
+    result: dict[str, Any] = {
+        "metrics": int(metric.group("count")),
+        "duration_seconds": float(metric.group("seconds")),
+        "metrics_per_second": float(metric.group("rate")),
+    }
+    row_matches = list(ROW_RE.finditer(text))
+    if row_matches:
+        row = row_matches[-1]
+        result.update(
+            {
+                "rows": int(row.group("count")),
+                "rows_per_second": float(row.group("rate")),
+            }
+        )
+    return result
+
+
+def parse_query_log(text: str) -> dict[str, Any]:
+    marker = text.rfind("Run complete after")
+    if marker < 0:
+        raise SummaryError("query log has no final run marker")
+    matches = list(QUERY_RE.finditer(text[marker:]))
+    if not matches:
+        raise SummaryError("query log has no final all-queries summary")
+    match = matches[-1]
+    return {
+        "mean_milliseconds": float(match.group("mean")),
+        "count": int(match.group("count")),
+    }
+
+
+def _read_log(run_dir: Path, relative_path: str) -> str:
+    return (run_dir / relative_path).read_text(encoding="utf-8", errors="replace")
+
+
+def build_summary(run_dir: Path, manifest: dict[str, Any]) -> dict[str, Any]:
+    failures: list[dict[str, str]] = []
+    ingestion_runs: list[dict[str, Any]] = []
+    query_runs: list[dict[str, Any]] = []
+
+    for event in manifest.get("events", {}).get("loads", []):
+        base = {
+            "attempt": event["attempt"],
+            "database": event["database"],
+            "mode": event["database_mode"],
+            "log": event["log"],
+        }
+        if event.get("status") != "completed":
+            failures.append(
+                {"stage": "load", "log": event["log"], "reason": event.get("status", "failed")}
+            )
+            continue
+        try:
+            base.update(parse_load_log(_read_log(run_dir, event["log"])))
+            ingestion_runs.append(base)
+        except (OSError, SummaryError) as exc:
+            failures.append({"stage": "load", "log": event["log"], "reason": str(exc)})
+
+    for event in manifest.get("events", {}).get("queries", []):
+        base = {
+            "query_type": event["query_type"],
+            "attempt": event["attempt"],
+            "database": event["database"],
+            "log": event["log"],
+        }
+        if event.get("status") != "completed":
+            failures.append(
+                {"stage": "query", "log": event["log"], "reason": event.get("status", "failed")}
+            )
+            continue
+        try:
+            base.update(parse_query_log(_read_log(run_dir, event["log"])))
+            query_runs.append(base)
+        except (OSError, SummaryError) as exc:
+            failures.append({"stage": "query", "log": event["log"], "reason": str(exc)})
+
+    grouped: dict[str, list[dict[str, Any]]] = {}
+    for run in query_runs:
+        grouped.setdefault(run["query_type"], []).append(run)
+
+    queries: list[dict[str, Any]] = []
+    for query_type in sorted(grouped):
+        runs = grouped[query_type]
+        count = sum(run["count"] for run in runs)
+        weighted = sum(run["mean_milliseconds"] * run["count"] for run in runs)
+        queries.append(
+            {
+                "query_type": query_type,
+                "repetitions": len(runs),
+                "query_count": count,
+                "weighted_mean_milliseconds": weighted / count if count else 0.0,
+                "runs": runs,
+            }
+        )
+
+    return {
+        "run_id": manifest.get("run_id", run_dir.name),
+        "profile": manifest.get("profile"),
+        "database": manifest.get("database"),
+        "workload": manifest.get("workload", {}),
+        "ingestion_runs": ingestion_runs,
+        "queries": queries,
+        "failures": failures,
+    }
+
+
+def render_markdown(summary: dict[str, Any]) -> str:
+    lines = [
+        f"# GreptimeDB TSBS benchmark: {summary['run_id']}",
+        "",
+        f"- Profile: `{summary.get('profile')}`",
+        f"- Database: `{summary.get('database')}`",
+        "",
+        "## Ingestion",
+        "",
+    ]
+    if summary["ingestion_runs"]:
+        lines.extend(
+            [
+                "| Attempt | Mode | Metrics | Metrics/s | Rows | Rows/s | Log |",
+                "| ---: | --- | ---: | ---: | ---: | ---: | --- |",
+            ]
+        )
+        for run in summary["ingestion_runs"]:
+            rows_per_second = f"{run['rows_per_second']:.2f}" if "rows_per_second" in run else "-"
+            lines.append(
+                f"| {run['attempt']} | {run['mode']} | {run['metrics']} | "
+                f"{run['metrics_per_second']:.2f} | {run.get('rows', '-')} | {rows_per_second} | "
+                f"`{run['log']}` |"
+            )
+    else:
+        lines.append("No completed ingestion runs.")
+
+    lines.extend(["", "## Queries", ""])
+    if summary["queries"]:
+        lines.extend(
+            [
+                "| Query type | Repetitions | Query count | Weighted mean (ms) |",
+                "| --- | ---: | ---: | ---: |",
+            ]
+        )
+        for query in summary["queries"]:
+            lines.append(
+                f"| `{query['query_type']}` | {query['repetitions']} | {query['query_count']} | "
+                f"{query['weighted_mean_milliseconds']:.3f} |"
+            )
+    else:
+        lines.append("No completed query runs.")
+
+    if summary["failures"]:
+        lines.extend(["", "## Failures", "", "| Stage | Log | Reason |", "| --- | --- | --- |"])
+        for failure in summary["failures"]:
+            reason = failure["reason"].replace("|", "\\|")
+            lines.append(f"| {failure['stage']} | `{failure['log']}` | {reason} |")
+    lines.append("")
+    return "\n".join(lines)
+
+
+def write_summary(run_dir: Path, manifest: dict[str, Any]) -> dict[str, Any]:
+    summary = build_summary(run_dir, manifest)
+    (run_dir / "summary.json").write_text(json.dumps(summary, indent=2) + "\n", encoding="utf-8")
+    (run_dir / "summary.md").write_text(render_markdown(summary), encoding="utf-8")
+    return summary
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--run-dir", required=True, type=Path)
+    args = parser.parse_args()
+    run_dir = args.run_dir.resolve()
+    manifest = json.loads((run_dir / "manifest.json").read_text(encoding="utf-8"))
+    summary = write_summary(run_dir, manifest)
+    print(run_dir / "summary.md")
+    return 1 if summary["failures"] else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.agents/skills/benchmark-greptimedb/scripts/summarize.py
+++ b/.agents/skills/benchmark-greptimedb/scripts/summarize.py
@@ -110,17 +110,19 @@ def build_summary(run_dir: Path, manifest: dict[str, Any]) -> dict[str, Any]:
         except (OSError, SummaryError) as exc:
             failures.append({"stage": "query", "log": event["log"], "reason": str(exc)})
 
-    grouped: dict[str, list[dict[str, Any]]] = {}
+    grouped: dict[tuple[str, str], list[dict[str, Any]]] = {}
     for run in query_runs:
-        grouped.setdefault(run["query_type"], []).append(run)
+        key = (run["database"], run["query_type"])
+        grouped.setdefault(key, []).append(run)
 
     queries: list[dict[str, Any]] = []
-    for query_type in sorted(grouped):
-        runs = grouped[query_type]
+    for database, query_type in sorted(grouped):
+        runs = grouped[(database, query_type)]
         count = sum(run["count"] for run in runs)
         weighted = sum(run["mean_milliseconds"] * run["count"] for run in runs)
         queries.append(
             {
+                "database": database,
                 "query_type": query_type,
                 "repetitions": len(runs),
                 "query_count": count,
@@ -133,7 +135,9 @@ def build_summary(run_dir: Path, manifest: dict[str, Any]) -> dict[str, Any]:
         "run_id": manifest.get("run_id", run_dir.name),
         "profile": manifest.get("profile"),
         "database": manifest.get("database"),
+        "target": manifest.get("target"),
         "dataset": manifest.get("dataset"),
+        "query_set": manifest.get("query_set"),
         "workload": manifest.get("workload", {}),
         "ingestion_runs": ingestion_runs,
         "queries": queries,
@@ -146,8 +150,12 @@ def render_markdown(summary: dict[str, Any]) -> str:
         f"# GreptimeDB TSBS benchmark: {summary['run_id']}",
         "",
         f"- Profile: `{summary.get('profile')}`",
-        f"- Database: `{summary.get('database')}`",
+        f"- Current database: `{summary.get('database')}`",
     ]
+    target = summary.get("target")
+    if target:
+        target_name = target.get("database_id") or target.get("endpoint")
+        lines.append(f"- Benchmark target: `{target.get('mode')}:{target_name}`")
     dataset = summary.get("dataset")
     if dataset:
         lines.extend(
@@ -158,18 +166,26 @@ def render_markdown(summary: dict[str, Any]) -> str:
                 f"- Data path: `{dataset.get('data_path')}`",
             ]
         )
+    query_set = summary.get("query_set")
+    if query_set:
+        lines.extend(
+            [
+                f"- Query set: `{query_set.get('query_set_id')}`",
+                f"- Query-set manifest SHA-256: `{query_set.get('manifest_sha256')}`",
+            ]
+        )
     lines.extend(["", "## Ingestion", ""])
     if summary["ingestion_runs"]:
         lines.extend(
             [
-                "| Attempt | Mode | Metrics | Metrics/s | Rows | Rows/s | Log |",
-                "| ---: | --- | ---: | ---: | ---: | ---: | --- |",
+                "| Database | Attempt | Mode | Metrics | Metrics/s | Rows | Rows/s | Log |",
+                "| --- | ---: | --- | ---: | ---: | ---: | ---: | --- |",
             ]
         )
         for run in summary["ingestion_runs"]:
             rows_per_second = f"{run['rows_per_second']:.2f}" if "rows_per_second" in run else "-"
             lines.append(
-                f"| {run['attempt']} | {run['mode']} | {run['metrics']} | "
+                f"| `{run['database']}` | {run['attempt']} | {run['mode']} | {run['metrics']} | "
                 f"{run['metrics_per_second']:.2f} | {run.get('rows', '-')} | {rows_per_second} | "
                 f"`{run['log']}` |"
             )
@@ -180,13 +196,14 @@ def render_markdown(summary: dict[str, Any]) -> str:
     if summary["queries"]:
         lines.extend(
             [
-                "| Query type | Repetitions | Query count | Weighted mean (ms) |",
-                "| --- | ---: | ---: | ---: |",
+                "| Database | Query type | Repetitions | Query count | Weighted mean (ms) |",
+                "| --- | --- | ---: | ---: | ---: |",
             ]
         )
         for query in summary["queries"]:
             lines.append(
-                f"| `{query['query_type']}` | {query['repetitions']} | {query['query_count']} | "
+                f"| `{query['database']}` | `{query['query_type']}` | {query['repetitions']} | "
+                f"{query['query_count']} | "
                 f"{query['weighted_mean_milliseconds']:.3f} |"
             )
     else:

--- a/.agents/skills/benchmark-greptimedb/scripts/summarize.py
+++ b/.agents/skills/benchmark-greptimedb/scripts/summarize.py
@@ -133,6 +133,7 @@ def build_summary(run_dir: Path, manifest: dict[str, Any]) -> dict[str, Any]:
         "run_id": manifest.get("run_id", run_dir.name),
         "profile": manifest.get("profile"),
         "database": manifest.get("database"),
+        "dataset": manifest.get("dataset"),
         "workload": manifest.get("workload", {}),
         "ingestion_runs": ingestion_runs,
         "queries": queries,
@@ -146,10 +147,18 @@ def render_markdown(summary: dict[str, Any]) -> str:
         "",
         f"- Profile: `{summary.get('profile')}`",
         f"- Database: `{summary.get('database')}`",
-        "",
-        "## Ingestion",
-        "",
     ]
+    dataset = summary.get("dataset")
+    if dataset:
+        lines.extend(
+            [
+                f"- Dataset: `{dataset.get('dataset_id')}`",
+                f"- Data format: `{dataset.get('format')}`",
+                f"- Data SHA-256: `{dataset.get('sha256')}`",
+                f"- Data path: `{dataset.get('data_path')}`",
+            ]
+        )
+    lines.extend(["", "## Ingestion", ""])
     if summary["ingestion_runs"]:
         lines.extend(
             [

--- a/.agents/skills/benchmark-greptimedb/tests/test_benchmark.py
+++ b/.agents/skills/benchmark-greptimedb/tests/test_benchmark.py
@@ -89,6 +89,27 @@ wall clock time: 1.0sec
             self.assertEqual(query["query_count"], 8)
             self.assertEqual(query["weighted_mean_milliseconds"], 3.5)
 
+    def test_summary_includes_dataset_identity(self) -> None:
+        with tempfile.TemporaryDirectory() as temp:
+            run_dir = Path(temp)
+            manifest = {
+                "run_id": "test",
+                "profile": "smoke",
+                "database": "benchmark",
+                "dataset": {
+                    "dataset_id": "cpu-only-s10-abc",
+                    "format": "influx",
+                    "data_path": "/cache/data",
+                    "sha256": "1234",
+                },
+                "events": {"loads": [], "queries": []},
+            }
+            summary = summarize.build_summary(run_dir, manifest)
+            self.assertEqual(summary["dataset"]["dataset_id"], "cpu-only-s10-abc")
+            markdown = summarize.render_markdown(summary)
+            self.assertIn("cpu-only-s10-abc", markdown)
+            self.assertIn("1234", markdown)
+
 
 class RunnerSafetyTests(unittest.TestCase):
     def test_database_modes(self) -> None:
@@ -143,6 +164,55 @@ class RunnerSafetyTests(unittest.TestCase):
             run_dir = Path(temp)
             benchmark.save_manifest(run_dir, {"run_id": "test"})
             self.assertEqual(json.loads((run_dir / "manifest.json").read_text())["run_id"], "test")
+
+    def test_pinned_dataset_rejects_conflicting_selection(self) -> None:
+        args = benchmark.make_parser().parse_args(
+            ["generate", "--only", "data", "--dataset-id", "different"]
+        )
+        manifest = {
+            "dataset": {
+                "dataset_id": "pinned",
+                "dataset_path": "/tmp/pinned",
+            }
+        }
+        with self.assertRaisesRegex(benchmark.BenchmarkError, "conflicts"):
+            benchmark.dataset_selection_args(args, manifest)
+
+    def test_pinned_dataset_path_is_reused(self) -> None:
+        args = benchmark.make_parser().parse_args(["generate", "--only", "data"])
+        manifest = {
+            "dataset": {
+                "dataset_id": "pinned",
+                "dataset_path": "/tmp/pinned",
+            }
+        }
+        self.assertEqual(
+            benchmark.dataset_selection_args(args, manifest),
+            ["--dataset-path", str(Path("/tmp/pinned").resolve())],
+        )
+
+    def test_changed_pinned_dataset_checksum_is_rejected(self) -> None:
+        manifest = {"dataset": {"sha256": "old"}}
+        dataset = {"sha256": "new", "spec": {"use_case": "cpu-only"}}
+        with self.assertRaisesRegex(benchmark.BenchmarkError, "checksum changed"):
+            benchmark.validate_dataset_result(manifest, dataset, False)
+        benchmark.validate_dataset_result(manifest, dataset, True)
+
+    def test_legacy_run_local_data_is_still_reused(self) -> None:
+        with tempfile.TemporaryDirectory() as temp:
+            run_dir = Path(temp)
+            (run_dir / "data").mkdir()
+            legacy = run_dir / "data" / "influx-data.lp"
+            legacy.write_text("cpu value=1 1\n", encoding="utf-8")
+            manifest = {
+                "run_id": "legacy",
+                "workload": {},
+                "events": {"loads": [], "queries": []},
+            }
+            args = benchmark.make_parser().parse_args(["generate", "--only", "data"])
+            self.assertEqual(benchmark.generate_data(args, run_dir, manifest), legacy)
+            saved = json.loads((run_dir / "manifest.json").read_text(encoding="utf-8"))
+            self.assertEqual(saved["generated_data"], "data/influx-data.lp")
 
     def test_build_marker_does_not_trust_an_untracked_binary(self) -> None:
         with tempfile.TemporaryDirectory() as temp:

--- a/.agents/skills/benchmark-greptimedb/tests/test_benchmark.py
+++ b/.agents/skills/benchmark-greptimedb/tests/test_benchmark.py
@@ -113,6 +113,67 @@ wall clock time: 1.0sec
 
 
 class RunnerSafetyTests(unittest.TestCase):
+    def test_existing_run_inherits_database_when_omitted(self) -> None:
+        with tempfile.TemporaryDirectory() as temp:
+            run_dir = Path(temp)
+            manifest = {
+                "run_id": "existing",
+                "database": "custom",
+                "workload": json.loads(json.dumps(benchmark.PROFILES["smoke"])),
+                "events": {"loads": [], "queries": []},
+            }
+            (run_dir / "manifest.json").write_text(json.dumps(manifest), encoding="utf-8")
+            args = benchmark.make_parser().parse_args(
+                ["query", "--run-dir", str(run_dir), "--endpoint", "http://localhost:4000"]
+            )
+
+            self.assertIsNone(args.database)
+            benchmark.resolve_database(args)
+            self.assertEqual(args.database, "custom")
+            _, prepared = benchmark.prepare_run(args)
+            self.assertEqual(prepared["database"], "custom")
+
+    def test_explicit_database_overrides_existing_run(self) -> None:
+        with tempfile.TemporaryDirectory() as temp:
+            run_dir = Path(temp)
+            (run_dir / "manifest.json").write_text(
+                json.dumps(
+                    {
+                        "run_id": "existing",
+                        "database": "custom",
+                        "workload": json.loads(json.dumps(benchmark.PROFILES["smoke"])),
+                        "events": {"loads": [], "queries": []},
+                    }
+                ),
+                encoding="utf-8",
+            )
+            args = benchmark.make_parser().parse_args(
+                [
+                    "query",
+                    "--run-dir",
+                    str(run_dir),
+                    "--endpoint",
+                    "http://localhost:4000",
+                    "--database",
+                    "benchmark",
+                ]
+            )
+
+            benchmark.resolve_database(args)
+            _, prepared = benchmark.prepare_run(args)
+            self.assertEqual(args.database, "benchmark")
+            self.assertEqual(prepared["database"], "benchmark")
+
+    def test_new_run_defaults_to_benchmark_database(self) -> None:
+        with tempfile.TemporaryDirectory() as temp:
+            run_dir = Path(temp) / "new-run"
+            args = benchmark.make_parser().parse_args(
+                ["query", "--run-dir", str(run_dir), "--endpoint", "http://localhost:4000"]
+            )
+
+            benchmark.resolve_database(args)
+            self.assertEqual(args.database, "benchmark")
+
     def test_database_modes(self) -> None:
         self.assertEqual(
             benchmark.database_mode_args("create", "bench", None),
@@ -150,6 +211,31 @@ class RunnerSafetyTests(unittest.TestCase):
         )
         with self.assertRaisesRegex(benchmark.BenchmarkError, "exactly match"):
             benchmark.validate_args(args)
+
+    def test_reset_confirmation_uses_inherited_database(self) -> None:
+        with tempfile.TemporaryDirectory() as temp:
+            run_dir = Path(temp)
+            (run_dir / "manifest.json").write_text(
+                json.dumps({"database": "custom"}), encoding="utf-8"
+            )
+            args = benchmark.make_parser().parse_args(
+                [
+                    "load",
+                    "--run-dir",
+                    str(run_dir),
+                    "--endpoint",
+                    "http://localhost:4000",
+                    "--database-mode",
+                    "reset",
+                    "--confirm-reset",
+                    "other",
+                ]
+            )
+
+            benchmark.resolve_database(args)
+            self.assertEqual(args.database, "custom")
+            with self.assertRaisesRegex(benchmark.BenchmarkError, "exactly match"):
+                benchmark.validate_args(args)
 
     def test_attempts_are_append_only_per_query_type(self) -> None:
         events = [
@@ -214,6 +300,87 @@ class RunnerSafetyTests(unittest.TestCase):
             self.assertEqual(benchmark.generate_data(args, run_dir, manifest), legacy)
             saved = json.loads((run_dir / "manifest.json").read_text(encoding="utf-8"))
             self.assertEqual(saved["generated_data"], "data/influx-data.lp")
+
+    def test_data_workload_overrides_do_not_reuse_legacy_data(self) -> None:
+        changes = {
+            "start": "2023-06-10T00:00:00Z",
+            "end": "2023-06-13T00:00:00Z",
+            "scale": 20,
+            "seed": 456,
+            "log_interval": "20s",
+        }
+        for field, value in changes.items():
+            with self.subTest(field=field), tempfile.TemporaryDirectory() as temp:
+                run_dir = Path(temp)
+                (run_dir / "data").mkdir()
+                (run_dir / "data" / "influx-data.lp").write_text(
+                    "cpu value=1 1\n", encoding="utf-8"
+                )
+                manifest = {
+                    "run_id": "legacy",
+                    "profile": "smoke",
+                    "workload": json.loads(json.dumps(benchmark.PROFILES["smoke"])),
+                    "events": {"loads": [], "queries": []},
+                }
+                (run_dir / "manifest.json").write_text(json.dumps(manifest), encoding="utf-8")
+                option = "--" + field.replace("_", "-")
+                args = benchmark.make_parser().parse_args(
+                    ["generate", "--run-dir", str(run_dir), "--only", "data", option, str(value)]
+                )
+                _, prepared = benchmark.prepare_run(args)
+                generated = run_dir / "generated.lp"
+
+                def write_dataset_result(command, _log_path, **_kwargs):
+                    result_path = Path(command[command.index("--result-file") + 1])
+                    result_path.write_text(
+                        json.dumps(
+                            {
+                                "dataset_id": "updated",
+                                "dataset_path": str(run_dir / "dataset"),
+                                "data_path": str(generated),
+                                "format": "influx",
+                                "sha256": "1234",
+                                "spec": {
+                                    "use_case": "cpu-only",
+                                    **{
+                                        name: prepared["workload"][name]
+                                        for name in benchmark.DATA_WORKLOAD_OPTIONS
+                                    },
+                                },
+                            }
+                        ),
+                        encoding="utf-8",
+                    )
+
+                with mock.patch.object(
+                    benchmark, "run_tee", side_effect=write_dataset_result
+                ) as run_tee:
+                    result = benchmark.generate_data(args, run_dir, prepared)
+
+                run_tee.assert_called_once()
+                self.assertEqual(result, generated)
+                self.assertEqual(prepared["workload"][field], value)
+
+    def test_non_data_override_still_reuses_legacy_data(self) -> None:
+        with tempfile.TemporaryDirectory() as temp:
+            run_dir = Path(temp)
+            (run_dir / "data").mkdir()
+            legacy = run_dir / "data" / "influx-data.lp"
+            legacy.write_text("cpu value=1 1\n", encoding="utf-8")
+            manifest = {
+                "run_id": "legacy",
+                "workload": {},
+                "events": {"loads": [], "queries": []},
+            }
+            args = benchmark.make_parser().parse_args(
+                ["generate", "--only", "data", "--query-workers", "2"]
+            )
+
+            with mock.patch.object(benchmark, "run_tee") as run_tee:
+                result = benchmark.generate_data(args, run_dir, manifest)
+
+            run_tee.assert_not_called()
+            self.assertEqual(result, legacy)
 
     def test_build_marker_does_not_trust_an_untracked_binary(self) -> None:
         with tempfile.TemporaryDirectory() as temp:

--- a/.agents/skills/benchmark-greptimedb/tests/test_benchmark.py
+++ b/.agents/skills/benchmark-greptimedb/tests/test_benchmark.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import argparse
 import json
 import sys
 import tempfile
@@ -15,520 +16,208 @@ import benchmark  # noqa: E402
 import summarize  # noqa: E402
 
 
-class SummaryParserTests(unittest.TestCase):
-    def test_parse_load_log_with_metrics_and_rows(self) -> None:
-        parsed = summarize.parse_load_log(
-            """
-Summary:
-loaded 200 metrics in 2.000sec with 2 workers (mean rate 100.00 metrics/sec)
-loaded 40 rows in 2.000sec with 2 workers (mean rate 20.00 rows/sec)
-"""
+class SummaryTests(unittest.TestCase):
+    def test_parsers_and_target_identity(self) -> None:
+        load = summarize.parse_load_log(
+            "loaded 200 metrics in 2.000sec (mean rate 100.00 metrics/sec)\n"
+            "loaded 40 rows in 2.000sec (mean rate 20.00 rows/sec)\n"
         )
-        self.assertEqual(parsed["metrics"], 200)
-        self.assertEqual(parsed["rows"], 40)
-        self.assertEqual(parsed["metrics_per_second"], 100.0)
-        self.assertEqual(parsed["rows_per_second"], 20.0)
-
-    def test_parse_query_uses_final_all_queries_block(self) -> None:
-        parsed = summarize.parse_query_log(
-            """
-After 100 queries with 1 workers:
-all queries:
-min: 1.00ms, med: 2.00ms, mean: 999.00ms, max: 4.00ms, stddev: 1.00ms, sum: 0.1sec, count: 100
-
-Run complete after 10 queries with 1 workers (Overall query rate 3.00 queries/sec):
-all queries       :
-min: 1.00ms, med: 2.00ms, mean: 3.50ms, max: 4.00ms, stddev: 1.00ms, sum: 0.1sec, count: 10
-wall clock time: 1.0sec
-"""
+        self.assertEqual(load["metrics_per_second"], 100.0)
+        query = summarize.parse_query_log(
+            "Run complete after 10 queries\nall queries:\n"
+            "min: 1ms, mean: 3.50ms, max: 4ms, count: 10\n"
         )
-        self.assertEqual(parsed, {"mean_milliseconds": 3.5, "count": 10})
-
-    def test_parse_query_rejects_incomplete_log(self) -> None:
-        with self.assertRaises(summarize.SummaryError):
-            summarize.parse_query_log("all queries: mean: 2.00ms")
-
-    def test_weighted_query_summary(self) -> None:
+        self.assertEqual(query, {"mean_milliseconds": 3.5, "count": 10})
         with tempfile.TemporaryDirectory() as temp:
-            run_dir = Path(temp)
-            (run_dir / "logs").mkdir()
-            (run_dir / "logs/q1.log").write_text(
-                "Run complete after 2 queries\nall queries:\n"
-                "min: 1ms, med: 1ms, mean: 2.00ms, max: 3ms, stddev: 1ms, sum: 0.1sec, count: 2\n"
-            )
-            (run_dir / "logs/q2.log").write_text(
-                "Run complete after 6 queries\nall queries:\n"
-                "min: 1ms, med: 1ms, mean: 4.00ms, max: 5ms, stddev: 1ms, sum: 0.1sec, count: 6\n"
-            )
-            manifest = {
-                "run_id": "test",
-                "profile": "smoke",
-                "database": "benchmark",
-                "events": {
-                    "loads": [],
-                    "queries": [
-                        {
-                            "query_type": "cpu-max-all-1",
-                            "attempt": 1,
-                            "database": "benchmark",
-                            "log": "logs/q1.log",
-                            "status": "completed",
-                        },
-                        {
-                            "query_type": "cpu-max-all-1",
-                            "attempt": 2,
-                            "database": "benchmark",
-                            "log": "logs/q2.log",
-                            "status": "completed",
-                        },
-                    ],
-                },
-            }
-            summary = summarize.build_summary(run_dir, manifest)
-            query = summary["queries"][0]
-            self.assertEqual(query["repetitions"], 2)
-            self.assertEqual(query["query_count"], 8)
-            self.assertEqual(query["weighted_mean_milliseconds"], 3.5)
-
-    def test_summary_includes_dataset_identity(self) -> None:
-        with tempfile.TemporaryDirectory() as temp:
-            run_dir = Path(temp)
-            manifest = {
-                "run_id": "test",
-                "profile": "smoke",
-                "database": "benchmark",
-                "dataset": {
-                    "dataset_id": "cpu-only-s10-abc",
-                    "format": "influx",
-                    "data_path": "/cache/data",
-                    "sha256": "1234",
-                },
-                "events": {"loads": [], "queries": []},
-            }
-            summary = summarize.build_summary(run_dir, manifest)
-            self.assertEqual(summary["dataset"]["dataset_id"], "cpu-only-s10-abc")
-            markdown = summarize.render_markdown(summary)
-            self.assertIn("cpu-only-s10-abc", markdown)
-            self.assertIn("1234", markdown)
-
-
-class RunnerSafetyTests(unittest.TestCase):
-    def test_existing_run_inherits_database_when_omitted(self) -> None:
-        with tempfile.TemporaryDirectory() as temp:
-            run_dir = Path(temp)
-            manifest = {
-                "run_id": "existing",
-                "database": "custom",
-                "workload": json.loads(json.dumps(benchmark.PROFILES["smoke"])),
-                "events": {"loads": [], "queries": []},
-            }
-            (run_dir / "manifest.json").write_text(json.dumps(manifest), encoding="utf-8")
-            args = benchmark.make_parser().parse_args(
-                ["query", "--run-dir", str(run_dir), "--endpoint", "http://localhost:4000"]
-            )
-
-            self.assertIsNone(args.database)
-            benchmark.resolve_database(args)
-            self.assertEqual(args.database, "custom")
-            _, prepared = benchmark.prepare_run(args)
-            self.assertEqual(prepared["database"], "custom")
-
-    def test_explicit_database_overrides_existing_run(self) -> None:
-        with tempfile.TemporaryDirectory() as temp:
-            run_dir = Path(temp)
-            (run_dir / "manifest.json").write_text(
-                json.dumps(
-                    {
-                        "run_id": "existing",
-                        "database": "custom",
-                        "workload": json.loads(json.dumps(benchmark.PROFILES["smoke"])),
-                        "events": {"loads": [], "queries": []},
-                    }
-                ),
-                encoding="utf-8",
-            )
-            args = benchmark.make_parser().parse_args(
-                [
-                    "query",
-                    "--run-dir",
-                    str(run_dir),
-                    "--endpoint",
-                    "http://localhost:4000",
-                    "--database",
-                    "benchmark",
-                ]
-            )
-
-            benchmark.resolve_database(args)
-            _, prepared = benchmark.prepare_run(args)
-            self.assertEqual(args.database, "benchmark")
-            self.assertEqual(prepared["database"], "benchmark")
-
-    def test_new_run_defaults_to_benchmark_database(self) -> None:
-        with tempfile.TemporaryDirectory() as temp:
-            run_dir = Path(temp) / "new-run"
-            args = benchmark.make_parser().parse_args(
-                ["query", "--run-dir", str(run_dir), "--endpoint", "http://localhost:4000"]
-            )
-
-            benchmark.resolve_database(args)
-            self.assertEqual(args.database, "benchmark")
-
-    def test_database_modes(self) -> None:
-        self.assertEqual(
-            benchmark.database_mode_args("create", "bench", None),
-            ["--do-create-db=true", "--do-abort-on-exist=true"],
-        )
-        self.assertEqual(
-            benchmark.database_mode_args("reuse", "bench", None),
-            ["--do-create-db=false"],
-        )
-        self.assertEqual(
-            benchmark.database_mode_args("reset", "bench", "bench"),
-            ["--do-create-db=true"],
-        )
-        with self.assertRaises(benchmark.BenchmarkError):
-            benchmark.database_mode_args("reset", "bench", "other")
-
-    def test_external_load_requires_mode_before_work(self) -> None:
-        args = benchmark.make_parser().parse_args(["load", "--endpoint", "http://localhost:4000"])
-        with self.assertRaisesRegex(benchmark.BenchmarkError, "database-mode"):
-            benchmark.validate_args(args)
-
-    def test_reset_confirmation_is_validated_before_work(self) -> None:
-        args = benchmark.make_parser().parse_args(
-            [
-                "load",
-                "--endpoint",
-                "http://localhost:4000",
-                "--database",
-                "bench",
-                "--database-mode",
-                "reset",
-                "--confirm-reset",
-                "other",
-            ]
-        )
-        with self.assertRaisesRegex(benchmark.BenchmarkError, "exactly match"):
-            benchmark.validate_args(args)
-
-    def test_reset_confirmation_uses_inherited_database(self) -> None:
-        with tempfile.TemporaryDirectory() as temp:
-            run_dir = Path(temp)
-            (run_dir / "manifest.json").write_text(
-                json.dumps({"database": "custom"}), encoding="utf-8"
-            )
-            args = benchmark.make_parser().parse_args(
-                [
-                    "load",
-                    "--run-dir",
-                    str(run_dir),
-                    "--endpoint",
-                    "http://localhost:4000",
-                    "--database-mode",
-                    "reset",
-                    "--confirm-reset",
-                    "other",
-                ]
-            )
-
-            benchmark.resolve_database(args)
-            self.assertEqual(args.database, "custom")
-            with self.assertRaisesRegex(benchmark.BenchmarkError, "exactly match"):
-                benchmark.validate_args(args)
-
-    def test_attempts_are_append_only_per_query_type(self) -> None:
-        events = [
-            {"query_type": "a", "attempt": 1},
-            {"query_type": "a", "attempt": 2},
-            {"query_type": "b", "attempt": 1},
-        ]
-        self.assertEqual(benchmark.next_attempt(events, "a"), 3)
-        self.assertEqual(benchmark.next_attempt(events, "b"), 2)
-
-    def test_manifest_is_valid_json(self) -> None:
-        with tempfile.TemporaryDirectory() as temp:
-            run_dir = Path(temp)
-            benchmark.save_manifest(run_dir, {"run_id": "test"})
-            self.assertEqual(json.loads((run_dir / "manifest.json").read_text())["run_id"], "test")
-
-    def test_pinned_dataset_rejects_conflicting_selection(self) -> None:
-        args = benchmark.make_parser().parse_args(
-            ["generate", "--only", "data", "--dataset-id", "different"]
-        )
-        manifest = {
-            "dataset": {
-                "dataset_id": "pinned",
-                "dataset_path": "/tmp/pinned",
-            }
-        }
-        with self.assertRaisesRegex(benchmark.BenchmarkError, "conflicts"):
-            benchmark.dataset_selection_args(args, manifest)
-
-    def test_pinned_dataset_path_is_reused(self) -> None:
-        args = benchmark.make_parser().parse_args(["generate", "--only", "data"])
-        manifest = {
-            "dataset": {
-                "dataset_id": "pinned",
-                "dataset_path": "/tmp/pinned",
-            }
-        }
-        self.assertEqual(
-            benchmark.dataset_selection_args(args, manifest),
-            ["--dataset-path", str(Path("/tmp/pinned").resolve())],
-        )
-
-    def test_changed_pinned_dataset_checksum_is_rejected(self) -> None:
-        manifest = {"dataset": {"sha256": "old"}}
-        dataset = {"sha256": "new", "spec": {"use_case": "cpu-only"}}
-        with self.assertRaisesRegex(benchmark.BenchmarkError, "checksum changed"):
-            benchmark.validate_dataset_result(manifest, dataset, False)
-        benchmark.validate_dataset_result(manifest, dataset, True)
-
-    def test_legacy_run_local_data_is_still_reused(self) -> None:
-        with tempfile.TemporaryDirectory() as temp:
-            run_dir = Path(temp)
-            (run_dir / "data").mkdir()
-            legacy = run_dir / "data" / "influx-data.lp"
-            legacy.write_text("cpu value=1 1\n", encoding="utf-8")
-            manifest = {
-                "run_id": "legacy",
-                "workload": {},
-                "events": {"loads": [], "queries": []},
-            }
-            args = benchmark.make_parser().parse_args(["generate", "--only", "data"])
-            self.assertEqual(benchmark.generate_data(args, run_dir, manifest), legacy)
-            saved = json.loads((run_dir / "manifest.json").read_text(encoding="utf-8"))
-            self.assertEqual(saved["generated_data"], "data/influx-data.lp")
-
-    def test_data_workload_overrides_do_not_reuse_legacy_data(self) -> None:
-        changes = {
-            "start": "2023-06-10T00:00:00Z",
-            "end": "2023-06-13T00:00:00Z",
-            "scale": 20,
-            "seed": 456,
-            "log_interval": "20s",
-        }
-        for field, value in changes.items():
-            with self.subTest(field=field), tempfile.TemporaryDirectory() as temp:
-                run_dir = Path(temp)
-                (run_dir / "data").mkdir()
-                (run_dir / "data" / "influx-data.lp").write_text(
-                    "cpu value=1 1\n", encoding="utf-8"
-                )
-                manifest = {
-                    "run_id": "legacy",
-                    "profile": "smoke",
-                    "workload": json.loads(json.dumps(benchmark.PROFILES["smoke"])),
+            summary = summarize.build_summary(
+                Path(temp),
+                {
+                    "run_id": "run", "profile": "smoke", "database": "benchmark",
+                    "target": {"mode": "managed", "database_id": "db-a"},
+                    "dataset": {"dataset_id": "data-a"},
+                    "query_set": {"query_set_id": "set-a", "manifest_sha256": "abc"},
                     "events": {"loads": [], "queries": []},
-                }
-                (run_dir / "manifest.json").write_text(json.dumps(manifest), encoding="utf-8")
-                option = "--" + field.replace("_", "-")
-                args = benchmark.make_parser().parse_args(
-                    ["generate", "--run-dir", str(run_dir), "--only", "data", option, str(value)]
-                )
-                _, prepared = benchmark.prepare_run(args)
-                generated = run_dir / "generated.lp"
-
-                def write_dataset_result(command, _log_path, **_kwargs):
-                    result_path = Path(command[command.index("--result-file") + 1])
-                    result_path.write_text(
-                        json.dumps(
-                            {
-                                "dataset_id": "updated",
-                                "dataset_path": str(run_dir / "dataset"),
-                                "data_path": str(generated),
-                                "format": "influx",
-                                "sha256": "1234",
-                                "spec": {
-                                    "use_case": "cpu-only",
-                                    **{
-                                        name: prepared["workload"][name]
-                                        for name in benchmark.DATA_WORKLOAD_OPTIONS
-                                    },
-                                },
-                            }
-                        ),
-                        encoding="utf-8",
-                    )
-
-                with mock.patch.object(
-                    benchmark, "run_tee", side_effect=write_dataset_result
-                ) as run_tee:
-                    result = benchmark.generate_data(args, run_dir, prepared)
-
-                run_tee.assert_called_once()
-                self.assertEqual(result, generated)
-                self.assertEqual(prepared["workload"][field], value)
-
-    def test_non_data_override_still_reuses_legacy_data(self) -> None:
-        with tempfile.TemporaryDirectory() as temp:
-            run_dir = Path(temp)
-            (run_dir / "data").mkdir()
-            legacy = run_dir / "data" / "influx-data.lp"
-            legacy.write_text("cpu value=1 1\n", encoding="utf-8")
-            manifest = {
-                "run_id": "legacy",
-                "workload": {},
-                "events": {"loads": [], "queries": []},
-            }
-            args = benchmark.make_parser().parse_args(
-                ["generate", "--only", "data", "--query-workers", "2"]
+                },
             )
+        self.assertEqual(summary["target"]["database_id"], "db-a")
+        self.assertEqual(summary["query_set"]["query_set_id"], "set-a")
+        rendered = summarize.render_markdown(summary)
+        self.assertIn("managed:db-a", rendered)
+        self.assertIn("set-a", rendered)
 
-            with mock.patch.object(benchmark, "run_tee") as run_tee:
-                result = benchmark.generate_data(args, run_dir, manifest)
 
-            run_tee.assert_not_called()
-            self.assertEqual(result, legacy)
+class QuerySetIdentityTests(unittest.TestCase):
+    def dataset(self) -> dict:
+        return {"dataset_id": "data-a", "spec": {"use_case": "cpu-only", "seed": 123}}
 
-    def test_build_marker_does_not_trust_an_untracked_binary(self) -> None:
-        with tempfile.TemporaryDirectory() as temp:
-            run_dir = Path(temp)
-            (run_dir / "results").mkdir()
-            target = run_dir / "tsbs_generate_data"
-            target.touch()
-            marker = run_dir / "results" / "built-tsbs_generate_data"
-            self.assertTrue(benchmark.binary_needs_build(run_dir, "tsbs_generate_data", target, False))
-            marker.touch()
-            self.assertFalse(benchmark.binary_needs_build(run_dir, "tsbs_generate_data", target, False))
-            self.assertTrue(benchmark.binary_needs_build(run_dir, "tsbs_generate_data", target, True))
+    def workload(self, query_counts: dict[str, int]) -> dict:
+        return {
+            "seed": 123, "scale": 10, "start": "2023-01-01T00:00:00Z",
+            "end": "2023-01-02T00:00:00Z", "query_counts": query_counts,
+        }
 
-    def test_generated_output_is_replaced_only_after_success(self) -> None:
+    def test_identity_is_canonical_and_membership_sensitive(self) -> None:
+        first = benchmark.query_set_spec(self.dataset(), self.workload({"lastpoint": 3, "cpu-max-all-1": 2}))
+        reordered = benchmark.query_set_spec(self.dataset(), self.workload({"cpu-max-all-1": 2, "lastpoint": 3}))
+        self.assertEqual(benchmark.query_set_id(first), benchmark.query_set_id(reordered))
+        changed_count = benchmark.query_set_spec(self.dataset(), self.workload({"cpu-max-all-1": 3, "lastpoint": 3}))
+        subset = benchmark.query_set_spec(self.dataset(), self.workload({"lastpoint": 3}))
+        self.assertNotEqual(benchmark.query_set_id(first), benchmark.query_set_id(changed_count))
+        self.assertNotEqual(benchmark.query_set_id(first), benchmark.query_set_id(subset))
+
+
+class WorkspaceTests(unittest.TestCase):
+    def test_new_run_layout_has_no_local_artifacts_or_managed_state(self) -> None:
         with tempfile.TemporaryDirectory() as temp:
             root = Path(temp)
-            output = root / "generated.dat"
-            log = root / "generate.log"
-            output.write_text("old\n")
-            with self.assertRaises(benchmark.BenchmarkError):
-                benchmark.run_tee(
-                    [sys.executable, "-c", "print('partial'); raise SystemExit(2)"],
-                    log,
-                    stdout_path=output,
-                )
-            self.assertEqual(output.read_text(), "old\n")
-            self.assertFalse((root / "generated.dat.tmp").exists())
-            benchmark.run_tee([sys.executable, "-c", "print('new')"], log, stdout_path=output)
-            self.assertEqual(output.read_text(), "new\n")
+            args = benchmark.make_parser().parse_args(["generate", "--run-root", str(root), "--only", "queries", "--profile", "smoke"])
+            run_dir, manifest = benchmark.prepare_run(args)
+            self.assertEqual(manifest["schema_version"], benchmark.SCHEMA_VERSION)
+            self.assertEqual({path.name for path in run_dir.iterdir()}, {"logs", "results", "manifest.json"})
+            self.assertFalse((run_dir / "queries").exists())
+            self.assertFalse((run_dir / "data").exists())
+            self.assertFalse((run_dir / "greptimedb").exists())
 
-    def test_queries_are_reused_only_for_matching_generation_spec(self) -> None:
-        query_type = "cpu-max-all-1"
+    def test_old_or_malformed_run_manifest_is_rejected(self) -> None:
         with tempfile.TemporaryDirectory() as temp:
             run_dir = Path(temp)
-            (run_dir / "queries").mkdir()
-            (run_dir / "logs").mkdir()
-            output = benchmark.query_path(run_dir, query_type)
-            output.write_text("existing\n", encoding="utf-8")
-            workload = json.loads(json.dumps(benchmark.PROFILES["smoke"]))
-            manifest = {
-                "workload": workload,
-                "query_generation_specs": {
-                    query_type: benchmark.query_generation_spec(workload, query_type),
-                },
-            }
-            with (
-                mock.patch.object(benchmark, "ensure_binaries"),
-                mock.patch.object(benchmark, "run_tee") as run_tee,
-            ):
-                benchmark.generate_queries(run_dir, manifest, [query_type], False, False)
-            run_tee.assert_not_called()
-            self.assertEqual(output.read_text(encoding="utf-8"), "existing\n")
+            (run_dir / "manifest.json").write_text(json.dumps({"run_id": "old"}), encoding="utf-8")
+            args = benchmark.make_parser().parse_args(["generate", "--run-dir", str(run_dir), "--only", "queries"])
+            with self.assertRaisesRegex(benchmark.BenchmarkError, "unsupported"):
+                benchmark.prepare_run(args)
 
-    def test_workload_changes_regenerate_queries_and_update_spec(self) -> None:
-        query_type = "cpu-max-all-1"
-        changes = {
-            "seed": 456,
-            "scale": 20,
-            "start": "2023-06-10T00:00:00Z",
-            "end": "2023-06-13T00:00:00Z",
-            "query_count": 11,
+
+class QuerySetTests(unittest.TestCase):
+    def make_args(self, run_dir: Path, query_root: Path, *types: str) -> argparse.Namespace:
+        values = ["generate", "--run-dir", str(run_dir), "--query-root", str(query_root), "--profile", "smoke", "--only", "queries"]
+        for query_type in types:
+            values.extend(["--query-type", query_type])
+        return benchmark.make_parser().parse_args(values)
+
+    def make_manifest(self, run_dir: Path, args: argparse.Namespace) -> dict:
+        run_dir.mkdir(parents=True, exist_ok=True)
+        (run_dir / "logs").mkdir(); (run_dir / "results").mkdir()
+        manifest = {
+            "schema_version": benchmark.SCHEMA_VERSION, "kind": "greptimedb-run",
+            "run_id": run_dir.name, "created_at": benchmark.utc_now(), "profile": "smoke",
+            "database": "benchmark", "workload": benchmark.build_workload(args),
+            "dataset": {"dataset_id": "data-a", "dataset_path": "/tmp/data-a", "spec": {
+                "use_case": "cpu-only", "start": "2023-06-11T00:00:00Z", "end": "2023-06-12T00:00:00Z",
+                "scale": 10, "seed": 123, "log_interval": "10s",
+            }},
+            "events": {"loads": [], "queries": []},
         }
-        for field, value in changes.items():
-            with self.subTest(field=field), tempfile.TemporaryDirectory() as temp:
-                run_dir = Path(temp)
-                (run_dir / "queries").mkdir()
-                (run_dir / "logs").mkdir()
-                output = benchmark.query_path(run_dir, query_type)
-                output.write_text("stale\n", encoding="utf-8")
-                workload = json.loads(json.dumps(benchmark.PROFILES["smoke"]))
-                old_spec = benchmark.query_generation_spec(workload, query_type)
-                if field == "query_count":
-                    workload["query_counts"][query_type] = value
-                else:
-                    workload[field] = value
-                manifest = {
-                    "workload": workload,
-                    "query_generation_specs": {query_type: old_spec},
-                }
+        benchmark.save_manifest(run_dir, manifest)
+        return manifest
 
-                def write_generated(_command, _log_path, *, stdout_path, **_kwargs):
-                    stdout_path.write_text("fresh\n", encoding="utf-8")
+    def generator(self, _command, log_path, *, stdout_path, **_kwargs):
+        log_path.parent.mkdir(parents=True, exist_ok=True)
+        log_path.write_text("generated\n", encoding="utf-8")
+        stdout_path.parent.mkdir(parents=True, exist_ok=True)
+        stdout_path.write_text(f"query:{stdout_path.stem}\n", encoding="utf-8")
 
-                with (
-                    mock.patch.object(benchmark, "ensure_binaries"),
-                    mock.patch.object(benchmark, "run_tee", side_effect=write_generated) as run_tee,
-                ):
-                    benchmark.generate_queries(run_dir, manifest, [query_type], False, False)
-                run_tee.assert_called_once()
-                self.assertEqual(output.read_text(encoding="utf-8"), "fresh\n")
-                expected = benchmark.query_generation_spec(workload, query_type)
-                self.assertEqual(manifest["query_generation_specs"][query_type], expected)
-                saved = json.loads((run_dir / "manifest.json").read_text(encoding="utf-8"))
-                self.assertEqual(saved["query_generation_specs"][query_type], expected)
+    def checksum(self, path: Path) -> str:
+        if path.name == benchmark.BINARIES["queries"]:
+            return "b" * 64
+        return benchmark._real_sha(path) if hasattr(benchmark, "_real_sha") else ""
 
-    def test_legacy_query_without_generation_spec_is_regenerated(self) -> None:
-        query_type = "cpu-max-all-1"
+    def test_independent_runs_reuse_identical_validated_set(self) -> None:
         with tempfile.TemporaryDirectory() as temp:
-            run_dir = Path(temp)
-            (run_dir / "queries").mkdir()
-            (run_dir / "logs").mkdir()
-            output = benchmark.query_path(run_dir, query_type)
-            output.write_text("legacy\n", encoding="utf-8")
-            workload = json.loads(json.dumps(benchmark.PROFILES["smoke"]))
-            manifest = {"workload": workload}
+            root = Path(temp); query_root = root / "queries"
+            real_sha = benchmark.sha256_file
+            def hashes(path): return "b" * 64 if path.name == benchmark.BINARIES["queries"] else real_sha(path)
+            paths = []
+            for name in ("run-a", "run-b"):
+                run_dir = root / name; args = self.make_args(run_dir, query_root, "lastpoint", "cpu-max-all-1"); manifest = self.make_manifest(run_dir, args)
+                with mock.patch.object(benchmark, "ensure_binaries"), mock.patch.object(benchmark, "run_tee", side_effect=self.generator) as runner, mock.patch.object(benchmark, "sha256_file", side_effect=hashes):
+                    paths.append(benchmark.generate_queries(args, run_dir, manifest))
+                if name == "run-a": self.assertEqual(runner.call_count, 2)
+                else: runner.assert_not_called()
+            self.assertEqual(paths[0], paths[1])
+            self.assertEqual(json.loads((root / "run-b/manifest.json").read_text())["query_set"]["reused"], True)
 
-            def write_generated(_command, _log_path, *, stdout_path, **_kwargs):
-                stdout_path.write_text("fresh\n", encoding="utf-8")
-
-            with (
-                mock.patch.object(benchmark, "ensure_binaries"),
-                mock.patch.object(benchmark, "run_tee", side_effect=write_generated) as run_tee,
-            ):
-                benchmark.generate_queries(run_dir, manifest, [query_type], False, False)
-            run_tee.assert_called_once()
-            self.assertEqual(output.read_text(encoding="utf-8"), "fresh\n")
-            self.assertEqual(
-                manifest["query_generation_specs"][query_type],
-                benchmark.query_generation_spec(workload, query_type),
-            )
-
-    def test_failed_query_regeneration_preserves_previous_spec(self) -> None:
-        query_type = "cpu-max-all-1"
+    def test_failure_is_atomic_and_diagnostics_stay_in_run(self) -> None:
         with tempfile.TemporaryDirectory() as temp:
-            run_dir = Path(temp)
-            (run_dir / "queries").mkdir()
-            (run_dir / "logs").mkdir()
-            output = benchmark.query_path(run_dir, query_type)
-            output.write_text("existing\n", encoding="utf-8")
-            workload = json.loads(json.dumps(benchmark.PROFILES["smoke"]))
-            previous_spec = benchmark.query_generation_spec(workload, query_type)
-            workload["scale"] = 20
-            manifest = {
-                "workload": workload,
-                "query_generation_specs": {query_type: previous_spec},
-            }
-            with (
-                mock.patch.object(benchmark, "ensure_binaries"),
-                mock.patch.object(
-                    benchmark,
-                    "run_tee",
-                    side_effect=benchmark.BenchmarkError("generation failed"),
-                ),
-            ):
-                with self.assertRaises(benchmark.BenchmarkError):
-                    benchmark.generate_queries(run_dir, manifest, [query_type], False, False)
-            self.assertEqual(output.read_text(encoding="utf-8"), "existing\n")
-            self.assertEqual(manifest["query_generation_specs"][query_type], previous_spec)
+            root = Path(temp); run_dir = root / "run"; query_root = root / "queries"
+            args = self.make_args(run_dir, query_root, "lastpoint", "cpu-max-all-1"); manifest = self.make_manifest(run_dir, args)
+            calls = 0
+            def fail_second(command, log_path, *, stdout_path, **kwargs):
+                nonlocal calls; calls += 1; log_path.write_text("generator failed\n", encoding="utf-8")
+                if calls == 2: raise benchmark.BenchmarkError("failed")
+                stdout_path.parent.mkdir(parents=True, exist_ok=True); stdout_path.write_text("partial", encoding="utf-8")
+            with mock.patch.object(benchmark, "ensure_binaries"), mock.patch.object(benchmark, "run_tee", side_effect=fail_second):
+                with self.assertRaises(benchmark.BenchmarkError): benchmark.generate_queries(args, run_dir, manifest)
+            spec = benchmark.query_set_spec(manifest["dataset"], manifest["workload"])
+            self.assertFalse(benchmark.query_set_path(query_root, "data-a", benchmark.query_set_id(spec)).exists())
+            self.assertTrue(any((run_dir / "logs").iterdir()))
+            self.assertFalse(any(query_root.rglob("*.dat")))
+
+    def test_corrupt_manifest_or_artifact_fails_reuse(self) -> None:
+        with tempfile.TemporaryDirectory() as temp:
+            root = Path(temp); run_dir = root / "run"; query_root = root / "queries"
+            args = self.make_args(run_dir, query_root, "lastpoint"); manifest = self.make_manifest(run_dir, args); real_sha = benchmark.sha256_file
+            def hashes(path): return "b" * 64 if path.name == benchmark.BINARIES["queries"] else real_sha(path)
+            with mock.patch.object(benchmark, "ensure_binaries"), mock.patch.object(benchmark, "run_tee", side_effect=self.generator), mock.patch.object(benchmark, "sha256_file", side_effect=hashes):
+                path = benchmark.generate_queries(args, run_dir, manifest)
+            benchmark.query_file_path(path, "lastpoint").write_text("corrupt", encoding="utf-8")
+            with self.assertRaisesRegex(benchmark.BenchmarkError, "checksum mismatch"):
+                benchmark.validate_query_set(path, manifest["query_set"]["spec"])
+
+    def test_each_query_file_executes_once_and_records_checksum(self) -> None:
+        with tempfile.TemporaryDirectory() as temp:
+            root = Path(temp); run_dir = root / "run"; query_root = root / "queries"
+            args = self.make_args(run_dir, query_root, "lastpoint", "cpu-max-all-1"); args.database = "benchmark"; manifest = self.make_manifest(run_dir, args); real_sha = benchmark.sha256_file
+            def hashes(path): return "b" * 64 if path.name == benchmark.BINARIES["queries"] else real_sha(path)
+            with mock.patch.object(benchmark, "ensure_binaries"), mock.patch.object(benchmark, "run_tee", side_effect=self.generator), mock.patch.object(benchmark, "sha256_file", side_effect=hashes):
+                benchmark.generate_queries(args, run_dir, manifest)
+            def execute(_command, log_path, **_kwargs):
+                log_path.write_text("Run complete after 1 queries\nall queries:\nmin: 1ms, mean: 1ms, max: 1ms, count: 1\n", encoding="utf-8")
+            with mock.patch.object(benchmark, "generate_queries", return_value=Path(manifest["query_set"]["query_set_path"])), mock.patch.object(benchmark, "ensure_binaries"), mock.patch.object(benchmark, "run_tee", side_effect=execute) as runner:
+                benchmark.run_queries(args, run_dir, manifest, "http://localhost:4000")
+            self.assertEqual(runner.call_count, 2)
+            self.assertEqual(len(manifest["events"]["queries"]), 2)
+            self.assertTrue(all(event["file_sha256"] for event in manifest["events"]["queries"]))
+
+
+class ManagedDatabaseTests(unittest.TestCase):
+    def args(self, root: Path, mode: str | None = None) -> argparse.Namespace:
+        values = ["load", "--greptime-bin", "/bin/true", "--database-id", "db-a", "--database-root", str(root), "--database", "benchmark"]
+        if mode: values.extend(["--database-mode", mode])
+        if mode == "reset": values.extend(["--confirm-reset", "benchmark"])
+        return benchmark.make_parser().parse_args(values)
+
+    def test_workspace_bind_reuse_reset_and_lock(self) -> None:
+        with tempfile.TemporaryDirectory() as temp:
+            root = Path(temp); args = self.args(root); path, db = benchmark.prepare_database_workspace(args)
+            self.assertEqual({p.name for p in path.iterdir()}, {"manifest.json", "data", "logs"})
+            with benchmark.lock_database(path):
+                with self.assertRaisesRegex(benchmark.BenchmarkError, "locked"):
+                    with benchmark.lock_database(path): pass
+            dataset_a = {"dataset_id": "a", "dataset_path": "/a", "data_path": "/a/data", "format": "influx", "bytes": 1, "sha256": "a", "spec": {"use_case": "cpu-only"}}
+            dataset_b = {**dataset_a, "dataset_id": "b", "sha256": "b"}
+            run_dir = root / "run"; (run_dir / "logs").mkdir(parents=True); (run_dir / "results").mkdir()
+            manifest = {"workload": {"batch_size": 1, "load_workers": 1}, "events": {"loads": [], "queries": []}, "dataset": dataset_a}
+            with mock.patch.object(benchmark, "generate_data", return_value=Path("/a/data")), mock.patch.object(benchmark, "ensure_binaries"), mock.patch.object(benchmark, "run_tee"):
+                benchmark.load_data(args, run_dir, manifest, "http://localhost", True, db, path)
+            db = benchmark.validate_database_manifest(path, "db-a"); self.assertEqual(db["binding"]["dataset_id"], "a")
+            manifest["events"] = {"loads": [], "queries": []}
+            with mock.patch.object(benchmark, "generate_data", return_value=Path("/a/data")), mock.patch.object(benchmark, "ensure_binaries") as build, mock.patch.object(benchmark, "run_tee"):
+                benchmark.load_data(args, run_dir, manifest, "http://localhost", True, db, path)
+            build.assert_not_called(); self.assertEqual(manifest["events"]["loads"][0]["status"], "reused")
+            manifest["dataset"] = dataset_b; manifest["events"] = {"loads": [], "queries": []}
+            with mock.patch.object(benchmark, "generate_data", return_value=Path("/b/data")):
+                with self.assertRaisesRegex(benchmark.BenchmarkError, "different dataset"):
+                    benchmark.load_data(args, run_dir, manifest, "http://localhost", True, db, path)
+            reset = self.args(root, "reset")
+            with mock.patch.object(benchmark, "generate_data", return_value=Path("/b/data")), mock.patch.object(benchmark, "ensure_binaries"), mock.patch.object(benchmark, "run_tee"):
+                benchmark.load_data(reset, run_dir, manifest, "http://localhost", True, db, path)
+            self.assertEqual(benchmark.validate_database_manifest(path)["binding"]["dataset_id"], "b")
+
+    def test_managed_requires_database_id(self) -> None:
+        args = benchmark.make_parser().parse_args(["query", "--greptime-bin", "/bin/true"])
+        benchmark.resolve_database(args)
+        with self.assertRaisesRegex(benchmark.BenchmarkError, "database-id"):
+            benchmark.validate_args(args)
 
 
 if __name__ == "__main__":

--- a/.agents/skills/benchmark-greptimedb/tests/test_benchmark.py
+++ b/.agents/skills/benchmark-greptimedb/tests/test_benchmark.py
@@ -5,6 +5,7 @@ import sys
 import tempfile
 import unittest
 from pathlib import Path
+from unittest import mock
 
 
 SCRIPTS = Path(__file__).resolve().parents[1] / "scripts"
@@ -242,6 +243,125 @@ class RunnerSafetyTests(unittest.TestCase):
             self.assertFalse((root / "generated.dat.tmp").exists())
             benchmark.run_tee([sys.executable, "-c", "print('new')"], log, stdout_path=output)
             self.assertEqual(output.read_text(), "new\n")
+
+    def test_queries_are_reused_only_for_matching_generation_spec(self) -> None:
+        query_type = "cpu-max-all-1"
+        with tempfile.TemporaryDirectory() as temp:
+            run_dir = Path(temp)
+            (run_dir / "queries").mkdir()
+            (run_dir / "logs").mkdir()
+            output = benchmark.query_path(run_dir, query_type)
+            output.write_text("existing\n", encoding="utf-8")
+            workload = json.loads(json.dumps(benchmark.PROFILES["smoke"]))
+            manifest = {
+                "workload": workload,
+                "query_generation_specs": {
+                    query_type: benchmark.query_generation_spec(workload, query_type),
+                },
+            }
+            with (
+                mock.patch.object(benchmark, "ensure_binaries"),
+                mock.patch.object(benchmark, "run_tee") as run_tee,
+            ):
+                benchmark.generate_queries(run_dir, manifest, [query_type], False, False)
+            run_tee.assert_not_called()
+            self.assertEqual(output.read_text(encoding="utf-8"), "existing\n")
+
+    def test_workload_changes_regenerate_queries_and_update_spec(self) -> None:
+        query_type = "cpu-max-all-1"
+        changes = {
+            "seed": 456,
+            "scale": 20,
+            "start": "2023-06-10T00:00:00Z",
+            "end": "2023-06-13T00:00:00Z",
+            "query_count": 11,
+        }
+        for field, value in changes.items():
+            with self.subTest(field=field), tempfile.TemporaryDirectory() as temp:
+                run_dir = Path(temp)
+                (run_dir / "queries").mkdir()
+                (run_dir / "logs").mkdir()
+                output = benchmark.query_path(run_dir, query_type)
+                output.write_text("stale\n", encoding="utf-8")
+                workload = json.loads(json.dumps(benchmark.PROFILES["smoke"]))
+                old_spec = benchmark.query_generation_spec(workload, query_type)
+                if field == "query_count":
+                    workload["query_counts"][query_type] = value
+                else:
+                    workload[field] = value
+                manifest = {
+                    "workload": workload,
+                    "query_generation_specs": {query_type: old_spec},
+                }
+
+                def write_generated(_command, _log_path, *, stdout_path, **_kwargs):
+                    stdout_path.write_text("fresh\n", encoding="utf-8")
+
+                with (
+                    mock.patch.object(benchmark, "ensure_binaries"),
+                    mock.patch.object(benchmark, "run_tee", side_effect=write_generated) as run_tee,
+                ):
+                    benchmark.generate_queries(run_dir, manifest, [query_type], False, False)
+                run_tee.assert_called_once()
+                self.assertEqual(output.read_text(encoding="utf-8"), "fresh\n")
+                expected = benchmark.query_generation_spec(workload, query_type)
+                self.assertEqual(manifest["query_generation_specs"][query_type], expected)
+                saved = json.loads((run_dir / "manifest.json").read_text(encoding="utf-8"))
+                self.assertEqual(saved["query_generation_specs"][query_type], expected)
+
+    def test_legacy_query_without_generation_spec_is_regenerated(self) -> None:
+        query_type = "cpu-max-all-1"
+        with tempfile.TemporaryDirectory() as temp:
+            run_dir = Path(temp)
+            (run_dir / "queries").mkdir()
+            (run_dir / "logs").mkdir()
+            output = benchmark.query_path(run_dir, query_type)
+            output.write_text("legacy\n", encoding="utf-8")
+            workload = json.loads(json.dumps(benchmark.PROFILES["smoke"]))
+            manifest = {"workload": workload}
+
+            def write_generated(_command, _log_path, *, stdout_path, **_kwargs):
+                stdout_path.write_text("fresh\n", encoding="utf-8")
+
+            with (
+                mock.patch.object(benchmark, "ensure_binaries"),
+                mock.patch.object(benchmark, "run_tee", side_effect=write_generated) as run_tee,
+            ):
+                benchmark.generate_queries(run_dir, manifest, [query_type], False, False)
+            run_tee.assert_called_once()
+            self.assertEqual(output.read_text(encoding="utf-8"), "fresh\n")
+            self.assertEqual(
+                manifest["query_generation_specs"][query_type],
+                benchmark.query_generation_spec(workload, query_type),
+            )
+
+    def test_failed_query_regeneration_preserves_previous_spec(self) -> None:
+        query_type = "cpu-max-all-1"
+        with tempfile.TemporaryDirectory() as temp:
+            run_dir = Path(temp)
+            (run_dir / "queries").mkdir()
+            (run_dir / "logs").mkdir()
+            output = benchmark.query_path(run_dir, query_type)
+            output.write_text("existing\n", encoding="utf-8")
+            workload = json.loads(json.dumps(benchmark.PROFILES["smoke"]))
+            previous_spec = benchmark.query_generation_spec(workload, query_type)
+            workload["scale"] = 20
+            manifest = {
+                "workload": workload,
+                "query_generation_specs": {query_type: previous_spec},
+            }
+            with (
+                mock.patch.object(benchmark, "ensure_binaries"),
+                mock.patch.object(
+                    benchmark,
+                    "run_tee",
+                    side_effect=benchmark.BenchmarkError("generation failed"),
+                ),
+            ):
+                with self.assertRaises(benchmark.BenchmarkError):
+                    benchmark.generate_queries(run_dir, manifest, [query_type], False, False)
+            self.assertEqual(output.read_text(encoding="utf-8"), "existing\n")
+            self.assertEqual(manifest["query_generation_specs"][query_type], previous_spec)
 
 
 if __name__ == "__main__":

--- a/.agents/skills/benchmark-greptimedb/tests/test_benchmark.py
+++ b/.agents/skills/benchmark-greptimedb/tests/test_benchmark.py
@@ -17,6 +17,28 @@ import summarize  # noqa: E402
 
 
 class SummaryTests(unittest.TestCase):
+    def test_reused_load_without_log_is_not_a_failure(self) -> None:
+        with tempfile.TemporaryDirectory() as temp:
+            summary = summarize.build_summary(
+                Path(temp),
+                {
+                    "events": {
+                        "loads": [
+                            {
+                                "attempt": 1,
+                                "database": "benchmark",
+                                "database_mode": "reuse",
+                                "status": "reused",
+                            }
+                        ],
+                        "queries": [],
+                    }
+                },
+            )
+
+        self.assertEqual(summary["ingestion_runs"], [])
+        self.assertEqual(summary["failures"], [])
+
     def test_parsers_and_target_identity(self) -> None:
         load = summarize.parse_load_log(
             "loaded 200 metrics in 2.000sec (mean rate 100.00 metrics/sec)\n"

--- a/.agents/skills/benchmark-greptimedb/tests/test_benchmark.py
+++ b/.agents/skills/benchmark-greptimedb/tests/test_benchmark.py
@@ -1,0 +1,178 @@
+from __future__ import annotations
+
+import json
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+SCRIPTS = Path(__file__).resolve().parents[1] / "scripts"
+sys.path.insert(0, str(SCRIPTS))
+
+import benchmark  # noqa: E402
+import summarize  # noqa: E402
+
+
+class SummaryParserTests(unittest.TestCase):
+    def test_parse_load_log_with_metrics_and_rows(self) -> None:
+        parsed = summarize.parse_load_log(
+            """
+Summary:
+loaded 200 metrics in 2.000sec with 2 workers (mean rate 100.00 metrics/sec)
+loaded 40 rows in 2.000sec with 2 workers (mean rate 20.00 rows/sec)
+"""
+        )
+        self.assertEqual(parsed["metrics"], 200)
+        self.assertEqual(parsed["rows"], 40)
+        self.assertEqual(parsed["metrics_per_second"], 100.0)
+        self.assertEqual(parsed["rows_per_second"], 20.0)
+
+    def test_parse_query_uses_final_all_queries_block(self) -> None:
+        parsed = summarize.parse_query_log(
+            """
+After 100 queries with 1 workers:
+all queries:
+min: 1.00ms, med: 2.00ms, mean: 999.00ms, max: 4.00ms, stddev: 1.00ms, sum: 0.1sec, count: 100
+
+Run complete after 10 queries with 1 workers (Overall query rate 3.00 queries/sec):
+all queries       :
+min: 1.00ms, med: 2.00ms, mean: 3.50ms, max: 4.00ms, stddev: 1.00ms, sum: 0.1sec, count: 10
+wall clock time: 1.0sec
+"""
+        )
+        self.assertEqual(parsed, {"mean_milliseconds": 3.5, "count": 10})
+
+    def test_parse_query_rejects_incomplete_log(self) -> None:
+        with self.assertRaises(summarize.SummaryError):
+            summarize.parse_query_log("all queries: mean: 2.00ms")
+
+    def test_weighted_query_summary(self) -> None:
+        with tempfile.TemporaryDirectory() as temp:
+            run_dir = Path(temp)
+            (run_dir / "logs").mkdir()
+            (run_dir / "logs/q1.log").write_text(
+                "Run complete after 2 queries\nall queries:\n"
+                "min: 1ms, med: 1ms, mean: 2.00ms, max: 3ms, stddev: 1ms, sum: 0.1sec, count: 2\n"
+            )
+            (run_dir / "logs/q2.log").write_text(
+                "Run complete after 6 queries\nall queries:\n"
+                "min: 1ms, med: 1ms, mean: 4.00ms, max: 5ms, stddev: 1ms, sum: 0.1sec, count: 6\n"
+            )
+            manifest = {
+                "run_id": "test",
+                "profile": "smoke",
+                "database": "benchmark",
+                "events": {
+                    "loads": [],
+                    "queries": [
+                        {
+                            "query_type": "cpu-max-all-1",
+                            "attempt": 1,
+                            "database": "benchmark",
+                            "log": "logs/q1.log",
+                            "status": "completed",
+                        },
+                        {
+                            "query_type": "cpu-max-all-1",
+                            "attempt": 2,
+                            "database": "benchmark",
+                            "log": "logs/q2.log",
+                            "status": "completed",
+                        },
+                    ],
+                },
+            }
+            summary = summarize.build_summary(run_dir, manifest)
+            query = summary["queries"][0]
+            self.assertEqual(query["repetitions"], 2)
+            self.assertEqual(query["query_count"], 8)
+            self.assertEqual(query["weighted_mean_milliseconds"], 3.5)
+
+
+class RunnerSafetyTests(unittest.TestCase):
+    def test_database_modes(self) -> None:
+        self.assertEqual(
+            benchmark.database_mode_args("create", "bench", None),
+            ["--do-create-db=true", "--do-abort-on-exist=true"],
+        )
+        self.assertEqual(
+            benchmark.database_mode_args("reuse", "bench", None),
+            ["--do-create-db=false"],
+        )
+        self.assertEqual(
+            benchmark.database_mode_args("reset", "bench", "bench"),
+            ["--do-create-db=true"],
+        )
+        with self.assertRaises(benchmark.BenchmarkError):
+            benchmark.database_mode_args("reset", "bench", "other")
+
+    def test_external_load_requires_mode_before_work(self) -> None:
+        args = benchmark.make_parser().parse_args(["load", "--endpoint", "http://localhost:4000"])
+        with self.assertRaisesRegex(benchmark.BenchmarkError, "database-mode"):
+            benchmark.validate_args(args)
+
+    def test_reset_confirmation_is_validated_before_work(self) -> None:
+        args = benchmark.make_parser().parse_args(
+            [
+                "load",
+                "--endpoint",
+                "http://localhost:4000",
+                "--database",
+                "bench",
+                "--database-mode",
+                "reset",
+                "--confirm-reset",
+                "other",
+            ]
+        )
+        with self.assertRaisesRegex(benchmark.BenchmarkError, "exactly match"):
+            benchmark.validate_args(args)
+
+    def test_attempts_are_append_only_per_query_type(self) -> None:
+        events = [
+            {"query_type": "a", "attempt": 1},
+            {"query_type": "a", "attempt": 2},
+            {"query_type": "b", "attempt": 1},
+        ]
+        self.assertEqual(benchmark.next_attempt(events, "a"), 3)
+        self.assertEqual(benchmark.next_attempt(events, "b"), 2)
+
+    def test_manifest_is_valid_json(self) -> None:
+        with tempfile.TemporaryDirectory() as temp:
+            run_dir = Path(temp)
+            benchmark.save_manifest(run_dir, {"run_id": "test"})
+            self.assertEqual(json.loads((run_dir / "manifest.json").read_text())["run_id"], "test")
+
+    def test_build_marker_does_not_trust_an_untracked_binary(self) -> None:
+        with tempfile.TemporaryDirectory() as temp:
+            run_dir = Path(temp)
+            (run_dir / "results").mkdir()
+            target = run_dir / "tsbs_generate_data"
+            target.touch()
+            marker = run_dir / "results" / "built-tsbs_generate_data"
+            self.assertTrue(benchmark.binary_needs_build(run_dir, "tsbs_generate_data", target, False))
+            marker.touch()
+            self.assertFalse(benchmark.binary_needs_build(run_dir, "tsbs_generate_data", target, False))
+            self.assertTrue(benchmark.binary_needs_build(run_dir, "tsbs_generate_data", target, True))
+
+    def test_generated_output_is_replaced_only_after_success(self) -> None:
+        with tempfile.TemporaryDirectory() as temp:
+            root = Path(temp)
+            output = root / "generated.dat"
+            log = root / "generate.log"
+            output.write_text("old\n")
+            with self.assertRaises(benchmark.BenchmarkError):
+                benchmark.run_tee(
+                    [sys.executable, "-c", "print('partial'); raise SystemExit(2)"],
+                    log,
+                    stdout_path=output,
+                )
+            self.assertEqual(output.read_text(), "old\n")
+            self.assertFalse((root / "generated.dat.tmp").exists())
+            benchmark.run_tee([sys.executable, "-c", "print('new')"], log, stdout_path=output)
+            self.assertEqual(output.read_text(), "new\n")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.agents/skills/generate-tsbs-data/SKILL.md
+++ b/.agents/skills/generate-tsbs-data/SKILL.md
@@ -1,17 +1,27 @@
 ---
 name: generate-tsbs-data
-description: Generate, cache, inspect, and verify reusable TSBS benchmark datasets in any tsbs_generate_data format. Use for creating benchmark input, reusing identical data across database benchmarks, preparing multiple serialization variants of one logical workload, or validating cached TSBS data before loading it.
+description: Prepare logical TSBS dataset metadata and generate, cache, inspect, or verify reusable serialized dataset variants. Use for benchmark dataset identity, metadata-only query preparation, shared data generation, multiple database formats, cache inspection, or artifact checksum validation.
 ---
 
 # Generate TSBS Data
 
-Use `scripts/generate.py` for deterministic dataset generation and cache
-validation. Read `references/datasets.md` when choosing profiles, formats, or
-shared cache locations.
+Use `scripts/generate.py` for deterministic logical dataset identity,
+generation, and validation. Read `references/datasets.md` when choosing
+profiles, formats, or shared roots.
+
+## Prepare metadata only
+
+Create or reuse a logical dataset without generating a serialization:
+
+```bash
+python3 .agents/skills/generate-tsbs-data/scripts/generate.py prepare \
+  --profile smoke --dataset-root .benchmarks/datasets
+```
+
+Use this for query-only workflows. A logical dataset may contain only
+`dataset.json`; no format is required.
 
 ## Generate or reuse data
-
-Run the script from the TSBS repository root:
 
 ```bash
 python3 .agents/skills/generate-tsbs-data/scripts/generate.py generate \
@@ -21,18 +31,13 @@ python3 .agents/skills/generate-tsbs-data/scripts/generate.py generate \
   --profile manual --format timescaledb --dataset-root /shared/tsbs-data
 ```
 
-The default cache is `.benchmarks/datasets`. Set `TSBS_DATASET_ROOT` or pass
-`--dataset-root` to share datasets across repositories or machines. Generation
-builds only `tsbs_generate_data` when its binary is missing; pass `--rebuild`
-to rebuild it intentionally.
+The default root is `.benchmarks/datasets`. Set `TSBS_DATASET_ROOT` or pass
+`--dataset-root` to share datasets. Use `--dataset-id` or `--dataset-path`, but
+not both. Existing logical datasets inherit stored settings unless explicit
+overrides conflict. Pass `--regenerate` only to intentionally replace a format
+variant and `--rebuild` only to rebuild the generator.
 
-Use `--dataset-id` to select a named entry under the dataset root or
-`--dataset-path` to select an exact directory. Never pass both. Existing
-datasets inherit their stored workload unless explicit overrides are supplied;
-conflicting overrides fail. Format variants are verified before reuse. Pass
-`--regenerate` only when intentionally replacing a format variant.
-
-## Inspect cached data
+## Inspect and verify
 
 ```bash
 python3 .agents/skills/generate-tsbs-data/scripts/generate.py list
@@ -41,13 +46,7 @@ python3 .agents/skills/generate-tsbs-data/scripts/generate.py verify \
   --dataset-id DATASET_ID --format influx
 ```
 
-Use `--json` when another script needs machine-readable output. Report the
-dataset ID, format, data path, and SHA-256 checksum to callers.
-
-## Share across databases
-
-Keep one logical dataset ID for the same use case, seed, scale, timestamp range,
-and interval. Generate separate format variants only when loaders need distinct
-serialization. GreptimeDB and InfluxDB 3 can both consume the canonical
-`influx` variant; query generation remains the responsibility of each database
-benchmark skill.
+Use `--json` or `--result-file` for machine-readable output. Report the
+dataset ID and specification; for materialized variants also report format,
+data path, byte size, and SHA-256. Database-specific query generation belongs
+to the corresponding benchmark skill.

--- a/.agents/skills/generate-tsbs-data/SKILL.md
+++ b/.agents/skills/generate-tsbs-data/SKILL.md
@@ -1,0 +1,53 @@
+---
+name: generate-tsbs-data
+description: Generate, cache, inspect, and verify reusable TSBS benchmark datasets in any tsbs_generate_data format. Use for creating benchmark input, reusing identical data across database benchmarks, preparing multiple serialization variants of one logical workload, or validating cached TSBS data before loading it.
+---
+
+# Generate TSBS Data
+
+Use `scripts/generate.py` for deterministic dataset generation and cache
+validation. Read `references/datasets.md` when choosing profiles, formats, or
+shared cache locations.
+
+## Generate or reuse data
+
+Run the script from the TSBS repository root:
+
+```bash
+python3 .agents/skills/generate-tsbs-data/scripts/generate.py generate \
+  --profile smoke --format influx
+
+python3 .agents/skills/generate-tsbs-data/scripts/generate.py generate \
+  --profile manual --format timescaledb --dataset-root /shared/tsbs-data
+```
+
+The default cache is `.benchmarks/datasets`. Set `TSBS_DATASET_ROOT` or pass
+`--dataset-root` to share datasets across repositories or machines. Generation
+builds only `tsbs_generate_data` when its binary is missing; pass `--rebuild`
+to rebuild it intentionally.
+
+Use `--dataset-id` to select a named entry under the dataset root or
+`--dataset-path` to select an exact directory. Never pass both. Existing
+datasets inherit their stored workload unless explicit overrides are supplied;
+conflicting overrides fail. Format variants are verified before reuse. Pass
+`--regenerate` only when intentionally replacing a format variant.
+
+## Inspect cached data
+
+```bash
+python3 .agents/skills/generate-tsbs-data/scripts/generate.py list
+python3 .agents/skills/generate-tsbs-data/scripts/generate.py inspect --dataset-id DATASET_ID
+python3 .agents/skills/generate-tsbs-data/scripts/generate.py verify \
+  --dataset-id DATASET_ID --format influx
+```
+
+Use `--json` when another script needs machine-readable output. Report the
+dataset ID, format, data path, and SHA-256 checksum to callers.
+
+## Share across databases
+
+Keep one logical dataset ID for the same use case, seed, scale, timestamp range,
+and interval. Generate separate format variants only when loaders need distinct
+serialization. GreptimeDB and InfluxDB 3 can both consume the canonical
+`influx` variant; query generation remains the responsibility of each database
+benchmark skill.

--- a/.agents/skills/generate-tsbs-data/agents/openai.yaml
+++ b/.agents/skills/generate-tsbs-data/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "Generate TSBS Data"
-  short_description: "Generate and reuse shared TSBS datasets"
-  default_prompt: "Use $generate-tsbs-data to generate or reuse a cached TSBS dataset in the requested format."
+  short_description: "Prepare and generate shared TSBS datasets"
+  default_prompt: "Use $generate-tsbs-data to prepare or generate a validated shared TSBS dataset."

--- a/.agents/skills/generate-tsbs-data/agents/openai.yaml
+++ b/.agents/skills/generate-tsbs-data/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Generate TSBS Data"
+  short_description: "Generate and reuse shared TSBS datasets"
+  default_prompt: "Use $generate-tsbs-data to generate or reuse a cached TSBS dataset in the requested format."

--- a/.agents/skills/generate-tsbs-data/references/datasets.md
+++ b/.agents/skills/generate-tsbs-data/references/datasets.md
@@ -1,0 +1,48 @@
+# TSBS shared dataset reference
+
+## Cache layout
+
+```text
+.benchmarks/datasets/<dataset-id>/
+├── dataset.json
+└── formats/<format>/
+    ├── data
+    ├── generate.log
+    └── manifest.json
+```
+
+The dataset ID identifies logical points and excludes serialization format.
+Its normalized specification contains `use_case`, `seed`, `scale`, `start`,
+`end`, and `log_interval`. Each format directory contains one serialization of
+those points and records its own checksum and generator provenance.
+
+## Profiles
+
+| Setting | `manual` | `smoke` |
+| --- | --- | --- |
+| Start | `2023-06-11T00:00:00Z` | `2023-06-11T00:00:00Z` |
+| End | `2023-06-14T00:00:00Z` | `2023-06-12T00:00:00Z` |
+| Hosts | 4000 | 10 |
+| Seed | 123 | 123 |
+| Interval | 10s | 10s |
+| Use case | cpu-only | cpu-only |
+
+`manual` is the default. Explicit flags override profile values.
+
+## Formats and reuse
+
+Pass any format accepted by `tsbs_generate_data`. The generator remains the
+authoritative format validator. Use the same format variant only when the
+database loader accepts the exact serialization.
+
+GreptimeDB and InfluxDB 3 both use the Influx line-protocol serializer in this
+repository, so both should request `--format influx`. Other databases should
+request their native TSBS format under the same logical dataset ID.
+
+## Safety
+
+- Validate the manifest and SHA-256 checksum before every reuse.
+- Treat `--regenerate` as an explicit replacement of a shared artifact.
+- Publish a new payload only after generation succeeds.
+- Retain generation logs after failures.
+- Keep cached data out of Git; `.benchmarks/` is ignored.

--- a/.agents/skills/generate-tsbs-data/references/datasets.md
+++ b/.agents/skills/generate-tsbs-data/references/datasets.md
@@ -1,6 +1,6 @@
 # TSBS shared dataset reference
 
-## Cache layout
+## Layout and identity
 
 ```text
 .benchmarks/datasets/<dataset-id>/
@@ -11,10 +11,13 @@
     └── manifest.json
 ```
 
-The dataset ID identifies logical points and excludes serialization format.
-Its normalized specification contains `use_case`, `seed`, `scale`, `start`,
-`end`, and `log_interval`. Each format directory contains one serialization of
-those points and records its own checksum and generator provenance.
+Only `dataset.json` is required. Metadata-only preparation deliberately leaves
+`formats/` absent. The dataset ID identifies logical points and excludes
+serialization format. Its canonical specification contains `use_case`,
+`seed`, `scale`, `start`, `end`, and `log_interval`.
+
+Each format directory contains one serialization and records status, byte
+size, SHA-256, generator binary checksum, Git revision, and timestamps.
 
 ## Profiles
 
@@ -29,20 +32,13 @@ those points and records its own checksum and generator provenance.
 
 `manual` is the default. Explicit flags override profile values.
 
-## Formats and reuse
+## Formats and safety
 
-Pass any format accepted by `tsbs_generate_data`. The generator remains the
-authoritative format validator. Use the same format variant only when the
-database loader accepts the exact serialization.
+The generator validates format names. GreptimeDB and InfluxDB 3 consume the
+`influx` variant; other loaders should request their native TSBS format under
+the same logical dataset ID.
 
-GreptimeDB and InfluxDB 3 both use the Influx line-protocol serializer in this
-repository, so both should request `--format influx`. Other databases should
-request their native TSBS format under the same logical dataset ID.
-
-## Safety
-
-- Validate the manifest and SHA-256 checksum before every reuse.
-- Treat `--regenerate` as an explicit replacement of a shared artifact.
-- Publish a new payload only after generation succeeds.
-- Retain generation logs after failures.
-- Keep cached data out of Git; `.benchmarks/` is ignored.
+- Validate the logical manifest and artifact size/checksum before reuse.
+- Publish a replacement payload only after successful generation.
+- Preserve the completed artifact when regeneration fails.
+- Keep cached data outside Git; `.benchmarks/` is ignored.

--- a/.agents/skills/generate-tsbs-data/scripts/generate.py
+++ b/.agents/skills/generate-tsbs-data/scripts/generate.py
@@ -315,6 +315,16 @@ def result(
     }
 
 
+def logical_result(dataset_dir: Path, dataset_manifest: dict[str, Any], *, reused: bool) -> dict[str, Any]:
+    """Return metadata for a logical dataset without requiring a format artifact."""
+    return {
+        "dataset_id": dataset_manifest["dataset_id"],
+        "dataset_path": str(dataset_dir),
+        "spec": dataset_manifest["spec"],
+        "reused": reused,
+    }
+
+
 def prepare_dataset(args: argparse.Namespace) -> tuple[Path, dict[str, Any]]:
     explicit_selection = bool(args.dataset_id or args.dataset_path)
     dataset_dir = resolve_dataset_path(args) if explicit_selection else None
@@ -442,6 +452,19 @@ def make_parser() -> argparse.ArgumentParser:
     generate.add_argument("--result-file", type=Path)
     generate.add_argument("--json", action="store_true")
 
+    prepare = subparsers.add_parser("prepare", help="create or reuse logical dataset metadata only")
+    add_root_options(prepare)
+    add_selection_options(prepare)
+    prepare.add_argument("--profile", choices=sorted(PROFILES))
+    prepare.add_argument("--use-case")
+    prepare.add_argument("--start")
+    prepare.add_argument("--end")
+    prepare.add_argument("--scale", type=int)
+    prepare.add_argument("--seed", type=int)
+    prepare.add_argument("--log-interval")
+    prepare.add_argument("--result-file", type=Path)
+    prepare.add_argument("--json", action="store_true")
+
     list_command = subparsers.add_parser("list", help="list cached logical datasets")
     add_root_options(list_command)
     list_command.add_argument("--json", action="store_true")
@@ -479,6 +502,11 @@ def main(argv: Sequence[str] | None = None) -> int:
                 regenerate=args.regenerate,
                 rebuild=args.rebuild,
             )
+        elif args.command == "prepare":
+            selected_before = resolve_dataset_path(args, logical_spec(args))
+            existed = (selected_before / "dataset.json").is_file()
+            path, manifest = prepare_dataset(args)
+            output = logical_result(path, manifest, reused=existed)
         elif args.command == "list":
             output = list_datasets(args)
         elif args.command == "inspect":

--- a/.agents/skills/generate-tsbs-data/scripts/generate.py
+++ b/.agents/skills/generate-tsbs-data/scripts/generate.py
@@ -1,0 +1,497 @@
+#!/usr/bin/env python3
+"""Generate and manage reusable TSBS benchmark datasets."""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import hashlib
+import json
+import os
+import re
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any, Sequence
+
+
+SCRIPT_PATH = Path(__file__).resolve()
+REPO_ROOT = SCRIPT_PATH.parents[4]
+DEFAULT_DATASET_ROOT = REPO_ROOT / ".benchmarks" / "datasets"
+GENERATOR = REPO_ROOT / "bin" / "tsbs_generate_data"
+SCHEMA_VERSION = 1
+FORMAT_RE = re.compile(r"^[a-z0-9][a-z0-9_-]*$")
+ID_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]*$")
+
+PROFILES = {
+    "manual": {
+        "use_case": "cpu-only",
+        "start": "2023-06-11T00:00:00Z",
+        "end": "2023-06-14T00:00:00Z",
+        "scale": 4000,
+        "seed": 123,
+        "log_interval": "10s",
+    },
+    "smoke": {
+        "use_case": "cpu-only",
+        "start": "2023-06-11T00:00:00Z",
+        "end": "2023-06-12T00:00:00Z",
+        "scale": 10,
+        "seed": 123,
+        "log_interval": "10s",
+    },
+}
+
+
+class DatasetError(RuntimeError):
+    """Raised for an actionable dataset error."""
+
+
+def utc_now() -> str:
+    return dt.datetime.now(dt.timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def canonical_json(value: Any) -> str:
+    return json.dumps(value, sort_keys=True, separators=(",", ":"), ensure_ascii=True)
+
+
+def sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as stream:
+        for chunk in iter(lambda: stream.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def save_json(path: Path, value: Any) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temporary = path.with_name(f"{path.name}.tmp-{os.getpid()}")
+    temporary.write_text(json.dumps(value, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    os.replace(temporary, path)
+
+
+def read_json(path: Path) -> dict[str, Any]:
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except FileNotFoundError as exc:
+        raise DatasetError(f"missing manifest: {path}") from exc
+    except json.JSONDecodeError as exc:
+        raise DatasetError(f"invalid JSON manifest {path}: {exc}") from exc
+    if not isinstance(value, dict):
+        raise DatasetError(f"manifest must be an object: {path}")
+    return value
+
+
+def logical_spec(
+    args: argparse.Namespace,
+    base: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    if args.profile:
+        spec = dict(PROFILES[args.profile])
+    elif base is not None:
+        spec = dict(base)
+    else:
+        spec = dict(PROFILES["manual"])
+    for name in ("use_case", "start", "end", "scale", "seed", "log_interval"):
+        value = getattr(args, name, None)
+        if value is not None:
+            spec[name] = value
+    return spec
+
+
+def automatic_dataset_id(spec: dict[str, Any]) -> str:
+    digest = hashlib.sha256(canonical_json({"schema_version": SCHEMA_VERSION, "spec": spec}).encode()).hexdigest()
+    use_case = re.sub(r"[^a-z0-9]+", "-", str(spec["use_case"]).lower()).strip("-") or "data"
+    return f"{use_case}-s{spec['scale']}-{digest[:12]}"
+
+
+def dataset_root(args: argparse.Namespace) -> Path:
+    configured = args.dataset_root or os.environ.get("TSBS_DATASET_ROOT")
+    return Path(configured).expanduser().resolve() if configured else DEFAULT_DATASET_ROOT
+
+
+def resolve_dataset_path(args: argparse.Namespace, spec: dict[str, Any] | None = None) -> Path:
+    if getattr(args, "dataset_path", None):
+        return args.dataset_path.expanduser().resolve()
+    dataset_id = getattr(args, "dataset_id", None)
+    if dataset_id:
+        if not ID_RE.fullmatch(dataset_id):
+            raise DatasetError("--dataset-id may contain only letters, digits, '.', '_', and '-'")
+    elif spec is not None:
+        dataset_id = automatic_dataset_id(spec)
+    else:
+        raise DatasetError("provide --dataset-id or --dataset-path")
+    return dataset_root(args) / dataset_id
+
+
+def validate_format(format_name: str) -> None:
+    if not FORMAT_RE.fullmatch(format_name):
+        raise DatasetError("--format must contain only lowercase letters, digits, '_' and '-'")
+
+
+def validate_dataset_manifest(dataset_dir: Path, expected_spec: dict[str, Any] | None = None) -> dict[str, Any]:
+    manifest = read_json(dataset_dir / "dataset.json")
+    if manifest.get("schema_version") != SCHEMA_VERSION:
+        raise DatasetError(f"unsupported dataset schema in {dataset_dir / 'dataset.json'}")
+    if not isinstance(manifest.get("spec"), dict):
+        raise DatasetError(f"dataset manifest has no logical specification: {dataset_dir}")
+    if expected_spec is not None and manifest["spec"] != expected_spec:
+        raise DatasetError(f"dataset settings do not match requested workload: {dataset_dir}")
+    return manifest
+
+
+def validate_variant(dataset_dir: Path, format_name: str) -> dict[str, Any]:
+    variant_dir = dataset_dir / "formats" / format_name
+    manifest = read_json(variant_dir / "manifest.json")
+    if manifest.get("status") != "completed":
+        raise DatasetError(f"dataset format variant is not complete: {variant_dir}")
+    if manifest.get("format") != format_name:
+        raise DatasetError(f"dataset format manifest mismatch: {variant_dir}")
+    artifact = variant_dir / str(manifest.get("artifact", "data"))
+    if not artifact.is_file():
+        raise DatasetError(f"missing dataset artifact: {artifact}")
+    actual_size = artifact.stat().st_size
+    actual_checksum = sha256_file(artifact)
+    if actual_size != manifest.get("bytes") or actual_checksum != manifest.get("sha256"):
+        raise DatasetError(f"dataset artifact checksum mismatch: {artifact}")
+    return manifest
+
+
+def command_text(command: Sequence[str]) -> str:
+    return " ".join(subprocess.list2cmdline([part]) for part in command)
+
+
+def run_build(log_path: Path, rebuild: bool) -> None:
+    if GENERATOR.is_file() and not rebuild:
+        return
+    GENERATOR.parent.mkdir(parents=True, exist_ok=True)
+    command = ["go", "build", "-o", str(GENERATOR), "./cmd/tsbs_generate_data"]
+    log_path.parent.mkdir(parents=True, exist_ok=True)
+    with log_path.open("a", encoding="utf-8") as log:
+        header = f"$ {command_text(command)}\n"
+        log.write(header)
+        print(header, end="", file=sys.stderr)
+        process = subprocess.Popen(
+            command,
+            cwd=REPO_ROOT,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            text=True,
+            bufsize=1,
+        )
+        assert process.stdout is not None
+        for line in process.stdout:
+            log.write(line)
+            sys.stderr.write(line)
+        process.stdout.close()
+        if process.wait():
+            raise DatasetError(f"failed to build tsbs_generate_data; see {log_path}")
+
+
+def git_revision() -> str | None:
+    try:
+        return subprocess.run(
+            ["git", "rev-parse", "HEAD"],
+            cwd=REPO_ROOT,
+            check=True,
+            capture_output=True,
+            text=True,
+        ).stdout.strip()
+    except (OSError, subprocess.CalledProcessError):
+        return None
+
+
+def generate_variant(
+    dataset_dir: Path,
+    dataset_manifest: dict[str, Any],
+    format_name: str,
+    *,
+    regenerate: bool,
+    rebuild: bool,
+) -> dict[str, Any]:
+    validate_format(format_name)
+    variant_dir = dataset_dir / "formats" / format_name
+    log_path = variant_dir / "generate.log"
+    artifact = variant_dir / "data"
+    manifest_path = variant_dir / "manifest.json"
+    if manifest_path.exists() and not regenerate:
+        if rebuild:
+            run_build(log_path, True)
+        manifest = validate_variant(dataset_dir, format_name)
+        return result(dataset_dir, dataset_manifest, manifest, reused=True)
+
+    variant_dir.mkdir(parents=True, exist_ok=True)
+    run_build(log_path, rebuild)
+    spec = dataset_manifest["spec"]
+    command = [
+        str(GENERATOR),
+        f"--use-case={spec['use_case']}",
+        f"--seed={spec['seed']}",
+        f"--scale={spec['scale']}",
+        f"--timestamp-start={spec['start']}",
+        f"--timestamp-end={spec['end']}",
+        f"--log-interval={spec['log_interval']}",
+        f"--format={format_name}",
+    ]
+    temporary = artifact.with_name(f"data.tmp-{os.getpid()}")
+    started_at = utc_now()
+    with log_path.open("a", encoding="utf-8") as log:
+        header = f"$ {command_text(command)}\n"
+        log.write(header)
+        print(header, end="", file=sys.stderr)
+        with temporary.open("wb") as output:
+            process = subprocess.Popen(
+                command,
+                cwd=REPO_ROOT,
+                stdout=output,
+                stderr=subprocess.PIPE,
+                text=True,
+                bufsize=1,
+            )
+            assert process.stderr is not None
+            for line in process.stderr:
+                log.write(line)
+                sys.stderr.write(line)
+            process.stderr.close()
+            return_code = process.wait()
+    if return_code:
+        temporary.unlink(missing_ok=True)
+        if not artifact.exists():
+            save_json(
+                manifest_path,
+                {
+                    "schema_version": SCHEMA_VERSION,
+                    "format": format_name,
+                    "status": "failed",
+                    "started_at": started_at,
+                    "finished_at": utc_now(),
+                    "log": "generate.log",
+                },
+            )
+        raise DatasetError(f"tsbs_generate_data failed with exit code {return_code}; see {log_path}")
+
+    checksum = sha256_file(temporary)
+    size = temporary.stat().st_size
+    os.replace(temporary, artifact)
+    manifest = {
+        "schema_version": SCHEMA_VERSION,
+        "format": format_name,
+        "status": "completed",
+        "artifact": "data",
+        "bytes": size,
+        "sha256": checksum,
+        "started_at": started_at,
+        "finished_at": utc_now(),
+        "log": "generate.log",
+        "generator": {
+            "binary": "bin/tsbs_generate_data",
+            "binary_sha256": sha256_file(GENERATOR),
+            "git_revision": git_revision(),
+        },
+    }
+    save_json(manifest_path, manifest)
+    return result(dataset_dir, dataset_manifest, manifest, reused=False)
+
+
+def result(
+    dataset_dir: Path,
+    dataset_manifest: dict[str, Any],
+    variant_manifest: dict[str, Any],
+    *,
+    reused: bool,
+) -> dict[str, Any]:
+    format_name = str(variant_manifest["format"])
+    return {
+        "dataset_id": dataset_manifest["dataset_id"],
+        "dataset_path": str(dataset_dir),
+        "format": format_name,
+        "data_path": str(dataset_dir / "formats" / format_name / str(variant_manifest["artifact"])),
+        "bytes": variant_manifest["bytes"],
+        "sha256": variant_manifest["sha256"],
+        "spec": dataset_manifest["spec"],
+        "reused": reused,
+    }
+
+
+def prepare_dataset(args: argparse.Namespace) -> tuple[Path, dict[str, Any]]:
+    explicit_selection = bool(args.dataset_id or args.dataset_path)
+    dataset_dir = resolve_dataset_path(args) if explicit_selection else None
+    if dataset_dir is not None and (dataset_dir / "dataset.json").exists():
+        manifest = validate_dataset_manifest(dataset_dir)
+        requested = logical_spec(args, manifest["spec"])
+        if requested != manifest["spec"]:
+            raise DatasetError(f"dataset settings do not match requested workload: {dataset_dir}")
+        return dataset_dir, manifest
+
+    spec = logical_spec(args)
+    dataset_dir = dataset_dir or resolve_dataset_path(args, spec)
+    manifest_path = dataset_dir / "dataset.json"
+    dataset_dir.mkdir(parents=True, exist_ok=True)
+    manifest = {
+        "schema_version": SCHEMA_VERSION,
+        "dataset_id": args.dataset_id or automatic_dataset_id(spec),
+        "created_at": utc_now(),
+        "spec": spec,
+    }
+    save_json(manifest_path, manifest)
+    return dataset_dir, manifest
+
+
+def list_datasets(args: argparse.Namespace) -> list[dict[str, Any]]:
+    root = dataset_root(args)
+    if not root.exists():
+        return []
+    datasets: list[dict[str, Any]] = []
+    for path in sorted(root.iterdir()):
+        if not path.is_dir() or not (path / "dataset.json").is_file():
+            continue
+        try:
+            manifest = validate_dataset_manifest(path)
+            formats = []
+            if (path / "formats").is_dir():
+                for child in sorted(path.joinpath("formats").iterdir()):
+                    if not child.is_dir() or not (child / "manifest.json").is_file():
+                        continue
+                    variant_manifest = read_json(child / "manifest.json")
+                    if variant_manifest.get("status") == "completed":
+                        formats.append(child.name)
+            datasets.append(
+                {
+                    "dataset_id": manifest.get("dataset_id", path.name),
+                    "dataset_path": str(path.resolve()),
+                    "spec": manifest["spec"],
+                    "formats": formats,
+                }
+            )
+        except DatasetError:
+            continue
+    return datasets
+
+
+def select_existing(args: argparse.Namespace) -> tuple[Path, dict[str, Any]]:
+    path = resolve_dataset_path(args)
+    return path, validate_dataset_manifest(path)
+
+
+def verify_dataset(args: argparse.Namespace) -> dict[str, Any]:
+    path, manifest = select_existing(args)
+    if args.format:
+        formats = [args.format]
+    else:
+        formats_dir = path / "formats"
+        formats = (
+            sorted(child.name for child in formats_dir.iterdir() if child.is_dir())
+            if formats_dir.exists()
+            else []
+        )
+    if not formats:
+        raise DatasetError(f"dataset has no format variants: {path}")
+    variants = []
+    for format_name in formats:
+        validate_format(format_name)
+        variant = validate_variant(path, format_name)
+        variants.append(result(path, manifest, variant, reused=True))
+    return {"dataset_id": manifest["dataset_id"], "dataset_path": str(path), "variants": variants}
+
+
+def print_output(value: Any, as_json: bool) -> None:
+    if as_json:
+        print(json.dumps(value, sort_keys=True))
+        return
+    if isinstance(value, list):
+        for item in value:
+            print(f"{item['dataset_id']}\t{','.join(item['formats'])}\t{item['dataset_path']}")
+    elif isinstance(value, dict) and "data_path" in value:
+        action = "reused" if value.get("reused") else "generated"
+        print(f"Dataset {action}: {value['dataset_id']} ({value['format']})")
+        print(f"Data: {value['data_path']}")
+        print(f"SHA-256: {value['sha256']}")
+    else:
+        print(json.dumps(value, indent=2, sort_keys=True))
+
+
+def add_root_options(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument("--dataset-root", type=Path)
+
+
+def add_selection_options(parser: argparse.ArgumentParser, required: bool = False) -> None:
+    group = parser.add_mutually_exclusive_group(required=required)
+    group.add_argument("--dataset-id")
+    group.add_argument("--dataset-path", type=Path)
+
+
+def make_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    generate = subparsers.add_parser("generate", help="generate or reuse a format variant")
+    add_root_options(generate)
+    add_selection_options(generate)
+    generate.add_argument("--profile", choices=sorted(PROFILES))
+    generate.add_argument("--format", required=True)
+    generate.add_argument("--use-case")
+    generate.add_argument("--start")
+    generate.add_argument("--end")
+    generate.add_argument("--scale", type=int)
+    generate.add_argument("--seed", type=int)
+    generate.add_argument("--log-interval")
+    generate.add_argument("--regenerate", action="store_true")
+    generate.add_argument("--rebuild", action="store_true")
+    generate.add_argument("--result-file", type=Path)
+    generate.add_argument("--json", action="store_true")
+
+    list_command = subparsers.add_parser("list", help="list cached logical datasets")
+    add_root_options(list_command)
+    list_command.add_argument("--json", action="store_true")
+
+    inspect = subparsers.add_parser("inspect", help="show a logical dataset manifest")
+    add_root_options(inspect)
+    add_selection_options(inspect, required=True)
+    inspect.add_argument("--json", action="store_true")
+
+    verify = subparsers.add_parser("verify", help="verify cached format checksums")
+    add_root_options(verify)
+    add_selection_options(verify, required=True)
+    verify.add_argument("--format")
+    verify.add_argument("--json", action="store_true")
+    return parser
+
+
+def validate_args(args: argparse.Namespace) -> None:
+    if getattr(args, "scale", None) is not None and args.scale <= 0:
+        raise DatasetError("--scale must be positive")
+    if getattr(args, "format", None):
+        validate_format(args.format)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = make_parser().parse_args(argv)
+    try:
+        validate_args(args)
+        if args.command == "generate":
+            path, manifest = prepare_dataset(args)
+            output = generate_variant(
+                path,
+                manifest,
+                args.format,
+                regenerate=args.regenerate,
+                rebuild=args.rebuild,
+            )
+        elif args.command == "list":
+            output = list_datasets(args)
+        elif args.command == "inspect":
+            path, manifest = select_existing(args)
+            output = {**manifest, "dataset_path": str(path)}
+        else:
+            output = verify_dataset(args)
+        if getattr(args, "result_file", None):
+            save_json(args.result_file.resolve(), output)
+        print_output(output, args.json)
+        return 0
+    except (DatasetError, OSError) as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.agents/skills/generate-tsbs-data/scripts/generate.py
+++ b/.agents/skills/generate-tsbs-data/scripts/generate.py
@@ -215,10 +215,12 @@ def generate_variant(
     artifact = variant_dir / "data"
     manifest_path = variant_dir / "manifest.json"
     if manifest_path.exists() and not regenerate:
-        if rebuild:
-            run_build(log_path, True)
-        manifest = validate_variant(dataset_dir, format_name)
-        return result(dataset_dir, dataset_manifest, manifest, reused=True)
+        existing = read_json(manifest_path)
+        if existing.get("status") == "completed":
+            if rebuild:
+                run_build(log_path, True)
+            manifest = validate_variant(dataset_dir, format_name)
+            return result(dataset_dir, dataset_manifest, manifest, reused=True)
 
     variant_dir.mkdir(parents=True, exist_ok=True)
     run_build(log_path, rebuild)

--- a/.agents/skills/generate-tsbs-data/tests/test_generate.py
+++ b/.agents/skills/generate-tsbs-data/tests/test_generate.py
@@ -119,6 +119,28 @@ class DatasetVariantTests(unittest.TestCase):
             self.assertEqual(data_path.read_bytes(), old_data)
             self.assertEqual(manifest_path.read_bytes(), old_manifest)
 
+    def test_failed_initial_generation_can_be_retried_without_regenerate(self) -> None:
+        with tempfile.TemporaryDirectory() as temp:
+            root = Path(temp)
+            bad = self.make_generator(root, "import sys\nprint('partial')\nraise SystemExit(2)\n")
+            dataset_dir, manifest = self.prepare(root)
+            with mock.patch.object(generate, "GENERATOR", bad):
+                with self.assertRaises(generate.DatasetError):
+                    generate.generate_variant(dataset_dir, manifest, "influx", regenerate=False, rebuild=False)
+            manifest_path = dataset_dir / "formats" / "influx" / "manifest.json"
+            failed = json.loads(manifest_path.read_text(encoding="utf-8"))
+            self.assertEqual(failed["status"], "failed")
+
+            good = self.make_generator(root, "print('complete')\n")
+            with mock.patch.object(generate, "GENERATOR", good):
+                retried = generate.generate_variant(
+                    dataset_dir, manifest, "influx", regenerate=False, rebuild=False
+                )
+            self.assertFalse(retried["reused"])
+            self.assertTrue(Path(retried["data_path"]).is_file())
+            completed = json.loads(manifest_path.read_text(encoding="utf-8"))
+            self.assertEqual(completed["status"], "completed")
+
     def test_list_and_verify_report_variants(self) -> None:
         with tempfile.TemporaryDirectory() as temp:
             root = Path(temp)

--- a/.agents/skills/generate-tsbs-data/tests/test_generate.py
+++ b/.agents/skills/generate-tsbs-data/tests/test_generate.py
@@ -56,6 +56,25 @@ class DatasetIdentityTests(unittest.TestCase):
             self.assertEqual(reused["spec"], created["spec"])
             self.assertEqual(reused["spec"]["scale"], 10)
 
+    def test_prepare_creates_metadata_only_logical_dataset(self) -> None:
+        with tempfile.TemporaryDirectory() as temp:
+            result_file = Path(temp) / "result.json"
+            code = generate.main(
+                ["prepare", "--profile", "smoke", "--dataset-root", temp,
+                 "--result-file", str(result_file)]
+            )
+            self.assertEqual(code, 0)
+            result = json.loads(result_file.read_text(encoding="utf-8"))
+            dataset = Path(result["dataset_path"])
+            self.assertTrue((dataset / "dataset.json").is_file())
+            self.assertFalse((dataset / "formats").exists())
+            self.assertNotIn("data_path", result)
+            second = generate.make_parser().parse_args(
+                ["prepare", "--profile", "smoke", "--dataset-root", temp]
+            )
+            selected = generate.resolve_dataset_path(second, generate.logical_spec(second))
+            self.assertTrue((selected / "dataset.json").is_file())
+
 
 class DatasetVariantTests(unittest.TestCase):
     def make_generator(self, root: Path, body: str) -> Path:

--- a/.agents/skills/generate-tsbs-data/tests/test_generate.py
+++ b/.agents/skills/generate-tsbs-data/tests/test_generate.py
@@ -1,0 +1,165 @@
+from __future__ import annotations
+
+import json
+import stat
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+
+SCRIPTS = Path(__file__).resolve().parents[1] / "scripts"
+sys.path.insert(0, str(SCRIPTS))
+
+import generate  # noqa: E402
+
+
+class DatasetIdentityTests(unittest.TestCase):
+    def test_id_is_stable_and_format_independent(self) -> None:
+        spec = dict(generate.PROFILES["smoke"])
+        reordered = dict(reversed(list(spec.items())))
+        self.assertEqual(generate.automatic_dataset_id(spec), generate.automatic_dataset_id(reordered))
+        changed = dict(spec, scale=11)
+        self.assertNotEqual(generate.automatic_dataset_id(spec), generate.automatic_dataset_id(changed))
+
+    def test_dataset_selection_flags_are_mutually_exclusive(self) -> None:
+        with self.assertRaises(SystemExit):
+            generate.make_parser().parse_args(
+                ["generate", "--format", "influx", "--dataset-id", "one", "--dataset-path", "/tmp/two"]
+            )
+
+    def test_existing_named_dataset_rejects_different_settings(self) -> None:
+        with tempfile.TemporaryDirectory() as temp:
+            parser = generate.make_parser()
+            first = parser.parse_args(
+                ["generate", "--format", "influx", "--dataset-root", temp, "--dataset-id", "shared", "--scale", "10"]
+            )
+            generate.prepare_dataset(first)
+            second = parser.parse_args(
+                ["generate", "--format", "influx", "--dataset-root", temp, "--dataset-id", "shared", "--scale", "11"]
+            )
+            with self.assertRaisesRegex(generate.DatasetError, "do not match"):
+                generate.prepare_dataset(second)
+
+    def test_existing_named_dataset_inherits_stored_settings(self) -> None:
+        with tempfile.TemporaryDirectory() as temp:
+            parser = generate.make_parser()
+            first = parser.parse_args(
+                ["generate", "--format", "influx", "--dataset-root", temp, "--dataset-id", "shared", "--profile", "smoke"]
+            )
+            _, created = generate.prepare_dataset(first)
+            second = parser.parse_args(
+                ["generate", "--format", "influx", "--dataset-root", temp, "--dataset-id", "shared"]
+            )
+            _, reused = generate.prepare_dataset(second)
+            self.assertEqual(reused["spec"], created["spec"])
+            self.assertEqual(reused["spec"]["scale"], 10)
+
+
+class DatasetVariantTests(unittest.TestCase):
+    def make_generator(self, root: Path, body: str) -> Path:
+        script = root / "fake-generator"
+        script.write_text("#!/usr/bin/env python3\n" + body, encoding="utf-8")
+        script.chmod(script.stat().st_mode | stat.S_IXUSR)
+        return script
+
+    def prepare(self, root: Path) -> tuple[Path, dict]:
+        args = generate.make_parser().parse_args(
+            ["generate", "--profile", "smoke", "--format", "influx", "--dataset-root", str(root)]
+        )
+        return generate.prepare_dataset(args)
+
+    def test_multiple_formats_share_logical_dataset_and_reuse(self) -> None:
+        with tempfile.TemporaryDirectory() as temp:
+            root = Path(temp)
+            fake = self.make_generator(
+                root,
+                "import sys\n"
+                "print('payload:' + next(a for a in sys.argv if a.startswith('--format=')))\n",
+            )
+            dataset_dir, manifest = self.prepare(root)
+            with mock.patch.object(generate, "GENERATOR", fake):
+                influx = generate.generate_variant(dataset_dir, manifest, "influx", regenerate=False, rebuild=False)
+                timescale = generate.generate_variant(
+                    dataset_dir, manifest, "timescaledb", regenerate=False, rebuild=False
+                )
+                reused = generate.generate_variant(dataset_dir, manifest, "influx", regenerate=False, rebuild=False)
+            self.assertEqual(influx["dataset_id"], timescale["dataset_id"])
+            self.assertFalse(influx["reused"])
+            self.assertTrue(reused["reused"])
+            self.assertNotEqual(influx["sha256"], timescale["sha256"])
+
+    def test_corrupt_artifact_is_rejected(self) -> None:
+        with tempfile.TemporaryDirectory() as temp:
+            root = Path(temp)
+            fake = self.make_generator(root, "print('valid')\n")
+            dataset_dir, manifest = self.prepare(root)
+            with mock.patch.object(generate, "GENERATOR", fake):
+                result = generate.generate_variant(dataset_dir, manifest, "influx", regenerate=False, rebuild=False)
+            Path(result["data_path"]).write_text("corrupt\n", encoding="utf-8")
+            with self.assertRaisesRegex(generate.DatasetError, "checksum mismatch"):
+                generate.validate_variant(dataset_dir, "influx")
+
+    def test_failed_regeneration_preserves_completed_artifact(self) -> None:
+        with tempfile.TemporaryDirectory() as temp:
+            root = Path(temp)
+            good = self.make_generator(root, "print('original')\n")
+            dataset_dir, manifest = self.prepare(root)
+            with mock.patch.object(generate, "GENERATOR", good):
+                original = generate.generate_variant(dataset_dir, manifest, "influx", regenerate=False, rebuild=False)
+            data_path = Path(original["data_path"])
+            manifest_path = data_path.parent / "manifest.json"
+            old_data = data_path.read_bytes()
+            old_manifest = manifest_path.read_bytes()
+            bad = self.make_generator(root, "import sys\nprint('partial')\nraise SystemExit(2)\n")
+            with mock.patch.object(generate, "GENERATOR", bad):
+                with self.assertRaises(generate.DatasetError):
+                    generate.generate_variant(dataset_dir, manifest, "influx", regenerate=True, rebuild=False)
+            self.assertEqual(data_path.read_bytes(), old_data)
+            self.assertEqual(manifest_path.read_bytes(), old_manifest)
+
+    def test_list_and_verify_report_variants(self) -> None:
+        with tempfile.TemporaryDirectory() as temp:
+            root = Path(temp)
+            fake = self.make_generator(root, "print('valid')\n")
+            dataset_dir, manifest = self.prepare(root)
+            with mock.patch.object(generate, "GENERATOR", fake):
+                generate.generate_variant(dataset_dir, manifest, "influx", regenerate=False, rebuild=False)
+            list_args = generate.make_parser().parse_args(["list", "--dataset-root", str(root)])
+            listed = generate.list_datasets(list_args)
+            self.assertEqual(listed[0]["formats"], ["influx"])
+            verify_args = generate.make_parser().parse_args(
+                ["verify", "--dataset-path", str(dataset_dir), "--format", "influx"]
+            )
+            verified = generate.verify_dataset(verify_args)
+            artifact = Path(verified["variants"][0]["data_path"])
+            self.assertEqual(verified["variants"][0]["sha256"], generate.sha256_file(artifact))
+
+    def test_result_file_is_machine_readable(self) -> None:
+        with tempfile.TemporaryDirectory() as temp:
+            root = Path(temp)
+            result_file = root / "result.json"
+            fake = self.make_generator(root, "print('valid')\n")
+            with mock.patch.object(generate, "GENERATOR", fake):
+                code = generate.main(
+                    [
+                        "generate",
+                        "--profile",
+                        "smoke",
+                        "--format",
+                        "influx",
+                        "--dataset-root",
+                        str(root / "datasets"),
+                        "--result-file",
+                        str(result_file),
+                    ]
+                )
+            self.assertEqual(code, 0)
+            result = json.loads(result_file.read_text(encoding="utf-8"))
+            self.assertEqual(result["format"], "influx")
+            self.assertTrue(Path(result["data_path"]).is_file())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,9 @@
 .vscode
 *~
 bin
+.benchmarks/
+__pycache__/
+*.py[cod]
 
 # High Dynamic Range (HDR) Histogram files
 *.hdr

--- a/cmd/tsbs_generate_queries/main.go
+++ b/cmd/tsbs_generate_queries/main.go
@@ -95,6 +95,7 @@ func main() {
 	qg := inputs.NewQueryGenerator(useCaseMatrix)
 	err := qg.Generate(conf)
 	if err != nil {
-		fmt.Printf("error: %v\n", err)
+		fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		os.Exit(1)
 	}
 }


### PR DESCRIPTION
## What changed

- add a repository-scoped `benchmark-greptimedb` Codex skill
- add a standard-library Python runner with build, generate, load, query, summarize, and all stages
- log TSBS ingestion and query output and generate Markdown/JSON performance summaries
- support managed GreptimeDB binaries, existing HTTP endpoints, repeated selected queries, and guarded create/reuse/reset database modes
- build only the TSBS binaries required by each stage
- ignore generated benchmark and Python cache artifacts

## Why

The existing manual benchmark workflow requires many commands and does not consistently preserve raw output or aggregate ingestion speed and per-query mean latency. This makes repeated and query-only GreptimeDB benchmarking harder to reproduce.

## Impact

The skill automates the existing TSBS workflow while retaining stage-level control. External database reuse never drops the database, and reset mode requires an exact confirmation. Generated benchmark artifacts remain under the ignored `.benchmarks/` directory.

The Chinese source manual is intentionally not included in this PR.

## Validation

- `python3 -m unittest discover -s .agents/skills/benchmark-greptimedb/tests -v` — 11 tests passed
- skill `quick_validate.py` — passed
- Python compilation and `git diff --check` — passed
- managed one-day smoke benchmark: 86,400 rows / 864,000 metrics loaded and all 15 query types completed
- repeated query-only run against retained data — passed
- fresh-context skill forward test — passed
