### PR TITLE
Add structured benchmark results

### DIFF
--- a/.agents/skills/benchmark-greptimedb/SKILL.md
+++ b/.agents/skills/benchmark-greptimedb/SKILL.md
@@ -5,7 +5,7 @@ description: Run repeatable GreptimeDB TSBS benchmarks with shared datasets, com
 
 # Benchmark GreptimeDB
 
-Use `scripts/benchmark.py` for execution and log parsing. Read
+Use `scripts/benchmark.py` for execution and structured result parsing. Read
 `references/workload.md` before selecting workload sizes, query types, database
 modes, or shared workspace identifiers. Use `$generate-tsbs-data` for standalone
 dataset generation, inspection, or non-Greptime serialization formats.
@@ -66,7 +66,7 @@ size, and checksum validation.
 
 ## Report results
 
-Read `summary.md` and report the dataset ID and checksum, query-set ID and
+Read `summary.json` and report the dataset ID and checksum, query-set ID and
 manifest checksum, database ID or external target, metrics/second and
 rows/second for ingestion, weighted mean latency per query type, failures and
 their log paths, and the run directory. Preserve failed-run diagnostics.

--- a/.agents/skills/benchmark-greptimedb/scripts/summarize.py
+++ b/.agents/skills/benchmark-greptimedb/scripts/summarize.py
@@ -1,13 +1,18 @@
 #!/usr/bin/env python3
-"""Parse TSBS logs and write GreptimeDB benchmark summaries."""
+"""Parse TSBS results and write GreptimeDB benchmark summaries."""
 
 from __future__ import annotations
 
 import argparse
 import json
+import math
 import re
 from pathlib import Path
-from typing import Any
+from typing import Any, Callable
+
+
+RESULT_FORMAT_VERSION = "0.2"
+LEGACY_RESULT_FORMAT_VERSION = "0.1"
 
 
 METRIC_RE = re.compile(
@@ -26,7 +31,61 @@ QUERY_RE = re.compile(
 
 
 class SummaryError(ValueError):
-    """Raised when a completed TSBS log cannot be parsed."""
+    """Raised when a completed TSBS result or legacy log cannot be parsed."""
+
+
+def _mapping(value: Any, field: str) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        raise SummaryError(f"result field {field} must be an object")
+    return value
+
+
+def _number(value: Any, field: str) -> float:
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        raise SummaryError(f"result field {field} must be a number")
+    result = float(value)
+    if not math.isfinite(result) or result < 0:
+        raise SummaryError(f"result field {field} must be a non-negative finite number")
+    return result
+
+
+def _count(value: Any, field: str) -> int:
+    if isinstance(value, bool) or not isinstance(value, int) or value < 0:
+        raise SummaryError(f"result field {field} must be a non-negative integer")
+    return value
+
+
+def parse_load_result(result: dict[str, Any]) -> dict[str, Any]:
+    totals = _mapping(result.get("Totals"), "Totals")
+    metrics = _count(totals.get("metricCount"), "Totals.metricCount")
+    metric_rate = _number(totals.get("metricRate"), "Totals.metricRate")
+    rows = _count(totals.get("rowCount"), "Totals.rowCount")
+    row_rate = _number(totals.get("rowRate"), "Totals.rowRate")
+    parsed: dict[str, Any] = {
+        "metrics": metrics,
+        "duration_seconds": _number(result.get("DurationMillis"), "DurationMillis") / 1000.0,
+        "metrics_per_second": metric_rate,
+    }
+    if rows > 0:
+        parsed.update({"rows": rows, "rows_per_second": row_rate})
+    return parsed
+
+
+def parse_query_result(result: dict[str, Any]) -> dict[str, Any]:
+    totals = _mapping(result.get("Totals"), "Totals")
+    overall_stats = _mapping(totals.get("overallStats"), "Totals.overallStats")
+    all_queries = _mapping(
+        overall_stats.get("all_queries"), "Totals.overallStats.all_queries"
+    )
+    return {
+        "mean_milliseconds": _number(
+            all_queries.get("meanMilliseconds"),
+            "Totals.overallStats.all_queries.meanMilliseconds",
+        ),
+        "count": _count(
+            all_queries.get("count"), "Totals.overallStats.all_queries.count"
+        ),
+    }
 
 
 def parse_load_log(text: str) -> dict[str, Any]:
@@ -69,6 +128,36 @@ def _read_log(run_dir: Path, relative_path: str) -> str:
     return (run_dir / relative_path).read_text(encoding="utf-8", errors="replace")
 
 
+def _read_event_result(run_dir: Path, event: dict[str, Any]) -> dict[str, Any] | None:
+    relative_path = event.get("results")
+    if not relative_path:
+        return None
+    path = run_dir / relative_path
+    try:
+        result = json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        raise SummaryError(f"malformed result JSON {relative_path}: {exc}") from exc
+    result = _mapping(result, str(relative_path))
+    version = result.get("ResultFormatVersion")
+    if version == LEGACY_RESULT_FORMAT_VERSION:
+        return None
+    if version != RESULT_FORMAT_VERSION:
+        raise SummaryError(f"unsupported result format version {version!r} in {relative_path}")
+    return result
+
+
+def _parse_event(
+    run_dir: Path,
+    event: dict[str, Any],
+    result_parser: Callable[[dict[str, Any]], dict[str, Any]],
+    log_parser: Callable[[str], dict[str, Any]],
+) -> dict[str, Any]:
+    result = _read_event_result(run_dir, event)
+    if result is not None:
+        return result_parser(result)
+    return log_parser(_read_log(run_dir, event["log"]))
+
+
 def build_summary(run_dir: Path, manifest: dict[str, Any]) -> dict[str, Any]:
     failures: list[dict[str, str]] = []
     ingestion_runs: list[dict[str, Any]] = []
@@ -89,7 +178,7 @@ def build_summary(run_dir: Path, manifest: dict[str, Any]) -> dict[str, Any]:
             )
             continue
         try:
-            base.update(parse_load_log(_read_log(run_dir, event["log"])))
+            base.update(_parse_event(run_dir, event, parse_load_result, parse_load_log))
             ingestion_runs.append(base)
         except (OSError, SummaryError) as exc:
             failures.append({"stage": "load", "log": event["log"], "reason": str(exc)})
@@ -107,7 +196,7 @@ def build_summary(run_dir: Path, manifest: dict[str, Any]) -> dict[str, Any]:
             )
             continue
         try:
-            base.update(parse_query_log(_read_log(run_dir, event["log"])))
+            base.update(_parse_event(run_dir, event, parse_query_result, parse_query_log))
             query_runs.append(base)
         except (OSError, SummaryError) as exc:
             failures.append({"stage": "query", "log": event["log"], "reason": str(exc)})

--- a/.agents/skills/benchmark-greptimedb/tests/test_benchmark.py
+++ b/.agents/skills/benchmark-greptimedb/tests/test_benchmark.py
@@ -17,6 +17,11 @@ import summarize  # noqa: E402
 
 
 class SummaryTests(unittest.TestCase):
+    def write_json(self, root: Path, relative: str, value: dict) -> None:
+        path = root / relative
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps(value), encoding="utf-8")
+
     def test_reused_load_without_log_is_not_a_failure(self) -> None:
         with tempfile.TemporaryDirectory() as temp:
             summary = summarize.build_summary(
@@ -39,7 +44,184 @@ class SummaryTests(unittest.TestCase):
         self.assertEqual(summary["ingestion_runs"], [])
         self.assertEqual(summary["failures"], [])
 
+    def test_structured_results_do_not_require_logs(self) -> None:
+        with tempfile.TemporaryDirectory() as temp:
+            run_dir = Path(temp)
+            self.write_json(
+                run_dir,
+                "results/load.json",
+                {
+                    "ResultFormatVersion": "0.2",
+                    "DurationMillis": 2000,
+                    "Totals": {
+                        "metricCount": 200,
+                        "metricRate": 100.0,
+                        "rowCount": 40,
+                        "rowRate": 20.0,
+                    },
+                },
+            )
+            for name, count, mean in (("query-1.json", 10, 2.0), ("query-2.json", 30, 4.0)):
+                self.write_json(
+                    run_dir,
+                    f"results/{name}",
+                    {
+                        "ResultFormatVersion": "0.2",
+                        "DurationMillis": 1000,
+                        "Totals": {
+                            "overallStats": {
+                                "all_queries": {
+                                    "count": count,
+                                    "meanMilliseconds": mean,
+                                }
+                            }
+                        },
+                    },
+                )
+            summary = summarize.build_summary(
+                run_dir,
+                {
+                    "events": {
+                        "loads": [
+                            {
+                                "attempt": 1,
+                                "database": "benchmark",
+                                "database_mode": "create",
+                                "status": "completed",
+                                "log": "logs/missing-load.log",
+                                "results": "results/load.json",
+                            }
+                        ],
+                        "queries": [
+                            {
+                                "query_type": "lastpoint",
+                                "attempt": attempt,
+                                "database": "benchmark",
+                                "status": "completed",
+                                "log": f"logs/missing-query-{attempt}.log",
+                                "results": f"results/query-{attempt}.json",
+                            }
+                            for attempt in (1, 2)
+                        ],
+                    }
+                },
+            )
+
+        self.assertEqual(summary["failures"], [])
+        self.assertEqual(summary["ingestion_runs"][0]["metrics"], 200)
+        self.assertEqual(summary["ingestion_runs"][0]["duration_seconds"], 2.0)
+        self.assertEqual(summary["queries"][0]["query_count"], 40)
+        self.assertEqual(summary["queries"][0]["weighted_mean_milliseconds"], 3.5)
+
+    def test_legacy_result_uses_log_fallback(self) -> None:
+        with tempfile.TemporaryDirectory() as temp:
+            run_dir = Path(temp)
+            self.write_json(
+                run_dir,
+                "results/query.json",
+                {"ResultFormatVersion": "0.1", "Totals": {}},
+            )
+            log = run_dir / "logs/query.log"
+            log.parent.mkdir()
+            log.write_text(
+                "Run complete after 10 queries\nall queries:\n"
+                "min: 1ms, mean: 3.50ms, max: 4ms, count: 10\n",
+                encoding="utf-8",
+            )
+            summary = summarize.build_summary(
+                run_dir,
+                {
+                    "events": {
+                        "loads": [],
+                        "queries": [
+                            {
+                                "query_type": "lastpoint",
+                                "attempt": 1,
+                                "database": "benchmark",
+                                "status": "completed",
+                                "log": "logs/query.log",
+                                "results": "results/query.json",
+                            }
+                        ],
+                    }
+                },
+            )
+
+        self.assertEqual(summary["failures"], [])
+        self.assertEqual(summary["queries"][0]["weighted_mean_milliseconds"], 3.5)
+
+    def test_incomplete_current_result_is_a_failure(self) -> None:
+        with tempfile.TemporaryDirectory() as temp:
+            run_dir = Path(temp)
+            self.write_json(
+                run_dir,
+                "results/query.json",
+                {"ResultFormatVersion": "0.2", "Totals": {"overallStats": {}}},
+            )
+            summary = summarize.build_summary(
+                run_dir,
+                {
+                    "events": {
+                        "loads": [],
+                        "queries": [
+                            {
+                                "query_type": "lastpoint",
+                                "attempt": 1,
+                                "database": "benchmark",
+                                "status": "completed",
+                                "log": "logs/query.log",
+                                "results": "results/query.json",
+                            }
+                        ],
+                    }
+                },
+            )
+
+        self.assertEqual(summary["queries"], [])
+        self.assertIn("all_queries", summary["failures"][0]["reason"])
+        self.assertEqual(summary["failures"][0]["log"], "logs/query.log")
+
+    def test_malformed_current_result_is_a_failure(self) -> None:
+        with tempfile.TemporaryDirectory() as temp:
+            run_dir = Path(temp)
+            result = run_dir / "results/query.json"
+            result.parent.mkdir()
+            result.write_text("{not-json", encoding="utf-8")
+            summary = summarize.build_summary(
+                run_dir,
+                {
+                    "events": {
+                        "loads": [],
+                        "queries": [
+                            {
+                                "query_type": "lastpoint",
+                                "attempt": 1,
+                                "database": "benchmark",
+                                "status": "completed",
+                                "log": "logs/query.log",
+                                "results": "results/query.json",
+                            }
+                        ],
+                    }
+                },
+            )
+
+        self.assertEqual(summary["queries"], [])
+        self.assertIn("malformed result JSON", summary["failures"][0]["reason"])
+
     def test_parsers_and_target_identity(self) -> None:
+        structured_load = summarize.parse_load_result(
+            {
+                "DurationMillis": 2000,
+                "Totals": {
+                    "metricCount": 200,
+                    "metricRate": 100.0,
+                    "rowCount": 0,
+                    "rowRate": 0.0,
+                },
+            }
+        )
+        self.assertNotIn("rows", structured_load)
         load = summarize.parse_load_log(
             "loaded 200 metrics in 2.000sec (mean rate 100.00 metrics/sec)\n"
             "loaded 40 rows in 2.000sec (mean rate 20.00 rows/sec)\n"

--- a/load/loader.go
+++ b/load/loader.go
@@ -153,10 +153,10 @@ func (l *CommonBenchmarkRunner) postRun(wg *sync.WaitGroup, start *time.Time) {
 
 func (l *CommonBenchmarkRunner) saveTestResult(took time.Duration, start time.Time, end time.Time, metricRate, rowRate float64) {
 	totals := make(map[string]interface{})
+	totals["metricCount"] = l.metricCnt
 	totals["metricRate"] = metricRate
-	if l.rowCnt > 0 {
-		totals["rowRate"] = rowRate
-	}
+	totals["rowCount"] = l.rowCnt
+	totals["rowRate"] = rowRate
 
 	testResult := LoaderTestResult{
 		ResultFormatVersion: LoaderTestResultVersion,

--- a/load/loader_test.go
+++ b/load/loader_test.go
@@ -2,14 +2,51 @@ package load
 
 import (
 	"bytes"
+	"encoding/json"
 	"fmt"
-	"github.com/timescale/tsbs/pkg/targets"
+	"os"
+	"path/filepath"
 	"strings"
 	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
+
+	"github.com/timescale/tsbs/pkg/targets"
 )
+
+func TestSaveTestResultIncludesStructuredTotals(t *testing.T) {
+	for _, rows := range []uint64{0, 40} {
+		t.Run(fmt.Sprintf("rows-%d", rows), func(t *testing.T) {
+			resultPath := filepath.Join(t.TempDir(), "result.json")
+			loader := CommonBenchmarkRunner{
+				BenchmarkRunnerConfig: BenchmarkRunnerConfig{ResultsFile: resultPath},
+				metricCnt:             200,
+				rowCnt:                rows,
+			}
+			start := time.Unix(100, 0)
+			loader.saveTestResult(2*time.Second, start, start.Add(2*time.Second), 100, float64(rows)/2)
+
+			contents, err := os.ReadFile(resultPath)
+			if err != nil {
+				t.Fatal(err)
+			}
+			var result LoaderTestResult
+			if err := json.Unmarshal(contents, &result); err != nil {
+				t.Fatal(err)
+			}
+			if result.ResultFormatVersion != "0.2" {
+				t.Fatalf("unexpected result version %q", result.ResultFormatVersion)
+			}
+			if result.Totals["metricCount"] != float64(200) || result.Totals["metricRate"] != float64(100) {
+				t.Fatalf("unexpected metric totals: %#v", result.Totals)
+			}
+			if result.Totals["rowCount"] != float64(rows) || result.Totals["rowRate"] != float64(rows)/2 {
+				t.Fatalf("unexpected row totals: %#v", result.Totals)
+			}
+		})
+	}
+}
 
 type testProcessor struct {
 	worker int

--- a/load/loader_test_result.go
+++ b/load/loader_test_result.go
@@ -1,6 +1,6 @@
 package load
 
-const LoaderTestResultVersion = "0.1"
+const LoaderTestResultVersion = "0.2"
 
 // LoaderTestResult aggregates the results of an insert or load benchmark in a common format across targets
 type LoaderTestResult struct {
@@ -11,7 +11,7 @@ type LoaderTestResult struct {
 	RunnerConfig BenchmarkRunnerConfig `json:"RunnerConfig"`
 
 	// Run info
-	StartTime      int64 `json:"StartTime`
+	StartTime      int64 `json:"StartTime"`
 	EndTime        int64 `json:"EndTime"`
 	DurationMillis int64 `json:"DurationMillis"`
 

--- a/pkg/query/benchmark_result.go
+++ b/pkg/query/benchmark_result.go
@@ -1,6 +1,6 @@
 package query
 
-const BenchmarkTestResultVersion = "0.1"
+const BenchmarkTestResultVersion = "0.2"
 
 // LoaderTestResult aggregates the results of an query benchmark in a common format across targets
 type LoaderTestResult struct {
@@ -11,7 +11,7 @@ type LoaderTestResult struct {
 	RunnerConfig BenchmarkRunnerConfig `json:"RunnerConfig"`
 
 	// Run info
-	StartTime      int64 `json:"StartTime`
+	StartTime      int64 `json:"StartTime"`
 	EndTime        int64 `json:"EndTime"`
 	DurationMillis int64 `json:"DurationMillis"`
 

--- a/pkg/query/stat_processor.go
+++ b/pkg/query/stat_processor.go
@@ -215,6 +215,11 @@ func generateQuantileMap(hist *hdrhistogram.Histogram) (int64, map[string]float6
 	return ops, mp
 }
 
+type queryStatSummary struct {
+	Count            int64   `json:"count"`
+	MeanMilliseconds float64 `json:"meanMilliseconds"`
+}
+
 func (sp *defaultStatProcessor) GetTotalsMap() map[string]interface{} {
 	totals := make(map[string]interface{})
 	// PrewarmQueries tells the StatProcessor whether we're running each query twice to prewarm the cache
@@ -231,6 +236,20 @@ func (sp *defaultStatProcessor) GetTotalsMap() map[string]interface{} {
 		queryRates[stripRegex(label)] = overallQueryRate
 	}
 	totals["overallQueryRates"] = queryRates
+	// Include exact counts and mean latencies so result consumers do not need
+	// to parse the human-readable summary.
+	overallStats := make(map[string]queryStatSummary)
+	for label, statGroup := range sp.statMapping {
+		mean := 0.0
+		if statGroup.count > 0 {
+			mean = statGroup.Mean()
+		}
+		overallStats[stripRegex(label)] = queryStatSummary{
+			Count:            statGroup.count,
+			MeanMilliseconds: mean,
+		}
+	}
+	totals["overallStats"] = overallStats
 	// calculate overall quantiles
 	quantiles := make(map[string]interface{})
 	for label, statGroup := range sp.statMapping {

--- a/pkg/query/stat_processor_test.go
+++ b/pkg/query/stat_processor_test.go
@@ -1,9 +1,47 @@
 package query
 
 import (
+	"encoding/json"
 	"testing"
 	"time"
 )
+
+func TestGetTotalsMapIncludesStructuredStats(t *testing.T) {
+	limit := uint64(10)
+	allQueries := newStatGroup(limit)
+	allQueries.push(2)
+	allQueries.push(4)
+	sp := &defaultStatProcessor{
+		args:      &statProcessorArgs{limit: &limit},
+		startTime: time.Now().Add(-time.Second),
+		statMapping: map[string]*statGroup{
+			labelAllQueries: allQueries,
+		},
+	}
+
+	totals := sp.GetTotalsMap()
+	stats := totals["overallStats"].(map[string]queryStatSummary)
+	all := stats["all_queries"]
+	if all.Count != 2 || all.MeanMilliseconds != 3 {
+		t.Fatalf("unexpected all-query stats: %#v", all)
+	}
+	encoded, err := json.Marshal(totals)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var decoded map[string]interface{}
+	if err := json.Unmarshal(encoded, &decoded); err != nil {
+		t.Fatal(err)
+	}
+	overall := decoded["overallStats"].(map[string]interface{})
+	allJSON := overall["all_queries"].(map[string]interface{})
+	if allJSON["count"] != float64(2) || allJSON["meanMilliseconds"] != float64(3) {
+		t.Fatalf("unexpected JSON stats: %#v", allJSON)
+	}
+	if BenchmarkTestResultVersion != "0.2" {
+		t.Fatalf("unexpected result version %q", BenchmarkTestResultVersion)
+	}
+}
 
 func TestStatProcessorSend(t *testing.T) {
 	s := GetStat()


### PR DESCRIPTION
## What changed

- extend the existing TSBS `--results-file` schema to version `0.2`
- include loader metric/row counts and rates in structured output
- include query counts and mean latency per statistic label
- make the GreptimeDB benchmark skill consume JSON results directly
- retain text-log parsing for legacy `0.1` benchmark runs

## Why

The benchmark skill previously ignored result files and parsed human-readable loader/query output with regular expressions. That made summarization dependent on console formatting even though TSBS already had a JSON result path.

New benchmark runs now use a stable structured contract, while old run directories remain summarizable and logs remain available for diagnostics.

## Validation

- `go test ./load ./pkg/query ./cmd/tsbs_load_greptime ./cmd/tsbs_run_queries_influx`
- `python3 -m unittest discover -s .agents/skills/benchmark-greptimedb/tests -p 'test_*.py'`
- `git diff --check`

The repository-wide `go test ./...` still encounters unrelated failures in existing query-generator expectations and `cmd/tsbs_load_influx2` test compilation.