### PR TITLE
Add InfluxDB 3 benchmark skills

### DIFF
--- a/.agents/skills/benchmark-influxdb3/SKILL.md
+++ b/.agents/skills/benchmark-influxdb3/SKILL.md
@@ -1,0 +1,74 @@
+---
+name: benchmark-influxdb3
+description: Run repeatable InfluxDB 3 Core and Enterprise TSBS benchmarks with shared datasets, immutable SQL query sets, reusable managed instances, external clusters, independent logs, ingestion rates, and query-latency summaries. Use for InfluxDB 3 smoke or performance tests, Core-versus-Enterprise measurements, ingestion tests, query comparisons, or external InfluxDB 3 endpoints.
+---
+
+# Benchmark InfluxDB 3
+
+Use `scripts/benchmark.py` for execution and structured result parsing. Read
+`references/workload.md` before choosing workloads, editions, durability flags,
+or database modes. Use `$setup-influxdb3` to install and prepare a managed
+instance and `$generate-tsbs-data` for standalone dataset operations.
+
+## Collect inputs
+
+1. Select `all`, `generate`, `load`, `query`, or `summarize`.
+2. For load/query stages, select exactly one target:
+   - managed: a prepared `--instance-id`;
+   - external: repeat `--url` for endpoints in one Core instance or Enterprise
+     cluster and pass `--edition core|enterprise`.
+3. Select the database. External loads also require `create`, `reuse`, or an
+   explicitly confirmed `reset`. Never infer reset authorization.
+4. Keep durable writes and atomic batch rejection unless the user explicitly
+   requests `--no-sync` or `--accept-partial`.
+
+## Run benchmarks
+
+Run from the repository root:
+
+```bash
+python3 .agents/skills/benchmark-influxdb3/scripts/benchmark.py all \
+  --profile smoke --instance-id core-311
+
+python3 .agents/skills/benchmark-influxdb3/scripts/benchmark.py all \
+  --profile smoke --url http://127.0.0.1:8181 --edition enterprise \
+  --database-mode create
+
+python3 .agents/skills/benchmark-influxdb3/scripts/benchmark.py query \
+  --profile smoke --url http://127.0.0.1:8181 --edition core \
+  --query-type cpu-max-all-1 --query-type lastpoint
+
+python3 .agents/skills/benchmark-influxdb3/scripts/benchmark.py summarize \
+  --run-dir .benchmarks/influxdb3/runs/RUN_ID
+```
+
+Repeat `--query-type` to define membership; omit it for every supported type.
+Each immutable query file executes once per run. Query-only commands prepare
+logical dataset metadata without generating data. Shared query sets are reused
+only after exact manifest, membership, size, and checksum validation.
+
+## Authenticate external targets
+
+Set `INFLUXDB3_AUTH_TOKEN` for writes and queries and
+`INFLUXDB3_ADMIN_TOKEN` for database lifecycle operations. Override the
+variable names with `--auth-token-env` and `--admin-token-env`. Token values
+must never appear in reports, manifests, or command logs.
+
+For multiple URLs, set query workers to at least the URL count when every node
+must receive queries. The runner health-checks every URL and rejects conflicting
+version, revision, or build metadata, but the user must confirm the URLs belong
+to the same instance or cluster.
+
+## Protect databases
+
+- Reuse matching managed instance bindings without loading duplicate data.
+- Rebind only with `--database-mode reset --confirm-reset DATABASE` after the
+  user explicitly authorizes deletion.
+- Managed instances remain locked while their server is running.
+- External `reuse` may duplicate data; prefer query-only runs after one load.
+
+## Report results
+
+Read `summary.json` and report edition, version, instance or URLs, dataset and
+query-set checksums, durability flags, metrics/second and rows/second, weighted
+mean query latency, failures and log paths, and the run directory.

--- a/.agents/skills/benchmark-influxdb3/SKILL.md
+++ b/.agents/skills/benchmark-influxdb3/SKILL.md
@@ -71,4 +71,7 @@ to the same instance or cluster.
 
 Read `summary.json` and report edition, version, instance or URLs, dataset and
 query-set checksums, durability flags, metrics/second and rows/second, weighted
-mean query latency, failures and log paths, and the run directory.
+mean query latency, server diagnostics, failures and log paths, and the run
+directory. Ordinary server warnings and recoverable errors are diagnostics;
+fatal/panic output, startup failures, unexpected exits, and forced shutdowns
+are benchmark failures.

--- a/.agents/skills/benchmark-influxdb3/SKILL.md
+++ b/.agents/skills/benchmark-influxdb3/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: benchmark-influxdb3
-description: Run repeatable InfluxDB 3 Core and Enterprise TSBS benchmarks with shared datasets, immutable SQL query sets, reusable managed instances, external clusters, independent logs, ingestion rates, and query-latency summaries. Use for InfluxDB 3 smoke or performance tests, Core-versus-Enterprise measurements, ingestion tests, query comparisons, or external InfluxDB 3 endpoints.
+description: Run repeatable InfluxDB 3 Core and Enterprise TSBS benchmarks with shared datasets, immutable SQL query sets, reusable managed database workspaces, external clusters, independent logs, ingestion rates, and query-latency summaries. Use for InfluxDB 3 smoke or performance tests, Core-versus-Enterprise measurements, ingestion tests, query comparisons, or external InfluxDB 3 endpoints.
 ---
 
 # Benchmark InfluxDB 3
@@ -8,13 +8,13 @@ description: Run repeatable InfluxDB 3 Core and Enterprise TSBS benchmarks with 
 Use `scripts/benchmark.py` for execution and structured result parsing. Read
 `references/workload.md` before choosing workloads, editions, durability flags,
 or database modes. Use `$setup-influxdb3` to install and prepare a managed
-instance and `$generate-tsbs-data` for standalone dataset operations.
+database workspace and `$generate-tsbs-data` for standalone dataset operations.
 
 ## Collect inputs
 
 1. Select `all`, `generate`, `load`, `query`, or `summarize`.
 2. For load/query stages, select exactly one target:
-   - managed: a prepared `--instance-id`;
+   - managed: a prepared `--database-id`;
    - external: repeat `--url` for endpoints in one Core instance or Enterprise
      cluster and pass `--edition core|enterprise`.
 3. Select the database. External loads also require `create`, `reuse`, or an
@@ -28,7 +28,7 @@ Run from the repository root:
 
 ```bash
 python3 .agents/skills/benchmark-influxdb3/scripts/benchmark.py all \
-  --profile smoke --instance-id core-311
+  --profile smoke --database-id core-311
 
 python3 .agents/skills/benchmark-influxdb3/scripts/benchmark.py all \
   --profile smoke --url http://127.0.0.1:8181 --edition enterprise \
@@ -61,15 +61,17 @@ to the same instance or cluster.
 
 ## Protect databases
 
-- Reuse matching managed instance bindings without loading duplicate data.
+- Give every managed workspace a stable `--database-id`; `--database-root`
+  defaults to `.benchmarks/influxdb3/databases`.
+- Reuse matching managed database bindings without loading duplicate data.
 - Rebind only with `--database-mode reset --confirm-reset DATABASE` after the
   user explicitly authorizes deletion.
-- Managed instances remain locked while their server is running.
+- Managed database workspaces remain locked while their server is running.
 - External `reuse` may duplicate data; prefer query-only runs after one load.
 
 ## Report results
 
-Read `summary.json` and report edition, version, instance or URLs, dataset and
+Read `summary.json` and report edition, version, database ID or URLs, dataset and
 query-set checksums, durability flags, metrics/second and rows/second, weighted
 mean query latency, server diagnostics, failures and log paths, and the run
 directory. Ordinary server warnings and recoverable errors are diagnostics;

--- a/.agents/skills/benchmark-influxdb3/agents/openai.yaml
+++ b/.agents/skills/benchmark-influxdb3/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Benchmark InfluxDB 3"
+  short_description: "Run reusable InfluxDB 3 TSBS benchmarks"
+  default_prompt: "Use $benchmark-influxdb3 to run a repeatable TSBS benchmark against InfluxDB 3 Core or Enterprise."

--- a/.agents/skills/benchmark-influxdb3/references/workload.md
+++ b/.agents/skills/benchmark-influxdb3/references/workload.md
@@ -44,3 +44,7 @@ least as many query workers as URLs to exercise every endpoint.
 deletes and recreates it only after exact name confirmation. Never compare a
 `--no-sync` or `--accept-partial` run with the durable default without clearly
 labeling the difference.
+
+Before binding a managed instance to a SQL database, the runner verifies that
+its pinned executable starts for `--version` and reports the expected edition
+and exact version. Repair incomplete installations with `$setup-influxdb3`.

--- a/.agents/skills/benchmark-influxdb3/references/workload.md
+++ b/.agents/skills/benchmark-influxdb3/references/workload.md
@@ -8,7 +8,7 @@
 ├── queries/<dataset-id>/influx3/<query-set-id>/...
 └── influxdb3/
     ├── installations/...
-    ├── instances/<instance-id>/{manifest.json,data/,logs/}
+    ├── databases/<database-id>/{manifest.json,data/,logs/}
     └── runs/<run-id>/{manifest.json,logs/,results/,summary.json,summary.md}
 ```
 
@@ -33,8 +33,8 @@ timestamp is the dataset end plus one second.
 
 ## Database and target state
 
-Managed instance manifests pin edition, exact version, binary checksum,
-node/cluster identity, SQL database, and one loaded dataset checksum. External
+Managed database manifests pin the database ID, edition, exact version, binary
+checksum, node/cluster identity, SQL database, and one loaded dataset checksum. External
 targets require an explicit edition and may provide multiple URLs only when all
 URLs address the same Core instance or Enterprise cluster. The runner compares
 available `/ping` version metadata but cannot prove cluster membership. Use at
@@ -45,9 +45,10 @@ deletes and recreates it only after exact name confirmation. Never compare a
 `--no-sync` or `--accept-partial` run with the durable default without clearly
 labeling the difference.
 
-Before binding a managed instance to a SQL database, the runner verifies that
-its pinned executable starts for `--version` and reports the expected edition
-and exact version. Repair incomplete installations with `$setup-influxdb3`.
+Before binding a managed database workspace to a SQL database, the runner
+verifies that its pinned executable starts for `--version` and reports the
+expected edition and exact version. Repair incomplete installations with
+`$setup-influxdb3`.
 
 Each managed-server attempt has its own process log and lifecycle event with
 start, readiness, shutdown, exit-code, and forced/unexpected-exit state. The

--- a/.agents/skills/benchmark-influxdb3/references/workload.md
+++ b/.agents/skills/benchmark-influxdb3/references/workload.md
@@ -1,0 +1,46 @@
+# InfluxDB 3 TSBS workload reference
+
+## Shared workspace
+
+```text
+.benchmarks/
+├── datasets/<dataset-id>/formats/influx/...
+├── queries/<dataset-id>/influx3/<query-set-id>/...
+└── influxdb3/
+    ├── installations/...
+    ├── instances/<instance-id>/{manifest.json,data/,logs/}
+    └── runs/<run-id>/{manifest.json,logs/,results/,summary.json,summary.md}
+```
+
+Both Core and Enterprise consume the same `influx` line-protocol dataset and
+native InfluxDB 3 SQL query set. Reuse identical artifacts, query order,
+workers, batch sizes, and durability flags for comparisons.
+
+## Profiles
+
+| Setting | `manual` (default) | `smoke` |
+| --- | --- | --- |
+| Start | `2023-06-11T00:00:00Z` | `2023-06-11T00:00:00Z` |
+| End | `2023-06-14T00:00:00Z` | `2023-06-12T00:00:00Z` |
+| Hosts | 4000 | 10 |
+| Load workers | 6 | 2 |
+| Query workers | 1 | 1 |
+| Batch size | 3000 | 3000 |
+
+Both use seed `123`, interval `10s`, `cpu-only` data, `devops` queries,
+durable WAL acknowledgement, and rejection of partial batches. The query end
+timestamp is the dataset end plus one second.
+
+## Database and target state
+
+Managed instance manifests pin edition, exact version, binary checksum,
+node/cluster identity, SQL database, and one loaded dataset checksum. External
+targets require an explicit edition and may provide multiple URLs only when all
+URLs address the same Core instance or Enterprise cluster. The runner compares
+available `/ping` version metadata but cannot prove cluster membership. Use at
+least as many query workers as URLs to exercise every endpoint.
+
+`create` aborts if the database exists, `reuse` leaves it intact, and `reset`
+deletes and recreates it only after exact name confirmation. Never compare a
+`--no-sync` or `--accept-partial` run with the durable default without clearly
+labeling the difference.

--- a/.agents/skills/benchmark-influxdb3/references/workload.md
+++ b/.agents/skills/benchmark-influxdb3/references/workload.md
@@ -48,3 +48,10 @@ labeling the difference.
 Before binding a managed instance to a SQL database, the runner verifies that
 its pinned executable starts for `--version` and reports the expected edition
 and exact version. Repair incomplete installations with `$setup-influxdb3`.
+
+Each managed-server attempt has its own process log and lifecycle event with
+start, readiness, shutdown, exit-code, and forced/unexpected-exit state. The
+summary reports capped, email-redacted warning/error/fatal/panic samples.
+Warnings and recoverable errors remain diagnostic; fatal/panic output, startup
+failure, unexpected exit, or forced kill fail the run. Port probes retry briefly
+with address reuse enabled while continuing to reject active listeners.

--- a/.agents/skills/benchmark-influxdb3/scripts/benchmark.py
+++ b/.agents/skills/benchmark-influxdb3/scripts/benchmark.py
@@ -32,7 +32,7 @@ REPO_ROOT = SCRIPT_PATH.parents[4]
 BENCHMARK_ROOT = REPO_ROOT / ".benchmarks"
 DEFAULT_RUN_ROOT = BENCHMARK_ROOT / "influxdb3" / "runs"
 DEFAULT_QUERY_ROOT = BENCHMARK_ROOT / "queries"
-DEFAULT_INSTANCE_ROOT = BENCHMARK_ROOT / "influxdb3" / "instances"
+DEFAULT_DATABASE_ROOT = BENCHMARK_ROOT / "influxdb3" / "databases"
 DEFAULT_DATASET_ROOT = BENCHMARK_ROOT / "datasets"
 DATASET_RUNNER = REPO_ROOT / ".agents" / "skills" / "generate-tsbs-data" / "scripts" / "generate.py"
 DEFAULT_DATABASE = "benchmark"
@@ -405,22 +405,22 @@ def database_mode_args(mode: str, database: str, confirmation: str | None) -> li
 
 
 def database_workspace(args: argparse.Namespace) -> Path:
-    root = (args.instance_root or DEFAULT_INSTANCE_ROOT).expanduser().resolve()
-    return root / args.instance_id
+    root = (args.database_root or DEFAULT_DATABASE_ROOT).expanduser().resolve()
+    return root / args.database_id
 
 
 def validate_database_manifest(path: Path, expected_id: str | None = None) -> dict[str, Any]:
     manifest = read_json(path / "manifest.json")
-    required = {"schema_version", "kind", "instance_id", "edition", "version", "installation_path", "binary_sha256", "node_id", "cluster_id", "license", "database", "binding"}
-    if manifest.get("schema_version") != SCHEMA_VERSION or manifest.get("kind") != "influxdb3-instance" or not required.issubset(manifest):
+    required = {"schema_version", "kind", "database_id", "edition", "version", "installation_path", "binary_sha256", "node_id", "cluster_id", "license", "database", "binding"}
+    if manifest.get("schema_version") != SCHEMA_VERSION or manifest.get("kind") != "influxdb3-database" or not required.issubset(manifest):
         raise BenchmarkError(f"malformed database manifest: {path / 'manifest.json'}")
-    if expected_id is not None and manifest["instance_id"] != expected_id:
+    if expected_id is not None and manifest["database_id"] != expected_id:
         raise BenchmarkError(f"database workspace identity mismatch: {path}")
     if manifest["edition"] not in ("core", "enterprise") or manifest["database"] is not None and not isinstance(manifest["database"], str):
         raise BenchmarkError(f"malformed database manifest: {path / 'manifest.json'}")
     binary = Path(manifest["installation_path"]) / "influxdb3"
     if not binary.is_file() or sha256_file(binary) != manifest["binary_sha256"]:
-        raise BenchmarkError(f"instance binary checksum mismatch: {binary}")
+        raise BenchmarkError(f"database binary checksum mismatch: {binary}")
     binding = manifest["binding"]
     binding_fields = {"dataset_id", "spec", "format", "bytes", "sha256"}
     if binding is not None and (not isinstance(binding, dict) or set(binding) != binding_fields or not isinstance(binding.get("spec"), dict)):
@@ -459,15 +459,15 @@ def preflight_managed_binary(manifest: dict[str, Any]) -> None:
 def prepare_database_workspace(args: argparse.Namespace) -> tuple[Path, dict[str, Any]]:
     path = database_workspace(args); manifest_path = path / "manifest.json"
     if not manifest_path.exists():
-        raise BenchmarkError(f"managed instance is not prepared; use $setup-influxdb3 first: {path}")
-    manifest = validate_database_manifest(path, args.instance_id)
+        raise BenchmarkError(f"managed database is not prepared; use $setup-influxdb3 first: {path}")
+    manifest = validate_database_manifest(path, args.database_id)
     preflight_managed_binary(manifest)
     if manifest["edition"] == "enterprise" and manifest.get("license", {}).get("status") != "active":
-        raise BenchmarkError("managed Enterprise instance does not have an active license")
+        raise BenchmarkError("managed Enterprise database does not have an active license")
     if manifest["database"] is None:
         manifest["database"] = args.database; manifest["updated_at"] = utc_now(); save_json(manifest_path, manifest)
     elif manifest["database"] != args.database:
-        raise BenchmarkError("managed instance is bound to a different SQL database")
+        raise BenchmarkError("managed database workspace is bound to a different SQL database")
     return path, manifest
 
 
@@ -601,7 +601,7 @@ def check_port_available(port: int, timeout: float = 2.0) -> None:
 
 @contextlib.contextmanager
 def connection(args: argparse.Namespace, run_dir: Path, manifest: dict[str, Any]) -> Iterator[tuple[str, bool, dict[str, Any] | None, Path | None]]:
-    if bool(args.instance_id) == bool(args.url): raise BenchmarkError("provide exactly one of --instance-id or --url")
+    if bool(args.database_id) == bool(args.url): raise BenchmarkError("provide exactly one of --database-id or --url")
     if args.url:
         token = os.environ.get(args.auth_token_env, "")
         for url in args.url:
@@ -680,7 +680,7 @@ def add_run_options(parser: argparse.ArgumentParser) -> None:
 
 
 def add_connection_options(parser: argparse.ArgumentParser) -> None:
-    parser.add_argument("--instance-id"); parser.add_argument("--instance-root", type=Path); parser.add_argument("--url", action="append"); parser.add_argument("--edition", choices=("core", "enterprise")); parser.add_argument("--http-port", type=int, default=8181); parser.add_argument("--startup-timeout", type=int, default=60); parser.add_argument("--database", help=f"SQL database name (default: {DEFAULT_DATABASE})"); parser.add_argument("--auth-token-env", default="INFLUXDB3_AUTH_TOKEN"); parser.add_argument("--admin-token-env", default="INFLUXDB3_ADMIN_TOKEN")
+    parser.add_argument("--database-id"); parser.add_argument("--database-root", type=Path); parser.add_argument("--url", action="append"); parser.add_argument("--edition", choices=("core", "enterprise")); parser.add_argument("--http-port", type=int, default=8181); parser.add_argument("--startup-timeout", type=int, default=60); parser.add_argument("--database", help=f"SQL database name (default: {DEFAULT_DATABASE})"); parser.add_argument("--auth-token-env", default="INFLUXDB3_AUTH_TOKEN"); parser.add_argument("--admin-token-env", default="INFLUXDB3_ADMIN_TOKEN")
 
 
 def add_load_options(parser: argparse.ArgumentParser) -> None:
@@ -702,12 +702,12 @@ def validate_args(args: argparse.Namespace) -> None:
     for name in ("scale", "load_workers", "query_workers", "batch_size", "queries"):
         value = getattr(args, name, None)
         if value is not None and value <= 0: raise BenchmarkError(f"--{name.replace('_', '-')} must be positive")
-    for name in ("dataset_id", "instance_id"):
+    for name in ("dataset_id", "database_id"):
         value = getattr(args, name, None)
         if value and not ID_RE.fullmatch(value): raise BenchmarkError(f"--{name.replace('_', '-')} contains invalid characters")
     if args.command in ("load", "query", "all"):
-        if bool(args.instance_id) == bool(args.url): raise BenchmarkError("provide exactly one of --instance-id or --url")
-        if args.instance_id and args.edition: raise BenchmarkError("managed instance edition comes from its manifest; omit --edition")
+        if bool(args.database_id) == bool(args.url): raise BenchmarkError("provide exactly one of --database-id or --url")
+        if args.database_id and args.edition: raise BenchmarkError("managed database edition comes from its manifest; omit --edition")
         if args.url and not args.edition: raise BenchmarkError("external targets require --edition=core|enterprise")
         for url in args.url or []:
             parsed = urllib.parse.urlparse(url)
@@ -736,8 +736,8 @@ def main(argv: Sequence[str] | None = None) -> int:
                 server = {"version": database_manifest.get("version"), "revision": None, "build": None} if managed else probe_servers(args.url, os.environ.get(args.auth_token_env, ""))
                 if previous and server["version"] is None:
                     server = {key: previous.get(key) for key in ("version", "revision", "build")}
-                target = {"mode": "managed" if managed else "external", "urls": endpoint.split(","), "database": args.database, "instance_id": args.instance_id if managed else None, "edition": edition, "version": server["version"], "revision": server["revision"], "build": server["build"], "binary_sha256": database_manifest.get("binary_sha256") if managed else None, "no_sync": getattr(args, "no_sync", previous.get("no_sync", False)), "accept_partial": getattr(args, "accept_partial", previous.get("accept_partial", False))}
-                identity = ("mode", "urls", "database", "instance_id", "edition", "version", "binary_sha256")
+                target = {"mode": "managed" if managed else "external", "urls": endpoint.split(","), "database": args.database, "database_id": args.database_id if managed else None, "edition": edition, "version": server["version"], "revision": server["revision"], "build": server["build"], "binary_sha256": database_manifest.get("binary_sha256") if managed else None, "no_sync": getattr(args, "no_sync", previous.get("no_sync", False)), "accept_partial": getattr(args, "accept_partial", previous.get("accept_partial", False))}
+                identity = ("mode", "urls", "database", "database_id", "edition", "version", "binary_sha256")
                 if args.command in ("load", "all"):
                     identity += ("no_sync", "accept_partial")
                 if previous and any(previous.get(key) != target.get(key) for key in identity):

--- a/.agents/skills/benchmark-influxdb3/scripts/benchmark.py
+++ b/.agents/skills/benchmark-influxdb3/scripts/benchmark.py
@@ -428,11 +428,40 @@ def validate_database_manifest(path: Path, expected_id: str | None = None) -> di
     return manifest
 
 
+def preflight_managed_binary(manifest: dict[str, Any]) -> None:
+    binary = Path(manifest["installation_path"]) / "influxdb3"
+    try:
+        result = subprocess.run(
+            [str(binary), "--version"],
+            cwd=binary.parent,
+            capture_output=True,
+            text=True,
+            timeout=15,
+            check=False,
+        )
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        raise BenchmarkError(
+            f"managed InfluxDB 3 installation is not runnable: {binary}; "
+            f"repair it with $setup-influxdb3 install --edition {manifest['edition']} "
+            f"--version {manifest['version']} --reinstall: {exc}"
+        ) from exc
+    output = f"{result.stdout}\n{result.stderr}"
+    edition_name = "Core" if manifest["edition"] == "core" else "Enterprise"
+    reported = re.search(r"InfluxDB 3 (Core|Enterprise), ([^,\s]+)", output)
+    if result.returncode != 0 or reported is None or reported.groups() != (edition_name, manifest["version"]):
+        raise BenchmarkError(
+            f"managed InfluxDB 3 installation failed version validation; repair it with "
+            f"$setup-influxdb3 install --edition {manifest['edition']} "
+            f"--version {manifest['version']} --reinstall"
+        )
+
+
 def prepare_database_workspace(args: argparse.Namespace) -> tuple[Path, dict[str, Any]]:
     path = database_workspace(args); manifest_path = path / "manifest.json"
     if not manifest_path.exists():
         raise BenchmarkError(f"managed instance is not prepared; use $setup-influxdb3 first: {path}")
     manifest = validate_database_manifest(path, args.instance_id)
+    preflight_managed_binary(manifest)
     if manifest["edition"] == "enterprise" and manifest.get("license", {}).get("status") != "active":
         raise BenchmarkError("managed Enterprise instance does not have an active license")
     if manifest["database"] is None:

--- a/.agents/skills/benchmark-influxdb3/scripts/benchmark.py
+++ b/.agents/skills/benchmark-influxdb3/scripts/benchmark.py
@@ -1,0 +1,680 @@
+#!/usr/bin/env python3
+"""Run InfluxDB 3 TSBS benchmarks using shared, validated artifacts."""
+
+from __future__ import annotations
+
+import argparse
+import contextlib
+import datetime as dt
+import fcntl
+import hashlib
+import json
+import os
+import re
+import shutil
+import signal
+import socket
+import subprocess
+import sys
+import tempfile
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+from pathlib import Path
+from typing import Any, Iterator, Sequence
+
+from summarize import write_summary
+
+
+SCRIPT_PATH = Path(__file__).resolve()
+REPO_ROOT = SCRIPT_PATH.parents[4]
+BENCHMARK_ROOT = REPO_ROOT / ".benchmarks"
+DEFAULT_RUN_ROOT = BENCHMARK_ROOT / "influxdb3" / "runs"
+DEFAULT_QUERY_ROOT = BENCHMARK_ROOT / "queries"
+DEFAULT_INSTANCE_ROOT = BENCHMARK_ROOT / "influxdb3" / "instances"
+DEFAULT_DATASET_ROOT = BENCHMARK_ROOT / "datasets"
+DATASET_RUNNER = REPO_ROOT / ".agents" / "skills" / "generate-tsbs-data" / "scripts" / "generate.py"
+DEFAULT_DATABASE = "benchmark"
+SCHEMA_VERSION = 1
+ID_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]*$")
+DATA_WORKLOAD_OPTIONS = ("start", "end", "scale", "seed", "log_interval")
+
+QUERY_COUNTS_MANUAL = {
+    "cpu-max-all-1": 100, "cpu-max-all-8": 100, "double-groupby-1": 50,
+    "double-groupby-5": 50, "double-groupby-all": 50, "groupby-orderby-limit": 50,
+    "high-cpu-1": 100, "high-cpu-all": 50, "lastpoint": 10,
+    "single-groupby-1-1-1": 100, "single-groupby-1-1-12": 100,
+    "single-groupby-1-8-1": 100, "single-groupby-5-1-1": 100,
+    "single-groupby-5-1-12": 100, "single-groupby-5-8-1": 100,
+}
+QUERY_TYPES = tuple(QUERY_COUNTS_MANUAL)
+PROFILES = {
+    "manual": {
+        "start": "2023-06-11T00:00:00Z", "end": "2023-06-14T00:00:00Z",
+        "scale": 4000, "seed": 123, "log_interval": "10s", "load_workers": 6,
+        "query_workers": 1, "batch_size": 3000, "query_counts": QUERY_COUNTS_MANUAL,
+    },
+    "smoke": {
+        "start": "2023-06-11T00:00:00Z", "end": "2023-06-12T00:00:00Z",
+        "scale": 10, "seed": 123, "log_interval": "10s", "load_workers": 2,
+        "query_workers": 1, "batch_size": 3000,
+        "query_counts": {query_type: 10 for query_type in QUERY_TYPES},
+    },
+}
+BINARIES = {"queries": "tsbs_generate_queries", "load": "tsbs_load_influx3", "query": "tsbs_run_queries_influx3"}
+BUILT_THIS_PROCESS: set[str] = set()
+
+
+class BenchmarkError(RuntimeError):
+    """Raised for an actionable benchmark failure."""
+
+
+def utc_now() -> str:
+    return dt.datetime.now(dt.timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def canonical_json(value: Any) -> str:
+    return json.dumps(value, sort_keys=True, separators=(",", ":"), ensure_ascii=True)
+
+
+def sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as stream:
+        for chunk in iter(lambda: stream.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def save_json(path: Path, value: Any) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temporary = path.with_name(f"{path.name}.tmp-{os.getpid()}")
+    temporary.write_text(json.dumps(value, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    os.replace(temporary, path)
+
+
+def read_json(path: Path) -> dict[str, Any]:
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except FileNotFoundError as exc:
+        raise BenchmarkError(f"missing manifest: {path}") from exc
+    except json.JSONDecodeError as exc:
+        raise BenchmarkError(f"invalid JSON manifest {path}: {exc}") from exc
+    if not isinstance(value, dict):
+        raise BenchmarkError(f"manifest must be an object: {path}")
+    return value
+
+
+def new_run_dir(run_root: Path = DEFAULT_RUN_ROOT) -> Path:
+    run_root.mkdir(parents=True, exist_ok=True)
+    base = dt.datetime.now(dt.timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    candidate = run_root / base
+    suffix = 1
+    while candidate.exists():
+        candidate = run_root / f"{base}-{suffix:02d}"
+        suffix += 1
+    return candidate
+
+
+def add_one_second(timestamp: str) -> str:
+    parsed = dt.datetime.fromisoformat(timestamp.replace("Z", "+00:00"))
+    return (parsed + dt.timedelta(seconds=1)).isoformat().replace("+00:00", "Z")
+
+
+def validate_run_manifest(manifest: dict[str, Any], path: Path) -> None:
+    required = {"schema_version", "kind", "run_id", "created_at", "profile", "workload", "events"}
+    if manifest.get("schema_version") != SCHEMA_VERSION or manifest.get("kind") != "influxdb3-run":
+        raise BenchmarkError(f"unsupported run manifest schema: {path}")
+    if not required.issubset(manifest) or not isinstance(manifest["workload"], dict):
+        raise BenchmarkError(f"malformed run manifest: {path}")
+    events = manifest["events"]
+    if not isinstance(events, dict) or not isinstance(events.get("loads"), list) or not isinstance(events.get("queries"), list):
+        raise BenchmarkError(f"malformed run events: {path}")
+    workload = manifest["workload"]
+    workload_fields = ("start", "end", "scale", "seed", "log_interval", "load_workers", "query_workers", "batch_size", "query_counts")
+    if not all(field in workload for field in workload_fields) or not isinstance(workload["query_counts"], dict):
+        raise BenchmarkError(f"malformed run workload: {path}")
+
+
+def save_manifest(run_dir: Path, manifest: dict[str, Any]) -> None:
+    manifest["updated_at"] = utc_now()
+    save_json(run_dir / "manifest.json", manifest)
+
+
+def resolve_database(args: argparse.Namespace) -> None:
+    if not hasattr(args, "database") or args.database is not None:
+        return
+    args.database = DEFAULT_DATABASE
+    if args.run_dir and (args.run_dir.resolve() / "manifest.json").exists():
+        manifest = read_json(args.run_dir.resolve() / "manifest.json")
+        validate_run_manifest(manifest, args.run_dir.resolve() / "manifest.json")
+        args.database = manifest.get("database", DEFAULT_DATABASE)
+
+
+def prepare_run(args: argparse.Namespace) -> tuple[Path, dict[str, Any]]:
+    run_root = (args.run_root or DEFAULT_RUN_ROOT).expanduser().resolve()
+    run_dir = args.run_dir.expanduser().resolve() if args.run_dir else new_run_dir(run_root)
+    (run_dir / "logs").mkdir(parents=True, exist_ok=True)
+    (run_dir / "results").mkdir(parents=True, exist_ok=True)
+    manifest_path = run_dir / "manifest.json"
+    if manifest_path.exists():
+        manifest = read_json(manifest_path)
+        validate_run_manifest(manifest, manifest_path)
+        workload_options = ("profile", "start", "end", "scale", "seed", "log_interval", "load_workers", "query_workers", "batch_size", "queries", "query_type")
+        if any(getattr(args, name, None) is not None for name in workload_options):
+            requested = build_workload(args, manifest["workload"])
+            if requested != manifest["workload"]:
+                raise BenchmarkError("run workload is immutable; create a new run for different settings")
+    else:
+        profile = args.profile or "manual"
+        manifest = {
+            "schema_version": SCHEMA_VERSION, "kind": "influxdb3-run", "run_id": run_dir.name,
+            "created_at": utc_now(), "profile": profile, "database": getattr(args, "database", DEFAULT_DATABASE),
+            "workload": build_workload(args), "events": {"loads": [], "queries": []},
+        }
+    if hasattr(args, "database") and manifest.get("database") != args.database and manifest_path.exists():
+        raise BenchmarkError("--database conflicts with the database pinned by this run")
+    save_manifest(run_dir, manifest)
+    return run_dir, manifest
+
+
+def build_workload(args: argparse.Namespace, base: dict[str, Any] | None = None) -> dict[str, Any]:
+    if base is not None and not args.profile:
+        workload = json.loads(json.dumps(base))
+    else:
+        workload = json.loads(json.dumps(PROFILES[args.profile or "manual"]))
+    for attr in ("start", "end", "scale", "seed", "log_interval", "load_workers", "query_workers", "batch_size"):
+        value = getattr(args, attr, None)
+        if value is not None:
+            workload[attr] = value
+    selected = sorted(set(args.query_type or workload["query_counts"]))
+    count_override = getattr(args, "queries", None)
+    workload["query_counts"] = {query_type: count_override if count_override is not None else workload["query_counts"][query_type] for query_type in selected}
+    return workload
+
+
+def relative(run_dir: Path, path: Path) -> str:
+    return str(path.relative_to(run_dir))
+
+
+def display_command(command: Sequence[str]) -> str:
+    redacted = []
+    for part in command:
+        if part.startswith(("--auth-token=", "--admin-token=")):
+            part = part.split("=", 1)[0] + "=<redacted>"
+        redacted.append(part)
+    return " ".join(subprocess.list2cmdline([part]) for part in redacted)
+
+
+def run_tee(command: Sequence[str], log_path: Path, *, stdout_path: Path | None = None, append: bool = False) -> None:
+    mode = "a" if append else "w"
+    log_path.parent.mkdir(parents=True, exist_ok=True)
+    with log_path.open(mode, encoding="utf-8") as log:
+        header = f"$ {display_command(command)}\n"
+        log.write(header); log.flush(); print(header, end="")
+        if stdout_path is None:
+            process = subprocess.Popen(command, cwd=REPO_ROOT, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True, bufsize=1)
+            assert process.stdout is not None
+            for line in process.stdout:
+                sys.stdout.write(line); log.write(line)
+            process.stdout.close(); return_code = process.wait()
+        else:
+            stdout_path.parent.mkdir(parents=True, exist_ok=True)
+            temporary_output = stdout_path.with_name(stdout_path.name + ".tmp")
+            with temporary_output.open("wb") as output:
+                process = subprocess.Popen(command, cwd=REPO_ROOT, stdout=output, stderr=subprocess.PIPE, text=True, bufsize=1)
+                assert process.stderr is not None
+                for line in process.stderr:
+                    sys.stdout.write(line); log.write(line)
+                process.stderr.close(); return_code = process.wait()
+        if return_code:
+            if stdout_path is not None:
+                temporary_output.unlink(missing_ok=True)
+            raise BenchmarkError(f"command failed with exit code {return_code}; see {log_path}")
+        if stdout_path is not None:
+            os.replace(temporary_output, stdout_path)
+
+
+def binary_needs_build(run_dir: Path, name: str, target: Path, rebuild: bool) -> bool:
+    marker = run_dir / "results" / f"built-{name}"
+    return name not in BUILT_THIS_PROCESS and (rebuild or not (target.exists() and marker.exists()))
+
+
+def ensure_binaries(run_dir: Path, stages: Sequence[str], rebuild: bool) -> None:
+    for stage in stages:
+        name = BINARIES[stage]; target = REPO_ROOT / "bin" / name
+        marker = run_dir / "results" / f"built-{name}"
+        if not binary_needs_build(run_dir, name, target, rebuild):
+            continue
+        target.parent.mkdir(parents=True, exist_ok=True)
+        run_tee(["go", "build", "-o", str(target), f"./cmd/{name}"], run_dir / "logs" / "build.log", append=True)
+        marker.write_text(utc_now() + "\n", encoding="utf-8"); BUILT_THIS_PROCESS.add(name)
+
+
+def dataset_selection_args(args: argparse.Namespace, manifest: dict[str, Any]) -> list[str]:
+    pinned = manifest.get("dataset")
+    if pinned:
+        pinned_path = Path(pinned["dataset_path"]).resolve()
+        if args.dataset_path and args.dataset_path.resolve() != pinned_path:
+            raise BenchmarkError("--dataset-path conflicts with the dataset pinned by this run")
+        if args.dataset_id and args.dataset_id != pinned["dataset_id"]:
+            raise BenchmarkError("--dataset-id conflicts with the dataset pinned by this run")
+        return ["--dataset-path", str(pinned_path)]
+    if args.dataset_path:
+        return ["--dataset-path", str(args.dataset_path.resolve())]
+    result: list[str] = []
+    if args.dataset_root:
+        result.extend(["--dataset-root", str(args.dataset_root.resolve())])
+    if args.dataset_id:
+        result.extend(["--dataset-id", args.dataset_id])
+    return result
+
+
+def prepare_dataset(args: argparse.Namespace, run_dir: Path, manifest: dict[str, Any], *, materialize: bool) -> dict[str, Any]:
+    workload = manifest["workload"]
+    result_path = run_dir / "results" / ("dataset.json" if materialize else "logical-dataset.json")
+    command = [sys.executable, str(DATASET_RUNNER), "generate" if materialize else "prepare"]
+    if materialize:
+        command.extend(["--format", "influx"])
+    command.extend(["--use-case", "cpu-only", "--result-file", str(result_path), *dataset_selection_args(args, manifest)])
+    if not manifest.get("dataset"):
+        command.extend(["--seed", str(workload["seed"]), "--scale", str(workload["scale"]), "--start", workload["start"], "--end", workload["end"], "--log-interval", workload["log_interval"]])
+    if materialize and args.regenerate:
+        command.append("--regenerate")
+    if materialize and args.rebuild:
+        command.append("--rebuild")
+    run_tee(command, run_dir / "logs" / ("generate-data.log" if materialize else "prepare-dataset.log"))
+    dataset = read_json(result_path)
+    if dataset["spec"].get("use_case") != "cpu-only":
+        raise BenchmarkError("InfluxDB 3 benchmark requires a cpu-only dataset")
+    pinned = manifest.get("dataset")
+    if pinned and pinned.get("dataset_id") != dataset.get("dataset_id"):
+        raise BenchmarkError("prepared dataset differs from the dataset pinned by this run")
+    for name in DATA_WORKLOAD_OPTIONS:
+        workload[name] = dataset["spec"][name]
+    manifest["dataset"] = dataset
+    save_manifest(run_dir, manifest)
+    return dataset
+
+
+def generate_data(args: argparse.Namespace, run_dir: Path, manifest: dict[str, Any]) -> Path:
+    dataset = prepare_dataset(args, run_dir, manifest, materialize=True)
+    return Path(dataset["data_path"])
+
+
+def query_set_spec(dataset: dict[str, Any], workload: dict[str, Any]) -> dict[str, Any]:
+    counts = {name: int(count) for name, count in sorted(workload["query_counts"].items())}
+    return {
+        "dataset": {"dataset_id": dataset["dataset_id"], "spec": dataset["spec"]},
+        "format": "influx3", "use_case": "devops", "seed": workload["seed"],
+        "scale": workload["scale"], "timestamp_start": workload["start"],
+        "timestamp_end": add_one_second(workload["end"]), "query_counts": counts,
+    }
+
+
+def query_set_id(spec: dict[str, Any]) -> str:
+    digest = hashlib.sha256(canonical_json({"schema_version": SCHEMA_VERSION, "spec": spec}).encode()).hexdigest()
+    return f"influx3-{digest[:16]}"
+
+
+def query_set_path(query_root: Path, dataset_id: str, set_id: str) -> Path:
+    return query_root / dataset_id / "influx3" / set_id
+
+
+def query_file_path(query_dir: Path, query_type: str) -> Path:
+    return query_dir / "queries" / f"{query_type}.dat"
+
+
+def validate_query_set(query_dir: Path, expected_spec: dict[str, Any]) -> dict[str, Any]:
+    manifest_path = query_dir / "manifest.json"; manifest = read_json(manifest_path)
+    required = {"schema_version", "kind", "query_set_id", "created_at", "spec", "generator", "files"}
+    if manifest.get("schema_version") != SCHEMA_VERSION or manifest.get("kind") != "influxdb3-query-set" or not required.issubset(manifest):
+        raise BenchmarkError(f"malformed query-set manifest: {manifest_path}")
+    if not isinstance(manifest["spec"], dict) or manifest["spec"] != expected_spec or manifest["query_set_id"] != query_set_id(expected_spec):
+        raise BenchmarkError(f"query-set specification mismatch: {query_dir}")
+    expected_types = set(expected_spec["query_counts"]); files = manifest["files"]
+    if not isinstance(files, dict) or set(files) != expected_types:
+        raise BenchmarkError(f"query-set membership mismatch: {query_dir}")
+    actual_names = {path.stem for path in (query_dir / "queries").glob("*.dat")}
+    if actual_names != expected_types:
+        raise BenchmarkError(f"query-set artifacts do not match membership: {query_dir}")
+    for query_type, metadata in files.items():
+        if not isinstance(metadata, dict) or metadata.get("path") != f"queries/{query_type}.dat" or not isinstance(metadata.get("bytes"), int) or not isinstance(metadata.get("sha256"), str):
+            raise BenchmarkError(f"malformed query artifact metadata: {query_dir}")
+        path = query_file_path(query_dir, query_type)
+        if not path.is_file() or path.stat().st_size != metadata.get("bytes") or sha256_file(path) != metadata.get("sha256"):
+            raise BenchmarkError(f"query artifact checksum mismatch: {path}")
+    return manifest
+
+
+def git_revision() -> str | None:
+    try:
+        return subprocess.run(["git", "rev-parse", "HEAD"], cwd=REPO_ROOT, check=True, capture_output=True, text=True).stdout.strip()
+    except (OSError, subprocess.CalledProcessError):
+        return None
+
+
+def generate_queries(args: argparse.Namespace, run_dir: Path, manifest: dict[str, Any]) -> Path:
+    dataset = manifest.get("dataset") or prepare_dataset(args, run_dir, manifest, materialize=False)
+    spec = query_set_spec(dataset, manifest["workload"]); set_id = query_set_id(spec)
+    root = (args.query_root or DEFAULT_QUERY_ROOT).expanduser().resolve()
+    destination = query_set_path(root, dataset["dataset_id"], set_id)
+    if destination.exists():
+        set_manifest = validate_query_set(destination, spec); reused = True
+    else:
+        ensure_binaries(run_dir, ["queries"], args.rebuild)
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        temporary = Path(tempfile.mkdtemp(prefix=f".{set_id}-", dir=destination.parent))
+        try:
+            files: dict[str, dict[str, Any]] = {}
+            for query_type, count in spec["query_counts"].items():
+                output = query_file_path(temporary, query_type)
+                command = [str(REPO_ROOT / "bin" / BINARIES["queries"]), f"--use-case={spec['use_case']}", f"--seed={spec['seed']}", f"--scale={spec['scale']}", f"--timestamp-start={spec['timestamp_start']}", f"--timestamp-end={spec['timestamp_end']}", f"--queries={count}", f"--query-type={query_type}", f"--format={spec['format']}"]
+                run_tee(command, run_dir / "logs" / f"generate-query-{query_type}.log", stdout_path=output)
+                files[query_type] = {"path": f"queries/{query_type}.dat", "bytes": output.stat().st_size, "sha256": sha256_file(output)}
+            binary = REPO_ROOT / "bin" / BINARIES["queries"]
+            set_manifest = {"schema_version": SCHEMA_VERSION, "kind": "influxdb3-query-set", "query_set_id": set_id, "created_at": utc_now(), "spec": spec, "generator": {"binary": "bin/tsbs_generate_queries", "binary_sha256": sha256_file(binary), "git_revision": git_revision()}, "files": files}
+            save_json(temporary / "manifest.json", set_manifest)
+            try:
+                os.replace(temporary, destination)
+            except OSError:
+                if not destination.exists():
+                    raise
+                validate_query_set(destination, spec)
+            reused = False
+        finally:
+            if temporary.exists():
+                shutil.rmtree(temporary)
+    set_manifest = validate_query_set(destination, spec)
+    manifest_checksum = sha256_file(destination / "manifest.json")
+    pinned = {"query_set_id": set_id, "query_set_path": str(destination), "manifest_sha256": manifest_checksum, "spec": spec, "reused": reused}
+    existing = manifest.get("query_set")
+    if existing and {k: existing.get(k) for k in ("query_set_id", "manifest_sha256", "spec")} != {k: pinned[k] for k in ("query_set_id", "manifest_sha256", "spec")}:
+        raise BenchmarkError("query set conflicts with the query set pinned by this run")
+    manifest["query_set"] = pinned; save_manifest(run_dir, manifest)
+    return destination
+
+
+def database_mode_args(mode: str, database: str, confirmation: str | None) -> list[str]:
+    if mode == "create": return ["--do-create-db=true", "--do-abort-on-exist=true"]
+    if mode == "reuse": return ["--do-create-db=false"]
+    if mode == "reset":
+        if confirmation != database: raise BenchmarkError("reset requires --confirm-reset to exactly match --database")
+        return ["--do-create-db=true"]
+    raise BenchmarkError(f"unknown database mode: {mode}")
+
+
+def database_workspace(args: argparse.Namespace) -> Path:
+    root = (args.instance_root or DEFAULT_INSTANCE_ROOT).expanduser().resolve()
+    return root / args.instance_id
+
+
+def validate_database_manifest(path: Path, expected_id: str | None = None) -> dict[str, Any]:
+    manifest = read_json(path / "manifest.json")
+    required = {"schema_version", "kind", "instance_id", "edition", "version", "installation_path", "binary_sha256", "node_id", "cluster_id", "license", "database", "binding"}
+    if manifest.get("schema_version") != SCHEMA_VERSION or manifest.get("kind") != "influxdb3-instance" or not required.issubset(manifest):
+        raise BenchmarkError(f"malformed database manifest: {path / 'manifest.json'}")
+    if expected_id is not None and manifest["instance_id"] != expected_id:
+        raise BenchmarkError(f"database workspace identity mismatch: {path}")
+    if manifest["edition"] not in ("core", "enterprise") or manifest["database"] is not None and not isinstance(manifest["database"], str):
+        raise BenchmarkError(f"malformed database manifest: {path / 'manifest.json'}")
+    binary = Path(manifest["installation_path"]) / "influxdb3"
+    if not binary.is_file() or sha256_file(binary) != manifest["binary_sha256"]:
+        raise BenchmarkError(f"instance binary checksum mismatch: {binary}")
+    binding = manifest["binding"]
+    binding_fields = {"dataset_id", "spec", "format", "bytes", "sha256"}
+    if binding is not None and (not isinstance(binding, dict) or set(binding) != binding_fields or not isinstance(binding.get("spec"), dict)):
+        raise BenchmarkError(f"malformed database binding: {path / 'manifest.json'}")
+    return manifest
+
+
+def prepare_database_workspace(args: argparse.Namespace) -> tuple[Path, dict[str, Any]]:
+    path = database_workspace(args); manifest_path = path / "manifest.json"
+    if not manifest_path.exists():
+        raise BenchmarkError(f"managed instance is not prepared; use $setup-influxdb3 first: {path}")
+    manifest = validate_database_manifest(path, args.instance_id)
+    if manifest["edition"] == "enterprise" and manifest.get("license", {}).get("status") != "active":
+        raise BenchmarkError("managed Enterprise instance does not have an active license")
+    if manifest["database"] is None:
+        manifest["database"] = args.database; manifest["updated_at"] = utc_now(); save_json(manifest_path, manifest)
+    elif manifest["database"] != args.database:
+        raise BenchmarkError("managed instance is bound to a different SQL database")
+    return path, manifest
+
+
+@contextlib.contextmanager
+def lock_database(path: Path) -> Iterator[None]:
+    descriptor = os.open(path, os.O_RDONLY)
+    try:
+        try: fcntl.flock(descriptor, fcntl.LOCK_EX | fcntl.LOCK_NB)
+        except BlockingIOError as exc: raise BenchmarkError(f"managed database workspace is locked: {path}") from exc
+        yield
+    finally:
+        fcntl.flock(descriptor, fcntl.LOCK_UN); os.close(descriptor)
+
+
+def dataset_binding(dataset: dict[str, Any]) -> dict[str, Any]:
+    return {"dataset_id": dataset["dataset_id"], "spec": dataset["spec"], "format": dataset["format"], "bytes": dataset["bytes"], "sha256": dataset["sha256"]}
+
+
+def next_attempt(events: Sequence[dict[str, Any]], query_type: str | None = None) -> int:
+    matching = [event for event in events if query_type is None or event.get("query_type") == query_type]
+    return max((int(event["attempt"]) for event in matching), default=0) + 1
+
+
+def credential_args(args: argparse.Namespace, *, include_admin: bool) -> list[str]:
+    result: list[str] = []
+    auth = os.environ.get(args.auth_token_env, "") if getattr(args, "auth_token_env", None) else ""
+    admin = os.environ.get(args.admin_token_env, "") if getattr(args, "admin_token_env", None) else ""
+    if auth:
+        result.append(f"--auth-token={auth}")
+    if include_admin and (admin or auth):
+        result.append(f"--admin-token={admin or auth}")
+    return result
+
+
+def load_data(args: argparse.Namespace, run_dir: Path, manifest: dict[str, Any], endpoint: str, managed: bool, database_manifest: dict[str, Any] | None = None, database_path: Path | None = None) -> None:
+    input_path = generate_data(args, run_dir, manifest); dataset = manifest["dataset"]
+    mode = args.database_mode or ("create" if managed else None)
+    if mode is None: raise BenchmarkError("external loads require --database-mode=create|reuse|reset")
+    binding = dataset_binding(dataset)
+    if managed and database_manifest is not None:
+        current = database_manifest["binding"]
+        if current == binding and mode != "reset":
+            manifest["events"]["loads"].append({"attempt": next_attempt(manifest["events"]["loads"]), "database": args.database, "database_mode": "reuse", "status": "reused", "dataset_id": dataset["dataset_id"], "started_at": utc_now(), "finished_at": utc_now()}); save_manifest(run_dir, manifest); return
+        if current is not None and current != binding and mode != "reset":
+            raise BenchmarkError("managed database contains a different dataset; use a confirmed reset to rebind it")
+    ensure_binaries(run_dir, ["load"], args.rebuild)
+    attempt = next_attempt(manifest["events"]["loads"]); log_path = run_dir / "logs" / f"load-run-{attempt:03d}.log"; result_path = run_dir / "results" / f"load-run-{attempt:03d}.json"
+    event = {"attempt": attempt, "database": args.database, "database_mode": mode, "dataset_id": dataset["dataset_id"], "log": relative(run_dir, log_path), "status": "running", "started_at": utc_now()}
+    manifest["events"]["loads"].append(event); save_manifest(run_dir, manifest)
+    workload = manifest["workload"]
+    command = [str(REPO_ROOT / "bin" / BINARIES["load"]), f"--urls={endpoint}", f"--file={input_path}", f"--db-name={args.database}", f"--batch-size={workload['batch_size']}", "--gzip=false", f"--workers={workload['load_workers']}", "--reporting-period=10s", f"--results-file={result_path}", f"--no-sync={str(args.no_sync).lower()}", f"--accept-partial={str(args.accept_partial).lower()}", *credential_args(args, include_admin=True), *database_mode_args(mode, args.database, args.confirm_reset)]
+    try: run_tee(command, log_path)
+    except Exception:
+        event.update(status="failed", finished_at=utc_now()); save_manifest(run_dir, manifest); raise
+    event.update(status="completed", finished_at=utc_now(), results=relative(run_dir, result_path)); save_manifest(run_dir, manifest)
+    if managed and database_manifest is not None and database_path is not None:
+        database_manifest["binding"] = binding; database_manifest["updated_at"] = utc_now(); save_json(database_path / "manifest.json", database_manifest)
+
+
+def run_queries(args: argparse.Namespace, run_dir: Path, manifest: dict[str, Any], endpoint: str, database_manifest: dict[str, Any] | None = None) -> None:
+    query_dir = generate_queries(args, run_dir, manifest); set_manifest = validate_query_set(query_dir, manifest["query_set"]["spec"])
+    if database_manifest is not None:
+        binding = database_manifest.get("binding")
+        if binding is None or binding["dataset_id"] != manifest["dataset"]["dataset_id"] or binding["spec"] != manifest["dataset"]["spec"]:
+            raise BenchmarkError("managed database is not loaded with the query set's dataset")
+    ensure_binaries(run_dir, ["query"], args.rebuild); workload = manifest["workload"]
+    for query_type in set_manifest["spec"]["query_counts"]:
+        attempt = next_attempt(manifest["events"]["queries"], query_type); log_path = run_dir / "logs" / f"query-{query_type}-run-{attempt:03d}.log"; result_path = run_dir / "results" / f"query-{query_type}-run-{attempt:03d}.json"
+        metadata = set_manifest["files"][query_type]
+        event = {"query_type": query_type, "attempt": attempt, "database": args.database, "query_set_id": set_manifest["query_set_id"], "file": metadata["path"], "file_bytes": metadata["bytes"], "file_sha256": metadata["sha256"], "log": relative(run_dir, log_path), "status": "running", "started_at": utc_now()}
+        manifest["events"]["queries"].append(event); save_manifest(run_dir, manifest)
+        command = [str(REPO_ROOT / "bin" / BINARIES["query"]), f"--file={query_file_path(query_dir, query_type)}", f"--db-name={args.database}", f"--urls={endpoint}", f"--workers={workload['query_workers']}", "--print-interval=0", f"--results-file={result_path}", *credential_args(args, include_admin=False)]
+        try: run_tee(command, log_path)
+        except Exception:
+            event.update(status="failed", finished_at=utc_now()); save_manifest(run_dir, manifest); raise
+        event.update(status="completed", finished_at=utc_now(), results=relative(run_dir, result_path)); save_manifest(run_dir, manifest)
+
+
+def endpoint_ready(endpoint: str, token: str = "") -> bool:
+    headers = {"Authorization": f"Bearer {token}"} if token else {}
+    request = urllib.request.Request(endpoint.rstrip("/") + "/health", headers=headers)
+    try:
+        with urllib.request.urlopen(request, timeout=2) as response: return response.status == 200
+    except (OSError, urllib.error.URLError): return False
+
+
+def probe_server(endpoint: str, token: str = "") -> dict[str, Any]:
+    headers = {"Authorization": f"Bearer {token}"} if token else {}
+    request = urllib.request.Request(endpoint.rstrip("/") + "/ping", headers=headers)
+    try:
+        with urllib.request.urlopen(request, timeout=3) as response:
+            body = json.loads(response.read().decode("utf-8"))
+            if not isinstance(body, dict): body = {}
+            return {
+                "version": body.get("version") or response.headers.get("x-influxdb-version"),
+                "revision": body.get("revision"),
+                "build": response.headers.get("x-influxdb-build"),
+            }
+    except (OSError, urllib.error.URLError, json.JSONDecodeError):
+        return {"version": None, "revision": None, "build": None}
+
+
+def probe_servers(urls: Sequence[str], token: str = "") -> dict[str, Any]:
+    probes = [probe_server(url, token) for url in urls]
+    for field in ("version", "revision", "build"):
+        known = {probe[field] for probe in probes if probe[field] is not None}
+        if len(known) > 1:
+            raise BenchmarkError(f"external InfluxDB 3 endpoints report different {field} values")
+    return {
+        field: next((probe[field] for probe in probes if probe[field] is not None), None)
+        for field in ("version", "revision", "build")
+    }
+
+
+def check_port_available(port: int) -> None:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        try: sock.bind(("127.0.0.1", port))
+        except OSError as exc: raise BenchmarkError(f"managed InfluxDB 3 HTTP port {port} is unavailable") from exc
+
+
+@contextlib.contextmanager
+def connection(args: argparse.Namespace, run_dir: Path) -> Iterator[tuple[str, bool, dict[str, Any] | None, Path | None]]:
+    if bool(args.instance_id) == bool(args.url): raise BenchmarkError("provide exactly one of --instance-id or --url")
+    if args.url:
+        token = os.environ.get(args.auth_token_env, "")
+        for url in args.url:
+            if not endpoint_ready(url, token): raise BenchmarkError(f"InfluxDB 3 endpoint is not ready: {url}")
+        yield ",".join(url.rstrip("/") for url in args.url), False, None, None; return
+    workspace, database_manifest = prepare_database_workspace(args)
+    with lock_database(workspace):
+        binary = Path(database_manifest["installation_path"]) / "influxdb3"
+        if not binary.is_file() or not os.access(binary, os.X_OK): raise BenchmarkError(f"InfluxDB 3 binary is not executable: {binary}")
+        check_port_available(args.http_port); endpoint = f"http://127.0.0.1:{args.http_port}"; process_log_path = run_dir / "logs" / "influxdb3-process.log"; process_log = process_log_path.open("a", encoding="utf-8")
+        command = [str(binary), "serve", "--object-store=file", f"--data-dir={workspace / 'data'}", f"--node-id={database_manifest['node_id']}", f"--http-bind=127.0.0.1:{args.http_port}", "--without-auth"]
+        if database_manifest["edition"] == "enterprise":
+            command.append(f"--cluster-id={database_manifest['cluster_id']}")
+            license_path = database_manifest.get("license", {}).get("path")
+            if license_path: command.append(f"--license-file={license_path}")
+        process_log.write(f"$ {display_command(command)}\n"); process_log.flush(); process = subprocess.Popen(command, cwd=workspace, stdout=process_log, stderr=subprocess.STDOUT, start_new_session=True)
+        try:
+            deadline = time.monotonic() + args.startup_timeout
+            while time.monotonic() < deadline:
+                if process.poll() is not None: raise BenchmarkError(f"InfluxDB 3 exited during startup; see {process_log_path}")
+                if endpoint_ready(endpoint): break
+                time.sleep(0.5)
+            else: raise BenchmarkError(f"InfluxDB 3 was not ready within {args.startup_timeout}s; see {process_log_path}")
+            yield endpoint, True, database_manifest, workspace
+        finally:
+            if process.poll() is None:
+                os.killpg(process.pid, signal.SIGTERM)
+                try: process.wait(timeout=15)
+                except subprocess.TimeoutExpired: os.killpg(process.pid, signal.SIGKILL); process.wait(timeout=5)
+            process_log.close()
+
+
+def add_run_options(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument("--run-dir", type=Path); parser.add_argument("--run-root", type=Path)
+    parser.add_argument("--profile", choices=sorted(PROFILES)); parser.add_argument("--start"); parser.add_argument("--end"); parser.add_argument("--scale", type=int); parser.add_argument("--seed", type=int); parser.add_argument("--log-interval")
+    parser.add_argument("--load-workers", type=int); parser.add_argument("--query-workers", type=int); parser.add_argument("--batch-size", type=int); parser.add_argument("--queries", type=int, help="count for every selected query type")
+    parser.add_argument("--query-type", action="append", choices=QUERY_TYPES); parser.add_argument("--query-root", type=Path); parser.add_argument("--regenerate", action="store_true"); parser.add_argument("--rebuild", action="store_true"); parser.add_argument("--dataset-root", type=Path)
+    dataset = parser.add_mutually_exclusive_group(); dataset.add_argument("--dataset-id"); dataset.add_argument("--dataset-path", type=Path)
+
+
+def add_connection_options(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument("--instance-id"); parser.add_argument("--instance-root", type=Path); parser.add_argument("--url", action="append"); parser.add_argument("--edition", choices=("core", "enterprise")); parser.add_argument("--http-port", type=int, default=8181); parser.add_argument("--startup-timeout", type=int, default=60); parser.add_argument("--database", help=f"SQL database name (default: {DEFAULT_DATABASE})"); parser.add_argument("--auth-token-env", default="INFLUXDB3_AUTH_TOKEN"); parser.add_argument("--admin-token-env", default="INFLUXDB3_ADMIN_TOKEN")
+
+
+def add_load_options(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument("--database-mode", choices=("create", "reuse", "reset")); parser.add_argument("--confirm-reset"); parser.add_argument("--no-sync", action="store_true"); parser.add_argument("--accept-partial", action="store_true")
+
+
+def make_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__); subparsers = parser.add_subparsers(dest="command", required=True)
+    build = subparsers.add_parser("build"); build.add_argument("--run-dir", type=Path); build.add_argument("--run-root", type=Path); build.add_argument("--rebuild", action="store_true")
+    generate = subparsers.add_parser("generate"); add_run_options(generate); generate.add_argument("--only", choices=("all", "data", "queries"), default="all")
+    load = subparsers.add_parser("load"); add_run_options(load); add_connection_options(load); add_load_options(load)
+    query = subparsers.add_parser("query"); add_run_options(query); add_connection_options(query)
+    all_command = subparsers.add_parser("all"); add_run_options(all_command); add_connection_options(all_command); add_load_options(all_command)
+    summarize = subparsers.add_parser("summarize"); summarize.add_argument("--run-dir", required=True, type=Path)
+    return parser
+
+
+def validate_args(args: argparse.Namespace) -> None:
+    for name in ("scale", "load_workers", "query_workers", "batch_size", "queries"):
+        value = getattr(args, name, None)
+        if value is not None and value <= 0: raise BenchmarkError(f"--{name.replace('_', '-')} must be positive")
+    for name in ("dataset_id", "instance_id"):
+        value = getattr(args, name, None)
+        if value and not ID_RE.fullmatch(value): raise BenchmarkError(f"--{name.replace('_', '-')} contains invalid characters")
+    if args.command in ("load", "query", "all"):
+        if bool(args.instance_id) == bool(args.url): raise BenchmarkError("provide exactly one of --instance-id or --url")
+        if args.instance_id and args.edition: raise BenchmarkError("managed instance edition comes from its manifest; omit --edition")
+        if args.url and not args.edition: raise BenchmarkError("external targets require --edition=core|enterprise")
+        for url in args.url or []:
+            parsed = urllib.parse.urlparse(url)
+            if parsed.scheme not in ("http", "https") or not parsed.netloc: raise BenchmarkError("--url must be an absolute HTTP or HTTPS URL")
+    if args.command in ("load", "all"):
+        if args.url and args.database_mode is None: raise BenchmarkError("external loads require --database-mode=create|reuse|reset")
+        if args.database_mode == "reset" and args.confirm_reset != args.database: raise BenchmarkError("reset requires --confirm-reset to exactly match --database")
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = make_parser().parse_args(argv); run_dir: Path | None = None; manifest: dict[str, Any] | None = None
+    try:
+        resolve_database(args); validate_args(args)
+        if args.command == "summarize":
+            run_dir = args.run_dir.resolve(); manifest = read_json(run_dir / "manifest.json"); validate_run_manifest(manifest, run_dir / "manifest.json"); summary = write_summary(run_dir, manifest); print(run_dir / "summary.md"); return 1 if summary["failures"] else 0
+        if args.command == "build":
+            run_dir = args.run_dir.resolve() if args.run_dir else new_run_dir((args.run_root or DEFAULT_RUN_ROOT).resolve()); (run_dir / "logs").mkdir(parents=True, exist_ok=True); (run_dir / "results").mkdir(parents=True, exist_ok=True); ensure_binaries(run_dir, list(BINARIES), args.rebuild); print(run_dir); return 0
+        run_dir, manifest = prepare_run(args)
+        if args.command == "generate":
+            if args.only in ("all", "data"): generate_data(args, run_dir, manifest)
+            if args.only in ("all", "queries"): generate_queries(args, run_dir, manifest)
+        elif args.command in ("load", "query", "all"):
+            with connection(args, run_dir) as (endpoint, managed, database_manifest, database_path):
+                edition = database_manifest["edition"] if managed else args.edition
+                previous = manifest.get("target") or {}
+                server = {"version": database_manifest.get("version"), "revision": None, "build": None} if managed else probe_servers(args.url, os.environ.get(args.auth_token_env, ""))
+                if previous and server["version"] is None:
+                    server = {key: previous.get(key) for key in ("version", "revision", "build")}
+                target = {"mode": "managed" if managed else "external", "urls": endpoint.split(","), "database": args.database, "instance_id": args.instance_id if managed else None, "edition": edition, "version": server["version"], "revision": server["revision"], "build": server["build"], "binary_sha256": database_manifest.get("binary_sha256") if managed else None, "no_sync": getattr(args, "no_sync", previous.get("no_sync", False)), "accept_partial": getattr(args, "accept_partial", previous.get("accept_partial", False))}
+                identity = ("mode", "urls", "database", "instance_id", "edition", "version", "binary_sha256")
+                if args.command in ("load", "all"):
+                    identity += ("no_sync", "accept_partial")
+                if previous and any(previous.get(key) != target.get(key) for key in identity):
+                    raise BenchmarkError("target conflicts with the target pinned by this run")
+                manifest["target"] = target; save_manifest(run_dir, manifest)
+                if args.command in ("load", "all"): load_data(args, run_dir, manifest, endpoint, managed, database_manifest, database_path)
+                if args.command in ("query", "all"): run_queries(args, run_dir, manifest, endpoint, database_manifest)
+        summary = write_summary(run_dir, manifest); print(f"Run directory: {run_dir}"); print(f"Summary: {run_dir / 'summary.md'}"); return 1 if summary["failures"] else 0
+    except (BenchmarkError, OSError, json.JSONDecodeError, KeyError, TypeError) as exc:
+        if run_dir is not None and manifest is not None:
+            try: write_summary(run_dir, manifest)
+            except OSError: pass
+        print(f"error: {exc}", file=sys.stderr); return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.agents/skills/benchmark-influxdb3/scripts/benchmark.py
+++ b/.agents/skills/benchmark-influxdb3/scripts/benchmark.py
@@ -170,7 +170,7 @@ def prepare_run(args: argparse.Namespace) -> tuple[Path, dict[str, Any]]:
         manifest = {
             "schema_version": SCHEMA_VERSION, "kind": "influxdb3-run", "run_id": run_dir.name,
             "created_at": utc_now(), "profile": profile, "database": getattr(args, "database", DEFAULT_DATABASE),
-            "workload": build_workload(args), "events": {"loads": [], "queries": []},
+            "workload": build_workload(args), "events": {"loads": [], "queries": [], "servers": []},
         }
     if hasattr(args, "database") and manifest.get("database") != args.database and manifest_path.exists():
         raise BenchmarkError("--database conflicts with the database pinned by this run")
@@ -582,14 +582,25 @@ def probe_servers(urls: Sequence[str], token: str = "") -> dict[str, Any]:
     }
 
 
-def check_port_available(port: int) -> None:
+def port_available(port: int) -> bool:
     with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
-        try: sock.bind(("127.0.0.1", port))
-        except OSError as exc: raise BenchmarkError(f"managed InfluxDB 3 HTTP port {port} is unavailable") from exc
+        sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        try:
+            sock.bind(("127.0.0.1", port)); return True
+        except OSError:
+            return False
+
+
+def check_port_available(port: int, timeout: float = 2.0) -> None:
+    deadline = time.monotonic() + timeout
+    while not port_available(port):
+        if time.monotonic() >= deadline:
+            raise BenchmarkError(f"managed InfluxDB 3 HTTP port {port} is unavailable")
+        time.sleep(0.1)
 
 
 @contextlib.contextmanager
-def connection(args: argparse.Namespace, run_dir: Path) -> Iterator[tuple[str, bool, dict[str, Any] | None, Path | None]]:
+def connection(args: argparse.Namespace, run_dir: Path, manifest: dict[str, Any]) -> Iterator[tuple[str, bool, dict[str, Any] | None, Path | None]]:
     if bool(args.instance_id) == bool(args.url): raise BenchmarkError("provide exactly one of --instance-id or --url")
     if args.url:
         token = os.environ.get(args.auth_token_env, "")
@@ -600,26 +611,63 @@ def connection(args: argparse.Namespace, run_dir: Path) -> Iterator[tuple[str, b
     with lock_database(workspace):
         binary = Path(database_manifest["installation_path"]) / "influxdb3"
         if not binary.is_file() or not os.access(binary, os.X_OK): raise BenchmarkError(f"InfluxDB 3 binary is not executable: {binary}")
-        check_port_available(args.http_port); endpoint = f"http://127.0.0.1:{args.http_port}"; process_log_path = run_dir / "logs" / "influxdb3-process.log"; process_log = process_log_path.open("a", encoding="utf-8")
+        endpoint = f"http://127.0.0.1:{args.http_port}"
+        servers = manifest.setdefault("events", {}).setdefault("servers", [])
+        attempt = next_attempt(servers)
+        process_log_path = run_dir / "logs" / f"influxdb3-process-run-{attempt:03d}.log"
+        event = {"attempt": attempt, "log": relative(run_dir, process_log_path), "endpoint": endpoint, "status": "starting", "started_at": utc_now(), "ready_at": None, "shutdown_expected": False, "forced_shutdown": False, "unexpected_exit": False}
+        servers.append(event); save_manifest(run_dir, manifest)
+        process_log = process_log_path.open("w", encoding="utf-8")
+        try:
+            check_port_available(args.http_port)
+        except Exception:
+            process_log.write(f"managed InfluxDB 3 HTTP port {args.http_port} is unavailable\n"); process_log.close()
+            event.update(status="startup_failed", finished_at=utc_now()); save_manifest(run_dir, manifest); raise
         command = [str(binary), "serve", "--object-store=file", f"--data-dir={workspace / 'data'}", f"--node-id={database_manifest['node_id']}", f"--http-bind=127.0.0.1:{args.http_port}", "--without-auth"]
         if database_manifest["edition"] == "enterprise":
             command.append(f"--cluster-id={database_manifest['cluster_id']}")
             license_path = database_manifest.get("license", {}).get("path")
             if license_path: command.append(f"--license-file={license_path}")
-        process_log.write(f"$ {display_command(command)}\n"); process_log.flush(); process = subprocess.Popen(command, cwd=workspace, stdout=process_log, stderr=subprocess.STDOUT, start_new_session=True)
+        process_log.write(f"$ {display_command(command)}\n"); process_log.flush()
+        try:
+            process = subprocess.Popen(command, cwd=workspace, stdout=process_log, stderr=subprocess.STDOUT, start_new_session=True)
+        except Exception:
+            event.update(status="startup_failed", finished_at=utc_now()); save_manifest(run_dir, manifest); process_log.close(); raise
+        event["pid"] = process.pid; save_manifest(run_dir, manifest)
+        ready = False
         try:
             deadline = time.monotonic() + args.startup_timeout
             while time.monotonic() < deadline:
-                if process.poll() is not None: raise BenchmarkError(f"InfluxDB 3 exited during startup; see {process_log_path}")
-                if endpoint_ready(endpoint): break
+                if process.poll() is not None:
+                    event.update(status="startup_failed", unexpected_exit=True, exit_code=process.returncode, finished_at=utc_now()); save_manifest(run_dir, manifest)
+                    raise BenchmarkError(f"InfluxDB 3 exited during startup; see {process_log_path}")
+                if endpoint_ready(endpoint):
+                    ready = True; event.update(status="ready", ready_at=utc_now()); save_manifest(run_dir, manifest); break
                 time.sleep(0.5)
-            else: raise BenchmarkError(f"InfluxDB 3 was not ready within {args.startup_timeout}s; see {process_log_path}")
+            else:
+                event.update(status="startup_timeout", finished_at=utc_now()); save_manifest(run_dir, manifest)
+                raise BenchmarkError(f"InfluxDB 3 was not ready within {args.startup_timeout}s; see {process_log_path}")
             yield endpoint, True, database_manifest, workspace
         finally:
-            if process.poll() is None:
+            return_code = process.poll()
+            if ready and return_code is not None:
+                event.update(status="unexpected_exit", unexpected_exit=True, exit_code=return_code, finished_at=utc_now())
+            if return_code is None:
+                event.update(shutdown_expected=True, shutdown_started_at=utc_now()); save_manifest(run_dir, manifest)
                 os.killpg(process.pid, signal.SIGTERM)
-                try: process.wait(timeout=15)
-                except subprocess.TimeoutExpired: os.killpg(process.pid, signal.SIGKILL); process.wait(timeout=5)
+                try:
+                    return_code = process.wait(timeout=15)
+                except subprocess.TimeoutExpired:
+                    event["forced_shutdown"] = True
+                    os.killpg(process.pid, signal.SIGKILL); return_code = process.wait(timeout=5)
+                if event["forced_shutdown"]:
+                    event["status"] = "forced_shutdown"
+                elif event["status"] not in ("startup_failed", "startup_timeout"):
+                    event["status"] = "stopped"
+                event.update(exit_code=return_code, finished_at=utc_now())
+            elif event.get("finished_at") is None:
+                event["finished_at"] = utc_now()
+            save_manifest(run_dir, manifest)
             process_log.close()
 
 
@@ -682,7 +730,7 @@ def main(argv: Sequence[str] | None = None) -> int:
             if args.only in ("all", "data"): generate_data(args, run_dir, manifest)
             if args.only in ("all", "queries"): generate_queries(args, run_dir, manifest)
         elif args.command in ("load", "query", "all"):
-            with connection(args, run_dir) as (endpoint, managed, database_manifest, database_path):
+            with connection(args, run_dir, manifest) as (endpoint, managed, database_manifest, database_path):
                 edition = database_manifest["edition"] if managed else args.edition
                 previous = manifest.get("target") or {}
                 server = {"version": database_manifest.get("version"), "revision": None, "build": None} if managed else probe_servers(args.url, os.environ.get(args.auth_token_env, ""))

--- a/.agents/skills/benchmark-influxdb3/scripts/summarize.py
+++ b/.agents/skills/benchmark-influxdb3/scripts/summarize.py
@@ -13,6 +13,12 @@ from typing import Any, Callable
 
 RESULT_FORMAT_VERSION = "0.2"
 LEGACY_RESULT_FORMAT_VERSION = "0.1"
+MAX_SERVER_DIAGNOSTIC_SAMPLES = 20
+EMAIL_RE = re.compile(r"(?<![\w.+-])[\w.+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}(?![\w.-])")
+PANIC_RE = re.compile(r"\bpanic(?:ked)?\b|fatal runtime error", re.IGNORECASE)
+FATAL_RE = re.compile(r"\bfatal\b", re.IGNORECASE)
+ERROR_RE = re.compile(r"(?:^|\s)ERROR(?:\s|$)", re.IGNORECASE)
+WARNING_RE = re.compile(r"(?:^|\s)WARN(?:ING)?(?:\s|$)|<jemalloc>:", re.IGNORECASE)
 
 
 METRIC_RE = re.compile(
@@ -158,6 +164,42 @@ def _parse_event(
     return log_parser(_read_log(run_dir, event["log"]))
 
 
+def server_diagnostics(run_dir: Path, manifest: dict[str, Any], failures: list[dict[str, str]]) -> dict[str, Any]:
+    counts = {"warning": 0, "error": 0, "fatal": 0, "panic": 0}
+    samples: list[dict[str, str]] = []
+    attempts: list[dict[str, Any]] = []
+    failing_statuses = {"starting", "startup_failed", "startup_timeout", "unexpected_exit", "forced_shutdown"}
+    for event in manifest.get("events", {}).get("servers", []):
+        log = event.get("log", "")
+        attempt = {key: event.get(key) for key in ("attempt", "log", "status", "started_at", "ready_at", "finished_at", "exit_code", "forced_shutdown", "unexpected_exit")}
+        attempts.append(attempt)
+        status = event.get("status", "unknown")
+        if status in failing_statuses or event.get("unexpected_exit") or event.get("forced_shutdown"):
+            failures.append({"stage": "server", "log": log, "reason": status})
+        try:
+            lines = _read_log(run_dir, log).splitlines()
+        except OSError as exc:
+            failures.append({"stage": "server", "log": log, "reason": str(exc)})
+            continue
+        fatal_or_panic = False
+        for raw_line in lines:
+            line = EMAIL_RE.sub("<redacted-email>", raw_line.strip())
+            severity = None
+            if PANIC_RE.search(line): severity = "panic"
+            elif FATAL_RE.search(line): severity = "fatal"
+            elif ERROR_RE.search(line): severity = "error"
+            elif WARNING_RE.search(line): severity = "warning"
+            if severity is None:
+                continue
+            counts[severity] += 1
+            if len(samples) < MAX_SERVER_DIAGNOSTIC_SAMPLES:
+                samples.append({"severity": severity, "log": log, "message": line})
+            fatal_or_panic = fatal_or_panic or severity in ("fatal", "panic")
+        if fatal_or_panic:
+            failures.append({"stage": "server", "log": log, "reason": "server log contains fatal or panic diagnostics"})
+    return {**{f"{name}_count": value for name, value in counts.items()}, "samples": samples, "attempts": attempts}
+
+
 def build_summary(run_dir: Path, manifest: dict[str, Any]) -> dict[str, Any]:
     failures: list[dict[str, str]] = []
     ingestion_runs: list[dict[str, Any]] = []
@@ -222,6 +264,7 @@ def build_summary(run_dir: Path, manifest: dict[str, Any]) -> dict[str, Any]:
             }
         )
 
+    diagnostics = server_diagnostics(run_dir, manifest, failures)
     return {
         "run_id": manifest.get("run_id", run_dir.name),
         "profile": manifest.get("profile"),
@@ -232,6 +275,7 @@ def build_summary(run_dir: Path, manifest: dict[str, Any]) -> dict[str, Any]:
         "workload": manifest.get("workload", {}),
         "ingestion_runs": ingestion_runs,
         "queries": queries,
+        "server_diagnostics": diagnostics,
         "failures": failures,
     }
 
@@ -304,6 +348,18 @@ def render_markdown(summary: dict[str, Any]) -> str:
             )
     else:
         lines.append("No completed query runs.")
+
+    diagnostics = summary.get("server_diagnostics", {})
+    lines.extend(["", "## Server diagnostics", ""])
+    lines.append(
+        f"Warnings: {diagnostics.get('warning_count', 0)}; errors: {diagnostics.get('error_count', 0)}; "
+        f"fatals: {diagnostics.get('fatal_count', 0)}; panics: {diagnostics.get('panic_count', 0)}."
+    )
+    if diagnostics.get("samples"):
+        lines.extend(["", "| Severity | Log | Sample |", "| --- | --- | --- |"])
+        for sample in diagnostics["samples"]:
+            message = sample["message"].replace("|", "\\|")
+            lines.append(f"| {sample['severity']} | `{sample['log']}` | {message} |")
 
     if summary["failures"]:
         lines.extend(["", "## Failures", "", "| Stage | Log | Reason |", "| --- | --- | --- |"])

--- a/.agents/skills/benchmark-influxdb3/scripts/summarize.py
+++ b/.agents/skills/benchmark-influxdb3/scripts/summarize.py
@@ -1,0 +1,336 @@
+#!/usr/bin/env python3
+"""Parse TSBS results and write InfluxDB 3 benchmark summaries."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import re
+from pathlib import Path
+from typing import Any, Callable
+
+
+RESULT_FORMAT_VERSION = "0.2"
+LEGACY_RESULT_FORMAT_VERSION = "0.1"
+
+
+METRIC_RE = re.compile(
+    r"loaded\s+(?P<count>\d+)\s+metrics\s+in\s+(?P<seconds>[0-9.]+)sec.*?"
+    r"mean rate\s+(?P<rate>[0-9.]+)\s+metrics/sec"
+)
+ROW_RE = re.compile(
+    r"loaded\s+(?P<count>\d+)\s+rows\s+in\s+(?P<seconds>[0-9.]+)sec.*?"
+    r"mean rate\s+(?P<rate>[0-9.]+)\s+rows/sec"
+)
+QUERY_RE = re.compile(
+    r"all queries\s*:\s*\n\s*"
+    r"min:.*?mean:\s*(?P<mean>[0-9.]+)ms,.*?count:\s*(?P<count>\d+)",
+    re.DOTALL,
+)
+
+
+class SummaryError(ValueError):
+    """Raised when a completed TSBS result or legacy log cannot be parsed."""
+
+
+def _mapping(value: Any, field: str) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        raise SummaryError(f"result field {field} must be an object")
+    return value
+
+
+def _number(value: Any, field: str) -> float:
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        raise SummaryError(f"result field {field} must be a number")
+    result = float(value)
+    if not math.isfinite(result) or result < 0:
+        raise SummaryError(f"result field {field} must be a non-negative finite number")
+    return result
+
+
+def _count(value: Any, field: str) -> int:
+    if isinstance(value, bool) or not isinstance(value, int) or value < 0:
+        raise SummaryError(f"result field {field} must be a non-negative integer")
+    return value
+
+
+def parse_load_result(result: dict[str, Any]) -> dict[str, Any]:
+    totals = _mapping(result.get("Totals"), "Totals")
+    metrics = _count(totals.get("metricCount"), "Totals.metricCount")
+    metric_rate = _number(totals.get("metricRate"), "Totals.metricRate")
+    rows = _count(totals.get("rowCount"), "Totals.rowCount")
+    row_rate = _number(totals.get("rowRate"), "Totals.rowRate")
+    parsed: dict[str, Any] = {
+        "metrics": metrics,
+        "duration_seconds": _number(result.get("DurationMillis"), "DurationMillis") / 1000.0,
+        "metrics_per_second": metric_rate,
+    }
+    if rows > 0:
+        parsed.update({"rows": rows, "rows_per_second": row_rate})
+    return parsed
+
+
+def parse_query_result(result: dict[str, Any]) -> dict[str, Any]:
+    totals = _mapping(result.get("Totals"), "Totals")
+    overall_stats = _mapping(totals.get("overallStats"), "Totals.overallStats")
+    all_queries = _mapping(
+        overall_stats.get("all_queries"), "Totals.overallStats.all_queries"
+    )
+    return {
+        "mean_milliseconds": _number(
+            all_queries.get("meanMilliseconds"),
+            "Totals.overallStats.all_queries.meanMilliseconds",
+        ),
+        "count": _count(
+            all_queries.get("count"), "Totals.overallStats.all_queries.count"
+        ),
+    }
+
+
+def parse_load_log(text: str) -> dict[str, Any]:
+    metric_matches = list(METRIC_RE.finditer(text))
+    if not metric_matches:
+        raise SummaryError("load log has no final metric summary")
+    metric = metric_matches[-1]
+    result: dict[str, Any] = {
+        "metrics": int(metric.group("count")),
+        "duration_seconds": float(metric.group("seconds")),
+        "metrics_per_second": float(metric.group("rate")),
+    }
+    row_matches = list(ROW_RE.finditer(text))
+    if row_matches:
+        row = row_matches[-1]
+        result.update(
+            {
+                "rows": int(row.group("count")),
+                "rows_per_second": float(row.group("rate")),
+            }
+        )
+    return result
+
+
+def parse_query_log(text: str) -> dict[str, Any]:
+    marker = text.rfind("Run complete after")
+    if marker < 0:
+        raise SummaryError("query log has no final run marker")
+    matches = list(QUERY_RE.finditer(text[marker:]))
+    if not matches:
+        raise SummaryError("query log has no final all-queries summary")
+    match = matches[-1]
+    return {
+        "mean_milliseconds": float(match.group("mean")),
+        "count": int(match.group("count")),
+    }
+
+
+def _read_log(run_dir: Path, relative_path: str) -> str:
+    return (run_dir / relative_path).read_text(encoding="utf-8", errors="replace")
+
+
+def _read_event_result(run_dir: Path, event: dict[str, Any]) -> dict[str, Any] | None:
+    relative_path = event.get("results")
+    if not relative_path:
+        return None
+    path = run_dir / relative_path
+    try:
+        result = json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        raise SummaryError(f"malformed result JSON {relative_path}: {exc}") from exc
+    result = _mapping(result, str(relative_path))
+    version = result.get("ResultFormatVersion")
+    if version == LEGACY_RESULT_FORMAT_VERSION:
+        return None
+    if version != RESULT_FORMAT_VERSION:
+        raise SummaryError(f"unsupported result format version {version!r} in {relative_path}")
+    return result
+
+
+def _parse_event(
+    run_dir: Path,
+    event: dict[str, Any],
+    result_parser: Callable[[dict[str, Any]], dict[str, Any]],
+    log_parser: Callable[[str], dict[str, Any]],
+) -> dict[str, Any]:
+    result = _read_event_result(run_dir, event)
+    if result is not None:
+        return result_parser(result)
+    return log_parser(_read_log(run_dir, event["log"]))
+
+
+def build_summary(run_dir: Path, manifest: dict[str, Any]) -> dict[str, Any]:
+    failures: list[dict[str, str]] = []
+    ingestion_runs: list[dict[str, Any]] = []
+    query_runs: list[dict[str, Any]] = []
+
+    for event in manifest.get("events", {}).get("loads", []):
+        if event.get("status") == "reused":
+            continue
+        base = {
+            "attempt": event["attempt"],
+            "database": event["database"],
+            "mode": event["database_mode"],
+            "log": event["log"],
+        }
+        if event.get("status") != "completed":
+            failures.append(
+                {"stage": "load", "log": event["log"], "reason": event.get("status", "failed")}
+            )
+            continue
+        try:
+            base.update(_parse_event(run_dir, event, parse_load_result, parse_load_log))
+            ingestion_runs.append(base)
+        except (OSError, SummaryError) as exc:
+            failures.append({"stage": "load", "log": event["log"], "reason": str(exc)})
+
+    for event in manifest.get("events", {}).get("queries", []):
+        base = {
+            "query_type": event["query_type"],
+            "attempt": event["attempt"],
+            "database": event["database"],
+            "log": event["log"],
+        }
+        if event.get("status") != "completed":
+            failures.append(
+                {"stage": "query", "log": event["log"], "reason": event.get("status", "failed")}
+            )
+            continue
+        try:
+            base.update(_parse_event(run_dir, event, parse_query_result, parse_query_log))
+            query_runs.append(base)
+        except (OSError, SummaryError) as exc:
+            failures.append({"stage": "query", "log": event["log"], "reason": str(exc)})
+
+    grouped: dict[tuple[str, str], list[dict[str, Any]]] = {}
+    for run in query_runs:
+        key = (run["database"], run["query_type"])
+        grouped.setdefault(key, []).append(run)
+
+    queries: list[dict[str, Any]] = []
+    for database, query_type in sorted(grouped):
+        runs = grouped[(database, query_type)]
+        count = sum(run["count"] for run in runs)
+        weighted = sum(run["mean_milliseconds"] * run["count"] for run in runs)
+        queries.append(
+            {
+                "database": database,
+                "query_type": query_type,
+                "repetitions": len(runs),
+                "query_count": count,
+                "weighted_mean_milliseconds": weighted / count if count else 0.0,
+                "runs": runs,
+            }
+        )
+
+    return {
+        "run_id": manifest.get("run_id", run_dir.name),
+        "profile": manifest.get("profile"),
+        "database": manifest.get("database"),
+        "target": manifest.get("target"),
+        "dataset": manifest.get("dataset"),
+        "query_set": manifest.get("query_set"),
+        "workload": manifest.get("workload", {}),
+        "ingestion_runs": ingestion_runs,
+        "queries": queries,
+        "failures": failures,
+    }
+
+
+def render_markdown(summary: dict[str, Any]) -> str:
+    lines = [
+        f"# InfluxDB 3 TSBS benchmark: {summary['run_id']}",
+        "",
+        f"- Profile: `{summary.get('profile')}`",
+        f"- Current database: `{summary.get('database')}`",
+    ]
+    target = summary.get("target")
+    if target:
+        target_name = target.get("instance_id") or ",".join(target.get("urls", []))
+        lines.append(f"- Benchmark target: `{target.get('mode')}:{target_name}`")
+        lines.append(f"- Edition: `{target.get('edition')}`")
+        if target.get("version"):
+            lines.append(f"- Version: `{target.get('version')}`")
+        lines.append(f"- Durable WAL acknowledgement: `{not target.get('no_sync', False)}`")
+        lines.append(f"- Partial batch acceptance: `{target.get('accept_partial', False)}`")
+    dataset = summary.get("dataset")
+    if dataset:
+        lines.extend(
+            [
+                f"- Dataset: `{dataset.get('dataset_id')}`",
+                f"- Data format: `{dataset.get('format')}`",
+                f"- Data SHA-256: `{dataset.get('sha256')}`",
+                f"- Data path: `{dataset.get('data_path')}`",
+            ]
+        )
+    query_set = summary.get("query_set")
+    if query_set:
+        lines.extend(
+            [
+                f"- Query set: `{query_set.get('query_set_id')}`",
+                f"- Query-set manifest SHA-256: `{query_set.get('manifest_sha256')}`",
+            ]
+        )
+    lines.extend(["", "## Ingestion", ""])
+    if summary["ingestion_runs"]:
+        lines.extend(
+            [
+                "| Database | Attempt | Mode | Metrics | Metrics/s | Rows | Rows/s | Log |",
+                "| --- | ---: | --- | ---: | ---: | ---: | ---: | --- |",
+            ]
+        )
+        for run in summary["ingestion_runs"]:
+            rows_per_second = f"{run['rows_per_second']:.2f}" if "rows_per_second" in run else "-"
+            lines.append(
+                f"| `{run['database']}` | {run['attempt']} | {run['mode']} | {run['metrics']} | "
+                f"{run['metrics_per_second']:.2f} | {run.get('rows', '-')} | {rows_per_second} | "
+                f"`{run['log']}` |"
+            )
+    else:
+        lines.append("No completed ingestion runs.")
+
+    lines.extend(["", "## Queries", ""])
+    if summary["queries"]:
+        lines.extend(
+            [
+                "| Database | Query type | Repetitions | Query count | Weighted mean (ms) |",
+                "| --- | --- | ---: | ---: | ---: |",
+            ]
+        )
+        for query in summary["queries"]:
+            lines.append(
+                f"| `{query['database']}` | `{query['query_type']}` | {query['repetitions']} | "
+                f"{query['query_count']} | "
+                f"{query['weighted_mean_milliseconds']:.3f} |"
+            )
+    else:
+        lines.append("No completed query runs.")
+
+    if summary["failures"]:
+        lines.extend(["", "## Failures", "", "| Stage | Log | Reason |", "| --- | --- | --- |"])
+        for failure in summary["failures"]:
+            reason = failure["reason"].replace("|", "\\|")
+            lines.append(f"| {failure['stage']} | `{failure['log']}` | {reason} |")
+    lines.append("")
+    return "\n".join(lines)
+
+
+def write_summary(run_dir: Path, manifest: dict[str, Any]) -> dict[str, Any]:
+    summary = build_summary(run_dir, manifest)
+    (run_dir / "summary.json").write_text(json.dumps(summary, indent=2) + "\n", encoding="utf-8")
+    (run_dir / "summary.md").write_text(render_markdown(summary), encoding="utf-8")
+    return summary
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--run-dir", required=True, type=Path)
+    args = parser.parse_args()
+    run_dir = args.run_dir.resolve()
+    manifest = json.loads((run_dir / "manifest.json").read_text(encoding="utf-8"))
+    summary = write_summary(run_dir, manifest)
+    print(run_dir / "summary.md")
+    return 1 if summary["failures"] else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.agents/skills/benchmark-influxdb3/scripts/summarize.py
+++ b/.agents/skills/benchmark-influxdb3/scripts/summarize.py
@@ -289,7 +289,7 @@ def render_markdown(summary: dict[str, Any]) -> str:
     ]
     target = summary.get("target")
     if target:
-        target_name = target.get("instance_id") or ",".join(target.get("urls", []))
+        target_name = target.get("database_id") or ",".join(target.get("urls", []))
         lines.append(f"- Benchmark target: `{target.get('mode')}:{target_name}`")
         lines.append(f"- Edition: `{target.get('edition')}`")
         if target.get("version"):

--- a/.agents/skills/benchmark-influxdb3/tests/test_benchmark.py
+++ b/.agents/skills/benchmark-influxdb3/tests/test_benchmark.py
@@ -1,0 +1,477 @@
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+
+SCRIPTS = Path(__file__).resolve().parents[1] / "scripts"
+sys.path.insert(0, str(SCRIPTS))
+
+import benchmark  # noqa: E402
+import summarize  # noqa: E402
+
+
+class SummaryTests(unittest.TestCase):
+    def write_json(self, root: Path, relative: str, value: dict) -> None:
+        path = root / relative
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps(value), encoding="utf-8")
+
+    def test_reused_load_without_log_is_not_a_failure(self) -> None:
+        with tempfile.TemporaryDirectory() as temp:
+            summary = summarize.build_summary(
+                Path(temp),
+                {
+                    "events": {
+                        "loads": [
+                            {
+                                "attempt": 1,
+                                "database": "benchmark",
+                                "database_mode": "reuse",
+                                "status": "reused",
+                            }
+                        ],
+                        "queries": [],
+                    }
+                },
+            )
+
+        self.assertEqual(summary["ingestion_runs"], [])
+        self.assertEqual(summary["failures"], [])
+
+    def test_structured_results_do_not_require_logs(self) -> None:
+        with tempfile.TemporaryDirectory() as temp:
+            run_dir = Path(temp)
+            self.write_json(
+                run_dir,
+                "results/load.json",
+                {
+                    "ResultFormatVersion": "0.2",
+                    "DurationMillis": 2000,
+                    "Totals": {
+                        "metricCount": 200,
+                        "metricRate": 100.0,
+                        "rowCount": 40,
+                        "rowRate": 20.0,
+                    },
+                },
+            )
+            for name, count, mean in (("query-1.json", 10, 2.0), ("query-2.json", 30, 4.0)):
+                self.write_json(
+                    run_dir,
+                    f"results/{name}",
+                    {
+                        "ResultFormatVersion": "0.2",
+                        "DurationMillis": 1000,
+                        "Totals": {
+                            "overallStats": {
+                                "all_queries": {
+                                    "count": count,
+                                    "meanMilliseconds": mean,
+                                }
+                            }
+                        },
+                    },
+                )
+            summary = summarize.build_summary(
+                run_dir,
+                {
+                    "events": {
+                        "loads": [
+                            {
+                                "attempt": 1,
+                                "database": "benchmark",
+                                "database_mode": "create",
+                                "status": "completed",
+                                "log": "logs/missing-load.log",
+                                "results": "results/load.json",
+                            }
+                        ],
+                        "queries": [
+                            {
+                                "query_type": "lastpoint",
+                                "attempt": attempt,
+                                "database": "benchmark",
+                                "status": "completed",
+                                "log": f"logs/missing-query-{attempt}.log",
+                                "results": f"results/query-{attempt}.json",
+                            }
+                            for attempt in (1, 2)
+                        ],
+                    }
+                },
+            )
+
+        self.assertEqual(summary["failures"], [])
+        self.assertEqual(summary["ingestion_runs"][0]["metrics"], 200)
+        self.assertEqual(summary["ingestion_runs"][0]["duration_seconds"], 2.0)
+        self.assertEqual(summary["queries"][0]["query_count"], 40)
+        self.assertEqual(summary["queries"][0]["weighted_mean_milliseconds"], 3.5)
+
+    def test_legacy_result_uses_log_fallback(self) -> None:
+        with tempfile.TemporaryDirectory() as temp:
+            run_dir = Path(temp)
+            self.write_json(
+                run_dir,
+                "results/query.json",
+                {"ResultFormatVersion": "0.1", "Totals": {}},
+            )
+            log = run_dir / "logs/query.log"
+            log.parent.mkdir()
+            log.write_text(
+                "Run complete after 10 queries\nall queries:\n"
+                "min: 1ms, mean: 3.50ms, max: 4ms, count: 10\n",
+                encoding="utf-8",
+            )
+            summary = summarize.build_summary(
+                run_dir,
+                {
+                    "events": {
+                        "loads": [],
+                        "queries": [
+                            {
+                                "query_type": "lastpoint",
+                                "attempt": 1,
+                                "database": "benchmark",
+                                "status": "completed",
+                                "log": "logs/query.log",
+                                "results": "results/query.json",
+                            }
+                        ],
+                    }
+                },
+            )
+
+        self.assertEqual(summary["failures"], [])
+        self.assertEqual(summary["queries"][0]["weighted_mean_milliseconds"], 3.5)
+
+    def test_incomplete_current_result_is_a_failure(self) -> None:
+        with tempfile.TemporaryDirectory() as temp:
+            run_dir = Path(temp)
+            self.write_json(
+                run_dir,
+                "results/query.json",
+                {"ResultFormatVersion": "0.2", "Totals": {"overallStats": {}}},
+            )
+            summary = summarize.build_summary(
+                run_dir,
+                {
+                    "events": {
+                        "loads": [],
+                        "queries": [
+                            {
+                                "query_type": "lastpoint",
+                                "attempt": 1,
+                                "database": "benchmark",
+                                "status": "completed",
+                                "log": "logs/query.log",
+                                "results": "results/query.json",
+                            }
+                        ],
+                    }
+                },
+            )
+
+        self.assertEqual(summary["queries"], [])
+        self.assertIn("all_queries", summary["failures"][0]["reason"])
+        self.assertEqual(summary["failures"][0]["log"], "logs/query.log")
+
+    def test_malformed_current_result_is_a_failure(self) -> None:
+        with tempfile.TemporaryDirectory() as temp:
+            run_dir = Path(temp)
+            result = run_dir / "results/query.json"
+            result.parent.mkdir()
+            result.write_text("{not-json", encoding="utf-8")
+            summary = summarize.build_summary(
+                run_dir,
+                {
+                    "events": {
+                        "loads": [],
+                        "queries": [
+                            {
+                                "query_type": "lastpoint",
+                                "attempt": 1,
+                                "database": "benchmark",
+                                "status": "completed",
+                                "log": "logs/query.log",
+                                "results": "results/query.json",
+                            }
+                        ],
+                    }
+                },
+            )
+
+        self.assertEqual(summary["queries"], [])
+        self.assertIn("malformed result JSON", summary["failures"][0]["reason"])
+
+    def test_parsers_and_target_identity(self) -> None:
+        structured_load = summarize.parse_load_result(
+            {
+                "DurationMillis": 2000,
+                "Totals": {
+                    "metricCount": 200,
+                    "metricRate": 100.0,
+                    "rowCount": 0,
+                    "rowRate": 0.0,
+                },
+            }
+        )
+        self.assertNotIn("rows", structured_load)
+        load = summarize.parse_load_log(
+            "loaded 200 metrics in 2.000sec (mean rate 100.00 metrics/sec)\n"
+            "loaded 40 rows in 2.000sec (mean rate 20.00 rows/sec)\n"
+        )
+        self.assertEqual(load["metrics_per_second"], 100.0)
+        query = summarize.parse_query_log(
+            "Run complete after 10 queries\nall queries:\n"
+            "min: 1ms, mean: 3.50ms, max: 4ms, count: 10\n"
+        )
+        self.assertEqual(query, {"mean_milliseconds": 3.5, "count": 10})
+        with tempfile.TemporaryDirectory() as temp:
+            summary = summarize.build_summary(
+                Path(temp),
+                {
+                    "run_id": "run", "profile": "smoke", "database": "benchmark",
+                    "target": {"mode": "managed", "instance_id": "db-a", "edition": "core", "urls": ["http://localhost:8181"]},
+                    "dataset": {"dataset_id": "data-a"},
+                    "query_set": {"query_set_id": "set-a", "manifest_sha256": "abc"},
+                    "events": {"loads": [], "queries": []},
+                },
+            )
+        self.assertEqual(summary["target"]["instance_id"], "db-a")
+        self.assertEqual(summary["query_set"]["query_set_id"], "set-a")
+        rendered = summarize.render_markdown(summary)
+        self.assertIn("managed:db-a", rendered)
+        self.assertIn("set-a", rendered)
+
+
+class QuerySetIdentityTests(unittest.TestCase):
+    def dataset(self) -> dict:
+        return {"dataset_id": "data-a", "spec": {"use_case": "cpu-only", "seed": 123}}
+
+    def workload(self, query_counts: dict[str, int]) -> dict:
+        return {
+            "seed": 123, "scale": 10, "start": "2023-01-01T00:00:00Z",
+            "end": "2023-01-02T00:00:00Z", "query_counts": query_counts,
+        }
+
+    def test_identity_is_canonical_and_membership_sensitive(self) -> None:
+        first = benchmark.query_set_spec(self.dataset(), self.workload({"lastpoint": 3, "cpu-max-all-1": 2}))
+        reordered = benchmark.query_set_spec(self.dataset(), self.workload({"cpu-max-all-1": 2, "lastpoint": 3}))
+        self.assertEqual(benchmark.query_set_id(first), benchmark.query_set_id(reordered))
+        changed_count = benchmark.query_set_spec(self.dataset(), self.workload({"cpu-max-all-1": 3, "lastpoint": 3}))
+        subset = benchmark.query_set_spec(self.dataset(), self.workload({"lastpoint": 3}))
+        self.assertNotEqual(benchmark.query_set_id(first), benchmark.query_set_id(changed_count))
+        self.assertNotEqual(benchmark.query_set_id(first), benchmark.query_set_id(subset))
+
+
+class WorkspaceTests(unittest.TestCase):
+    def test_new_run_layout_has_no_local_artifacts_or_managed_state(self) -> None:
+        with tempfile.TemporaryDirectory() as temp:
+            root = Path(temp)
+            args = benchmark.make_parser().parse_args(["generate", "--run-root", str(root), "--only", "queries", "--profile", "smoke"])
+            run_dir, manifest = benchmark.prepare_run(args)
+            self.assertEqual(manifest["schema_version"], benchmark.SCHEMA_VERSION)
+            self.assertEqual({path.name for path in run_dir.iterdir()}, {"logs", "results", "manifest.json"})
+            self.assertFalse((run_dir / "queries").exists())
+            self.assertFalse((run_dir / "data").exists())
+            self.assertFalse((run_dir / "influxdb3").exists())
+
+    def test_old_or_malformed_run_manifest_is_rejected(self) -> None:
+        with tempfile.TemporaryDirectory() as temp:
+            run_dir = Path(temp)
+            (run_dir / "manifest.json").write_text(json.dumps({"run_id": "old"}), encoding="utf-8")
+            args = benchmark.make_parser().parse_args(["generate", "--run-dir", str(run_dir), "--only", "queries"])
+            with self.assertRaisesRegex(benchmark.BenchmarkError, "unsupported"):
+                benchmark.prepare_run(args)
+
+
+class QuerySetTests(unittest.TestCase):
+    def make_args(self, run_dir: Path, query_root: Path, *types: str) -> argparse.Namespace:
+        values = ["generate", "--run-dir", str(run_dir), "--query-root", str(query_root), "--profile", "smoke", "--only", "queries"]
+        for query_type in types:
+            values.extend(["--query-type", query_type])
+        return benchmark.make_parser().parse_args(values)
+
+    def make_manifest(self, run_dir: Path, args: argparse.Namespace) -> dict:
+        run_dir.mkdir(parents=True, exist_ok=True)
+        (run_dir / "logs").mkdir(); (run_dir / "results").mkdir()
+        manifest = {
+            "schema_version": benchmark.SCHEMA_VERSION, "kind": "influxdb3-run",
+            "run_id": run_dir.name, "created_at": benchmark.utc_now(), "profile": "smoke",
+            "database": "benchmark", "workload": benchmark.build_workload(args),
+            "dataset": {"dataset_id": "data-a", "dataset_path": "/tmp/data-a", "spec": {
+                "use_case": "cpu-only", "start": "2023-06-11T00:00:00Z", "end": "2023-06-12T00:00:00Z",
+                "scale": 10, "seed": 123, "log_interval": "10s",
+            }},
+            "events": {"loads": [], "queries": []},
+        }
+        benchmark.save_manifest(run_dir, manifest)
+        return manifest
+
+    def generator(self, _command, log_path, *, stdout_path, **_kwargs):
+        log_path.parent.mkdir(parents=True, exist_ok=True)
+        log_path.write_text("generated\n", encoding="utf-8")
+        stdout_path.parent.mkdir(parents=True, exist_ok=True)
+        stdout_path.write_text(f"query:{stdout_path.stem}\n", encoding="utf-8")
+
+    def checksum(self, path: Path) -> str:
+        if path.name == benchmark.BINARIES["queries"]:
+            return "b" * 64
+        return benchmark._real_sha(path) if hasattr(benchmark, "_real_sha") else ""
+
+    def test_independent_runs_reuse_identical_validated_set(self) -> None:
+        with tempfile.TemporaryDirectory() as temp:
+            root = Path(temp); query_root = root / "queries"
+            real_sha = benchmark.sha256_file
+            def hashes(path): return "b" * 64 if path.name == benchmark.BINARIES["queries"] else real_sha(path)
+            paths = []
+            for name in ("run-a", "run-b"):
+                run_dir = root / name; args = self.make_args(run_dir, query_root, "lastpoint", "cpu-max-all-1"); manifest = self.make_manifest(run_dir, args)
+                with mock.patch.object(benchmark, "ensure_binaries"), mock.patch.object(benchmark, "run_tee", side_effect=self.generator) as runner, mock.patch.object(benchmark, "sha256_file", side_effect=hashes):
+                    paths.append(benchmark.generate_queries(args, run_dir, manifest))
+                if name == "run-a": self.assertEqual(runner.call_count, 2)
+                else: runner.assert_not_called()
+            self.assertEqual(paths[0], paths[1])
+            self.assertEqual(json.loads((root / "run-b/manifest.json").read_text())["query_set"]["reused"], True)
+
+    def test_failure_is_atomic_and_diagnostics_stay_in_run(self) -> None:
+        with tempfile.TemporaryDirectory() as temp:
+            root = Path(temp); run_dir = root / "run"; query_root = root / "queries"
+            args = self.make_args(run_dir, query_root, "lastpoint", "cpu-max-all-1"); manifest = self.make_manifest(run_dir, args)
+            calls = 0
+            def fail_second(command, log_path, *, stdout_path, **kwargs):
+                nonlocal calls; calls += 1; log_path.write_text("generator failed\n", encoding="utf-8")
+                if calls == 2: raise benchmark.BenchmarkError("failed")
+                stdout_path.parent.mkdir(parents=True, exist_ok=True); stdout_path.write_text("partial", encoding="utf-8")
+            with mock.patch.object(benchmark, "ensure_binaries"), mock.patch.object(benchmark, "run_tee", side_effect=fail_second):
+                with self.assertRaises(benchmark.BenchmarkError): benchmark.generate_queries(args, run_dir, manifest)
+            spec = benchmark.query_set_spec(manifest["dataset"], manifest["workload"])
+            self.assertFalse(benchmark.query_set_path(query_root, "data-a", benchmark.query_set_id(spec)).exists())
+            self.assertTrue(any((run_dir / "logs").iterdir()))
+            self.assertFalse(any(query_root.rglob("*.dat")))
+
+    def test_corrupt_manifest_or_artifact_fails_reuse(self) -> None:
+        with tempfile.TemporaryDirectory() as temp:
+            root = Path(temp); run_dir = root / "run"; query_root = root / "queries"
+            args = self.make_args(run_dir, query_root, "lastpoint"); manifest = self.make_manifest(run_dir, args); real_sha = benchmark.sha256_file
+            def hashes(path): return "b" * 64 if path.name == benchmark.BINARIES["queries"] else real_sha(path)
+            with mock.patch.object(benchmark, "ensure_binaries"), mock.patch.object(benchmark, "run_tee", side_effect=self.generator), mock.patch.object(benchmark, "sha256_file", side_effect=hashes):
+                path = benchmark.generate_queries(args, run_dir, manifest)
+            benchmark.query_file_path(path, "lastpoint").write_text("corrupt", encoding="utf-8")
+            with self.assertRaisesRegex(benchmark.BenchmarkError, "checksum mismatch"):
+                benchmark.validate_query_set(path, manifest["query_set"]["spec"])
+
+    def test_each_query_file_executes_once_and_records_checksum(self) -> None:
+        with tempfile.TemporaryDirectory() as temp:
+            root = Path(temp); run_dir = root / "run"; query_root = root / "queries"
+            args = self.make_args(run_dir, query_root, "lastpoint", "cpu-max-all-1"); args.database = "benchmark"; manifest = self.make_manifest(run_dir, args); real_sha = benchmark.sha256_file
+            def hashes(path): return "b" * 64 if path.name == benchmark.BINARIES["queries"] else real_sha(path)
+            with mock.patch.object(benchmark, "ensure_binaries"), mock.patch.object(benchmark, "run_tee", side_effect=self.generator), mock.patch.object(benchmark, "sha256_file", side_effect=hashes):
+                benchmark.generate_queries(args, run_dir, manifest)
+            def execute(_command, log_path, **_kwargs):
+                log_path.write_text("Run complete after 1 queries\nall queries:\nmin: 1ms, mean: 1ms, max: 1ms, count: 1\n", encoding="utf-8")
+            with mock.patch.object(benchmark, "generate_queries", return_value=Path(manifest["query_set"]["query_set_path"])), mock.patch.object(benchmark, "ensure_binaries"), mock.patch.object(benchmark, "run_tee", side_effect=execute) as runner:
+                benchmark.run_queries(args, run_dir, manifest, "http://localhost:4000")
+            self.assertEqual(runner.call_count, 2)
+            self.assertEqual(len(manifest["events"]["queries"]), 2)
+            self.assertTrue(all(event["file_sha256"] for event in manifest["events"]["queries"]))
+
+
+class ManagedDatabaseTests(unittest.TestCase):
+    def args(self, root: Path, mode: str | None = None) -> argparse.Namespace:
+        values = ["load", "--instance-id", "db-a", "--instance-root", str(root), "--database", "benchmark"]
+        if mode: values.extend(["--database-mode", mode])
+        if mode == "reset": values.extend(["--confirm-reset", "benchmark"])
+        return benchmark.make_parser().parse_args(values)
+
+    def prepare_instance(self, root: Path) -> Path:
+        installation = root / "installation"; installation.mkdir(parents=True)
+        binary = installation / "influxdb3"; binary.write_bytes(b"binary"); binary.chmod(0o755)
+        path = root / "db-a"; path.mkdir(); (path / "data").mkdir(); (path / "logs").mkdir()
+        benchmark.save_json(path / "manifest.json", {
+            "schema_version": 1, "kind": "influxdb3-instance", "instance_id": "db-a",
+            "edition": "core", "version": "3.11.1", "installation_path": str(installation),
+            "binary_sha256": benchmark.sha256_file(binary), "node_id": "db-a-node",
+            "cluster_id": None, "license": {"status": "not-required", "source": None},
+            "created_at": benchmark.utc_now(), "database": None, "binding": None,
+        })
+        return path
+
+    def test_workspace_bind_reuse_reset_and_lock(self) -> None:
+        with tempfile.TemporaryDirectory() as temp:
+            root = Path(temp); self.prepare_instance(root); args = self.args(root); path, db = benchmark.prepare_database_workspace(args)
+            self.assertEqual({p.name for p in path.iterdir()}, {"manifest.json", "data", "logs"})
+            with benchmark.lock_database(path):
+                with self.assertRaisesRegex(benchmark.BenchmarkError, "locked"):
+                    with benchmark.lock_database(path): pass
+            dataset_a = {"dataset_id": "a", "dataset_path": "/a", "data_path": "/a/data", "format": "influx", "bytes": 1, "sha256": "a", "spec": {"use_case": "cpu-only"}}
+            dataset_b = {**dataset_a, "dataset_id": "b", "sha256": "b"}
+            run_dir = root / "run"; (run_dir / "logs").mkdir(parents=True); (run_dir / "results").mkdir()
+            manifest = {"workload": {"batch_size": 1, "load_workers": 1}, "events": {"loads": [], "queries": []}, "dataset": dataset_a}
+            with mock.patch.object(benchmark, "generate_data", return_value=Path("/a/data")), mock.patch.object(benchmark, "ensure_binaries"), mock.patch.object(benchmark, "run_tee"):
+                benchmark.load_data(args, run_dir, manifest, "http://localhost", True, db, path)
+            db = benchmark.validate_database_manifest(path, "db-a"); self.assertEqual(db["binding"]["dataset_id"], "a")
+            manifest["events"] = {"loads": [], "queries": []}
+            with mock.patch.object(benchmark, "generate_data", return_value=Path("/a/data")), mock.patch.object(benchmark, "ensure_binaries") as build, mock.patch.object(benchmark, "run_tee"):
+                benchmark.load_data(args, run_dir, manifest, "http://localhost", True, db, path)
+            build.assert_not_called(); self.assertEqual(manifest["events"]["loads"][0]["status"], "reused")
+            manifest["dataset"] = dataset_b; manifest["events"] = {"loads": [], "queries": []}
+            with mock.patch.object(benchmark, "generate_data", return_value=Path("/b/data")):
+                with self.assertRaisesRegex(benchmark.BenchmarkError, "different dataset"):
+                    benchmark.load_data(args, run_dir, manifest, "http://localhost", True, db, path)
+            reset = self.args(root, "reset")
+            with mock.patch.object(benchmark, "generate_data", return_value=Path("/b/data")), mock.patch.object(benchmark, "ensure_binaries"), mock.patch.object(benchmark, "run_tee"):
+                benchmark.load_data(reset, run_dir, manifest, "http://localhost", True, db, path)
+            self.assertEqual(benchmark.validate_database_manifest(path)["binding"]["dataset_id"], "b")
+
+    def test_managed_requires_database_id(self) -> None:
+        args = benchmark.make_parser().parse_args(["query"])
+        benchmark.resolve_database(args)
+        with self.assertRaisesRegex(benchmark.BenchmarkError, "exactly one"):
+            benchmark.validate_args(args)
+
+
+class TargetTests(unittest.TestCase):
+    def test_external_target_validation_and_token_redaction(self) -> None:
+        args = benchmark.make_parser().parse_args([
+            "all", "--url", "http://node-a:8181", "--url", "http://node-b:8181",
+            "--edition", "enterprise", "--database-mode", "create",
+        ])
+        benchmark.resolve_database(args); benchmark.validate_args(args)
+        with mock.patch.dict("os.environ", {
+            "INFLUXDB3_AUTH_TOKEN": "query-secret",
+            "INFLUXDB3_ADMIN_TOKEN": "admin-secret",
+        }):
+            command = benchmark.credential_args(args, include_admin=True)
+        displayed = benchmark.display_command(command)
+        self.assertNotIn("query-secret", displayed)
+        self.assertNotIn("admin-secret", displayed)
+        self.assertEqual(displayed.count("<redacted>"), 2)
+
+    def test_influxdb3_binaries_and_query_format(self) -> None:
+        self.assertEqual(benchmark.BINARIES["load"], "tsbs_load_influx3")
+        self.assertEqual(benchmark.BINARIES["query"], "tsbs_run_queries_influx3")
+        spec = benchmark.query_set_spec(
+            {"dataset_id": "data", "spec": {"use_case": "cpu-only"}},
+            {"seed": 1, "scale": 1, "start": "2023-01-01T00:00:00Z", "end": "2023-01-02T00:00:00Z", "query_counts": {"lastpoint": 1}},
+        )
+        self.assertEqual(spec["format"], "influx3")
+        self.assertTrue(benchmark.query_set_id(spec).startswith("influx3-"))
+
+    def test_external_nodes_must_report_matching_versions(self) -> None:
+        with mock.patch.object(benchmark, "probe_server", side_effect=[
+            {"version": "3.11.1", "revision": "a", "build": "enterprise"},
+            {"version": "3.11.0", "revision": "b", "build": "enterprise"},
+        ]):
+            with self.assertRaisesRegex(benchmark.BenchmarkError, "different version"):
+                benchmark.probe_servers(["http://a", "http://b"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.agents/skills/benchmark-influxdb3/tests/test_benchmark.py
+++ b/.agents/skills/benchmark-influxdb3/tests/test_benchmark.py
@@ -45,6 +45,29 @@ class SummaryTests(unittest.TestCase):
         self.assertEqual(summary["ingestion_runs"], [])
         self.assertEqual(summary["failures"], [])
 
+    def test_server_warnings_are_diagnostics_but_fatal_output_fails(self) -> None:
+        with tempfile.TemporaryDirectory() as temp:
+            run_dir = Path(temp); logs = run_dir / "logs"; logs.mkdir()
+            (logs / "server-1.log").write_text(" WARN retrying for person@example.com\n ERROR request recovered\n")
+            manifest = {"events": {"loads": [], "queries": [], "servers": [{"attempt": 1, "log": "logs/server-1.log", "status": "stopped"}]}}
+            summary = summarize.build_summary(run_dir, manifest)
+            self.assertEqual(summary["failures"], [])
+            self.assertEqual(summary["server_diagnostics"]["warning_count"], 1)
+            self.assertEqual(summary["server_diagnostics"]["error_count"], 1)
+            self.assertNotIn("person@example.com", json.dumps(summary))
+
+            (logs / "server-1.log").write_text("thread worker panicked at secret@example.com\n")
+            failed = summarize.build_summary(run_dir, manifest)
+            self.assertEqual(failed["failures"][0]["stage"], "server")
+            self.assertEqual(failed["server_diagnostics"]["panic_count"], 1)
+
+    def test_server_lifecycle_failure_is_reported(self) -> None:
+        with tempfile.TemporaryDirectory() as temp:
+            run_dir = Path(temp); logs = run_dir / "logs"; logs.mkdir()
+            (logs / "server.log").write_text("startup ended\n")
+            summary = summarize.build_summary(run_dir, {"events": {"loads": [], "queries": [], "servers": [{"attempt": 1, "log": "logs/server.log", "status": "unexpected_exit", "unexpected_exit": True}]}})
+        self.assertEqual(summary["failures"][0]["stage"], "server")
+
     def test_structured_results_do_not_require_logs(self) -> None:
         with tempfile.TemporaryDirectory() as temp:
             run_dir = Path(temp)
@@ -272,6 +295,14 @@ class QuerySetIdentityTests(unittest.TestCase):
 
 
 class WorkspaceTests(unittest.TestCase):
+    def test_port_probe_enables_address_reuse_and_retries(self) -> None:
+        sock = mock.MagicMock(); sock.__enter__.return_value = sock
+        with mock.patch.object(benchmark.socket, "socket", return_value=sock):
+            self.assertTrue(benchmark.port_available(8181))
+        sock.setsockopt.assert_called_once_with(benchmark.socket.SOL_SOCKET, benchmark.socket.SO_REUSEADDR, 1)
+        with mock.patch.object(benchmark, "port_available", side_effect=[False, True]), mock.patch.object(benchmark.time, "sleep"):
+            benchmark.check_port_available(8181)
+
     def test_new_run_layout_has_no_local_artifacts_or_managed_state(self) -> None:
         with tempfile.TemporaryDirectory() as temp:
             root = Path(temp)

--- a/.agents/skills/benchmark-influxdb3/tests/test_benchmark.py
+++ b/.agents/skills/benchmark-influxdb3/tests/test_benchmark.py
@@ -261,13 +261,13 @@ class SummaryTests(unittest.TestCase):
                 Path(temp),
                 {
                     "run_id": "run", "profile": "smoke", "database": "benchmark",
-                    "target": {"mode": "managed", "instance_id": "db-a", "edition": "core", "urls": ["http://localhost:8181"]},
+                    "target": {"mode": "managed", "database_id": "db-a", "edition": "core", "urls": ["http://localhost:8181"]},
                     "dataset": {"dataset_id": "data-a"},
                     "query_set": {"query_set_id": "set-a", "manifest_sha256": "abc"},
                     "events": {"loads": [], "queries": []},
                 },
             )
-        self.assertEqual(summary["target"]["instance_id"], "db-a")
+        self.assertEqual(summary["target"]["database_id"], "db-a")
         self.assertEqual(summary["query_set"]["query_set_id"], "set-a")
         rendered = summarize.render_markdown(summary)
         self.assertIn("managed:db-a", rendered)
@@ -417,19 +417,19 @@ class QuerySetTests(unittest.TestCase):
 
 class ManagedDatabaseTests(unittest.TestCase):
     def args(self, root: Path, mode: str | None = None) -> argparse.Namespace:
-        values = ["load", "--instance-id", "db-a", "--instance-root", str(root), "--database", "benchmark"]
+        values = ["load", "--database-id", "db-a", "--database-root", str(root), "--database", "benchmark"]
         if mode: values.extend(["--database-mode", mode])
         if mode == "reset": values.extend(["--confirm-reset", "benchmark"])
         return benchmark.make_parser().parse_args(values)
 
-    def prepare_instance(self, root: Path) -> Path:
+    def prepare_database(self, root: Path) -> Path:
         installation = root / "installation"; installation.mkdir(parents=True)
         binary = installation / "influxdb3"
         binary.write_text("#!/bin/sh\necho 'influxdb3 InfluxDB 3 Core, 3.11.1, revision test'\n", encoding="utf-8")
         binary.chmod(0o755)
         path = root / "db-a"; path.mkdir(); (path / "data").mkdir(); (path / "logs").mkdir()
         benchmark.save_json(path / "manifest.json", {
-            "schema_version": 1, "kind": "influxdb3-instance", "instance_id": "db-a",
+            "schema_version": 1, "kind": "influxdb3-database", "database_id": "db-a",
             "edition": "core", "version": "3.11.1", "installation_path": str(installation),
             "binary_sha256": benchmark.sha256_file(binary), "node_id": "db-a-node",
             "cluster_id": None, "license": {"status": "not-required", "source": None},
@@ -439,7 +439,7 @@ class ManagedDatabaseTests(unittest.TestCase):
 
     def test_workspace_bind_reuse_reset_and_lock(self) -> None:
         with tempfile.TemporaryDirectory() as temp:
-            root = Path(temp); self.prepare_instance(root); args = self.args(root); path, db = benchmark.prepare_database_workspace(args)
+            root = Path(temp); self.prepare_database(root); args = self.args(root); path, db = benchmark.prepare_database_workspace(args)
             self.assertEqual({p.name for p in path.iterdir()}, {"manifest.json", "data", "logs"})
             with benchmark.lock_database(path):
                 with self.assertRaisesRegex(benchmark.BenchmarkError, "locked"):
@@ -472,7 +472,7 @@ class ManagedDatabaseTests(unittest.TestCase):
 
     def test_failed_preflight_does_not_bind_database(self) -> None:
         with tempfile.TemporaryDirectory() as temp:
-            root = Path(temp); path = self.prepare_instance(root); args = self.args(root)
+            root = Path(temp); path = self.prepare_database(root); args = self.args(root)
             with mock.patch.object(
                 benchmark.subprocess,
                 "run",

--- a/.agents/skills/benchmark-influxdb3/tests/test_benchmark.py
+++ b/.agents/skills/benchmark-influxdb3/tests/test_benchmark.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import subprocess
 import sys
 import tempfile
 import unittest
@@ -392,7 +393,9 @@ class ManagedDatabaseTests(unittest.TestCase):
 
     def prepare_instance(self, root: Path) -> Path:
         installation = root / "installation"; installation.mkdir(parents=True)
-        binary = installation / "influxdb3"; binary.write_bytes(b"binary"); binary.chmod(0o755)
+        binary = installation / "influxdb3"
+        binary.write_text("#!/bin/sh\necho 'influxdb3 InfluxDB 3 Core, 3.11.1, revision test'\n", encoding="utf-8")
+        binary.chmod(0o755)
         path = root / "db-a"; path.mkdir(); (path / "data").mkdir(); (path / "logs").mkdir()
         benchmark.save_json(path / "manifest.json", {
             "schema_version": 1, "kind": "influxdb3-instance", "instance_id": "db-a",
@@ -435,6 +438,20 @@ class ManagedDatabaseTests(unittest.TestCase):
         benchmark.resolve_database(args)
         with self.assertRaisesRegex(benchmark.BenchmarkError, "exactly one"):
             benchmark.validate_args(args)
+
+    def test_failed_preflight_does_not_bind_database(self) -> None:
+        with tempfile.TemporaryDirectory() as temp:
+            root = Path(temp); path = self.prepare_instance(root); args = self.args(root)
+            with mock.patch.object(
+                benchmark.subprocess,
+                "run",
+                side_effect=subprocess.TimeoutExpired(["influxdb3", "--version"], 15),
+            ):
+                with self.assertRaisesRegex(benchmark.BenchmarkError, "not runnable"):
+                    benchmark.prepare_database_workspace(args)
+            persisted = json.loads((path / "manifest.json").read_text(encoding="utf-8"))
+            self.assertIsNone(persisted["database"])
+            self.assertIsNone(persisted["binding"])
 
 
 class TargetTests(unittest.TestCase):

--- a/.agents/skills/setup-influxdb3/SKILL.md
+++ b/.agents/skills/setup-influxdb3/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: setup-influxdb3
-description: Install checksum-verified, version-pinned InfluxDB 3 Core or Enterprise native binaries and prepare reusable local benchmark instances. Use for local InfluxDB 3 installation, instance setup, Enterprise trial/home activation, license-file setup, installation verification, or locating a managed binary for TSBS.
+description: Install checksum-verified latest or version-pinned InfluxDB 3 Core or Enterprise native distributions and prepare reusable local benchmark instances. Use for local InfluxDB 3 installation, instance setup, Enterprise trial/home activation, license-file setup, installation verification, or locating a managed binary for TSBS.
 ---
 
 # Setup InfluxDB 3
@@ -9,27 +9,29 @@ Use `scripts/setup.py` for deterministic installation and instance management.
 Read `references/setup.md` before choosing an edition, version, platform, or
 Enterprise license flow. Use `$benchmark-influxdb3` after preparing an instance.
 
-## Install an exact version
+## Install the official latest or an exact version
 
 Run from the repository root:
 
 ```bash
 python3 .agents/skills/setup-influxdb3/scripts/setup.py install \
-  --edition core --version 3.11.1
+  --edition core
 
 python3 .agents/skills/setup-influxdb3/scripts/setup.py install \
   --edition enterprise --version 3.11.1
 ```
 
-Always use an exact version. Resolve a request for “latest” from official
-InfluxData release documentation first, then pass the resolved version. The
-installer verifies the vendor SHA-256 file and publishes atomically.
+Omitting `--version` resolves the edition-specific latest version from the
+official InfluxData installer without executing it. Pass an exact semantic
+version for deterministic setup; the literal value `latest` is invalid. The
+installer verifies the vendor SHA-256 and complete extracted distribution,
+checks `influxdb3 --version`, and publishes atomically.
 
 ## Prepare an instance
 
 ```bash
 python3 .agents/skills/setup-influxdb3/scripts/setup.py prepare \
-  --instance-id core-311 --edition core --version 3.11.1
+  --instance-id core-latest --edition core
 
 python3 .agents/skills/setup-influxdb3/scripts/setup.py prepare \
   --instance-id enterprise-311 --edition enterprise --version 3.11.1
@@ -37,6 +39,8 @@ python3 .agents/skills/setup-influxdb3/scripts/setup.py prepare \
 
 Instances use a file object store and stable node/cluster identifiers. Existing
 instances are immutable with respect to edition, version, and binary checksum.
+Omitting `--version` resolves the official latest at command execution time;
+it never upgrades an existing instance automatically.
 
 ## Activate Enterprise
 

--- a/.agents/skills/setup-influxdb3/SKILL.md
+++ b/.agents/skills/setup-influxdb3/SKILL.md
@@ -1,0 +1,67 @@
+---
+name: setup-influxdb3
+description: Install checksum-verified, version-pinned InfluxDB 3 Core or Enterprise native binaries and prepare reusable local benchmark instances. Use for local InfluxDB 3 installation, instance setup, Enterprise trial/home activation, license-file setup, installation verification, or locating a managed binary for TSBS.
+---
+
+# Setup InfluxDB 3
+
+Use `scripts/setup.py` for deterministic installation and instance management.
+Read `references/setup.md` before choosing an edition, version, platform, or
+Enterprise license flow. Use `$benchmark-influxdb3` after preparing an instance.
+
+## Install an exact version
+
+Run from the repository root:
+
+```bash
+python3 .agents/skills/setup-influxdb3/scripts/setup.py install \
+  --edition core --version 3.11.1
+
+python3 .agents/skills/setup-influxdb3/scripts/setup.py install \
+  --edition enterprise --version 3.11.1
+```
+
+Always use an exact version. Resolve a request for “latest” from official
+InfluxData release documentation first, then pass the resolved version. The
+installer verifies the vendor SHA-256 file and publishes atomically.
+
+## Prepare an instance
+
+```bash
+python3 .agents/skills/setup-influxdb3/scripts/setup.py prepare \
+  --instance-id core-311 --edition core --version 3.11.1
+
+python3 .agents/skills/setup-influxdb3/scripts/setup.py prepare \
+  --instance-id enterprise-311 --edition enterprise --version 3.11.1
+```
+
+Instances use a file object store and stable node/cluster identifiers. Existing
+instances are immutable with respect to edition, version, and binary checksum.
+
+## Activate Enterprise
+
+For trial or home activation, start the command and ask the user to verify the
+email while it waits:
+
+```bash
+export INFLUXDB3_LICENSE_EMAIL=USER@example.com
+python3 .agents/skills/setup-influxdb3/scripts/setup.py activate \
+  --instance-id enterprise-311 --license-type trial
+```
+
+Alternatively pass `--license-file /absolute/path/license.jwt`. Override the
+email variable name with `--license-email-env`. Never record or repeat the email
+or license contents. Preserve activation logs on failure and
+rerun activation safely after verification.
+
+## Inspect and verify
+
+```bash
+python3 .agents/skills/setup-influxdb3/scripts/setup.py list
+python3 .agents/skills/setup-influxdb3/scripts/setup.py inspect --instance-id core-311
+python3 .agents/skills/setup-influxdb3/scripts/setup.py verify --instance-id core-311
+```
+
+Report the instance ID, edition, exact version, binary path and checksum, and
+Enterprise license status. Do not add the binary to `PATH` or alter system
+packages or services.

--- a/.agents/skills/setup-influxdb3/SKILL.md
+++ b/.agents/skills/setup-influxdb3/SKILL.md
@@ -53,9 +53,19 @@ python3 .agents/skills/setup-influxdb3/scripts/setup.py activate \
   --instance-id enterprise-311 --license-type trial
 ```
 
+Prefer `--license-email-stdin` when supplying the email interactively or from a
+secret pipe. It takes precedence over the environment variable, reads exactly
+one line, and uses a non-echoing prompt on a terminal:
+
+```bash
+python3 .agents/skills/setup-influxdb3/scripts/setup.py activate \
+  --instance-id enterprise-311 --license-type home --license-email-stdin
+```
+
 Alternatively pass `--license-file /absolute/path/license.jwt`. Override the
-email variable name with `--license-email-env`. Never record or repeat the email
-or license contents. Preserve activation logs on failure and
+email variable name with `--license-email-env`. Activation output is redacted
+while it is streamed and scrubbed again during cleanup. Never record or repeat
+the email or license contents. Preserve activation logs on failure and
 rerun activation safely after verification.
 
 ## Inspect and verify

--- a/.agents/skills/setup-influxdb3/SKILL.md
+++ b/.agents/skills/setup-influxdb3/SKILL.md
@@ -1,13 +1,13 @@
 ---
 name: setup-influxdb3
-description: Install checksum-verified latest or version-pinned InfluxDB 3 Core or Enterprise native distributions and prepare reusable local benchmark instances. Use for local InfluxDB 3 installation, instance setup, Enterprise trial/home activation, license-file setup, installation verification, or locating a managed binary for TSBS.
+description: Install checksum-verified latest or version-pinned InfluxDB 3 Core or Enterprise native distributions and prepare reusable local benchmark database workspaces. Use for local InfluxDB 3 installation, database setup, Enterprise trial/home activation, license-file setup, installation verification, or locating a managed binary for TSBS.
 ---
 
 # Setup InfluxDB 3
 
-Use `scripts/setup.py` for deterministic installation and instance management.
+Use `scripts/setup.py` for deterministic installation and database management.
 Read `references/setup.md` before choosing an edition, version, platform, or
-Enterprise license flow. Use `$benchmark-influxdb3` after preparing an instance.
+Enterprise license flow. Use `$benchmark-influxdb3` after preparing a database workspace.
 
 ## Install the official latest or an exact version
 
@@ -27,20 +27,20 @@ version for deterministic setup; the literal value `latest` is invalid. The
 installer verifies the vendor SHA-256 and complete extracted distribution,
 checks `influxdb3 --version`, and publishes atomically.
 
-## Prepare an instance
+## Prepare a database workspace
 
 ```bash
 python3 .agents/skills/setup-influxdb3/scripts/setup.py prepare \
-  --instance-id core-latest --edition core
+  --database-id core-latest --edition core
 
 python3 .agents/skills/setup-influxdb3/scripts/setup.py prepare \
-  --instance-id enterprise-311 --edition enterprise --version 3.11.1
+  --database-id enterprise-311 --edition enterprise --version 3.11.1
 ```
 
-Instances use a file object store and stable node/cluster identifiers. Existing
-instances are immutable with respect to edition, version, and binary checksum.
+Database workspaces use a file object store and stable node/cluster identifiers.
+Existing workspaces are immutable with respect to edition, version, and binary checksum.
 Omitting `--version` resolves the official latest at command execution time;
-it never upgrades an existing instance automatically.
+it never upgrades an existing database workspace automatically.
 
 ## Activate Enterprise
 
@@ -50,7 +50,7 @@ email while it waits:
 ```bash
 export INFLUXDB3_LICENSE_EMAIL=USER@example.com
 python3 .agents/skills/setup-influxdb3/scripts/setup.py activate \
-  --instance-id enterprise-311 --license-type trial
+  --database-id enterprise-311 --license-type trial
 ```
 
 Prefer `--license-email-stdin` when supplying the email interactively or from a
@@ -59,7 +59,7 @@ one line, and uses a non-echoing prompt on a terminal:
 
 ```bash
 python3 .agents/skills/setup-influxdb3/scripts/setup.py activate \
-  --instance-id enterprise-311 --license-type home --license-email-stdin
+  --database-id enterprise-311 --license-type home --license-email-stdin
 ```
 
 Alternatively pass `--license-file /absolute/path/license.jwt`. Override the
@@ -72,10 +72,10 @@ rerun activation safely after verification.
 
 ```bash
 python3 .agents/skills/setup-influxdb3/scripts/setup.py list
-python3 .agents/skills/setup-influxdb3/scripts/setup.py inspect --instance-id core-311
-python3 .agents/skills/setup-influxdb3/scripts/setup.py verify --instance-id core-311
+python3 .agents/skills/setup-influxdb3/scripts/setup.py inspect --database-id core-311
+python3 .agents/skills/setup-influxdb3/scripts/setup.py verify --database-id core-311
 ```
 
-Report the instance ID, edition, exact version, binary path and checksum, and
+Report the database ID, edition, exact version, binary path and checksum, and
 Enterprise license status. Do not add the binary to `PATH` or alter system
 packages or services.

--- a/.agents/skills/setup-influxdb3/agents/openai.yaml
+++ b/.agents/skills/setup-influxdb3/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Setup InfluxDB 3"
+  short_description: "Install and prepare local InfluxDB 3"
+  default_prompt: "Use $setup-influxdb3 to install and prepare a local InfluxDB 3 Core or Enterprise instance."

--- a/.agents/skills/setup-influxdb3/agents/openai.yaml
+++ b/.agents/skills/setup-influxdb3/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "Setup InfluxDB 3"
   short_description: "Install and prepare local InfluxDB 3"
-  default_prompt: "Use $setup-influxdb3 to install and prepare a local InfluxDB 3 Core or Enterprise instance."
+  default_prompt: "Use $setup-influxdb3 to install and prepare a local InfluxDB 3 Core or Enterprise database workspace."

--- a/.agents/skills/setup-influxdb3/references/setup.md
+++ b/.agents/skills/setup-influxdb3/references/setup.md
@@ -5,10 +5,10 @@
 ```text
 .benchmarks/influxdb3/
 ├── installations/<edition>/<version>/<platform>/{manifest.json,influxdb3,python/,...}
-└── instances/<instance-id>/{manifest.json,data/,logs/}
+└── databases/<database-id>/{manifest.json,data/,logs/}
 ```
 
-Installations and instances are reusable and checksum validated. Core and
+Installations and database workspaces are reusable and checksum validated. Core and
 Enterprise artifacts use the official archive pattern
 `influxdb3-<edition>-<version>_<platform>.tar.gz` and its adjacent `.sha256`.
 The complete vendor distribution is retained because the executable depends on
@@ -23,17 +23,17 @@ version; pass an exact version for offline or reproducible operation.
 Supported native platforms are Linux AMD64, Linux ARM64, and macOS ARM64.
 Intel macOS and Windows are intentionally unsupported by the managed workflow.
 
-## Instance defaults
+## Database workspace defaults
 
 - Bind HTTP to `127.0.0.1:8181` unless a different activation port is selected.
-- Use `--object-store=file` and the instance `data/` directory.
-- Derive a stable node ID from the instance ID.
+- Use `--object-store=file` and the database workspace's `data/` directory.
+- Derive a stable node ID from the database ID.
 - Add a distinct stable cluster ID for Enterprise.
-- Use `--without-auth` for isolated managed benchmark instances.
+- Use `--without-auth` for isolated managed benchmark databases.
 
 Enterprise requires an active license. Trial/home activation supplies the email
 and license type only to the server process; neither value is written to the
-instance manifest. A license-file setup records only its absolute path and
+database manifest. A license-file setup records only its absolute path and
 never copies or reads the JWT contents. Use `--license-email-stdin` for a
 one-line secret input; it overrides the compatible environment-variable path.
 Activation logs redact both the supplied value and email-shaped text while

--- a/.agents/skills/setup-influxdb3/references/setup.md
+++ b/.agents/skills/setup-influxdb3/references/setup.md
@@ -4,13 +4,21 @@
 
 ```text
 .benchmarks/influxdb3/
-├── installations/<edition>/<version>/<platform>/{manifest.json,influxdb3}
+├── installations/<edition>/<version>/<platform>/{manifest.json,influxdb3,python/,...}
 └── instances/<instance-id>/{manifest.json,data/,logs/}
 ```
 
 Installations and instances are reusable and checksum validated. Core and
 Enterprise artifacts use the official archive pattern
 `influxdb3-<edition>-<version>_<platform>.tar.gz` and its adjacent `.sha256`.
+The complete vendor distribution is retained because the executable depends on
+its adjacent bundled Python runtime. Reuse validates both the distribution
+checksum and `influxdb3 --version`.
+
+When `--version` is omitted, `install` and `prepare` parse the edition-specific
+version variable from InfluxData's official quick-installer script without
+executing it. Resolution failures do not fall back to a cached or guessed
+version; pass an exact version for offline or reproducible operation.
 
 Supported native platforms are Linux AMD64, Linux ARM64, and macOS ARM64.
 Intel macOS and Windows are intentionally unsupported by the managed workflow.

--- a/.agents/skills/setup-influxdb3/references/setup.md
+++ b/.agents/skills/setup-influxdb3/references/setup.md
@@ -1,0 +1,29 @@
+# InfluxDB 3 local setup reference
+
+## Workspace
+
+```text
+.benchmarks/influxdb3/
+├── installations/<edition>/<version>/<platform>/{manifest.json,influxdb3}
+└── instances/<instance-id>/{manifest.json,data/,logs/}
+```
+
+Installations and instances are reusable and checksum validated. Core and
+Enterprise artifacts use the official archive pattern
+`influxdb3-<edition>-<version>_<platform>.tar.gz` and its adjacent `.sha256`.
+
+Supported native platforms are Linux AMD64, Linux ARM64, and macOS ARM64.
+Intel macOS and Windows are intentionally unsupported by the managed workflow.
+
+## Instance defaults
+
+- Bind HTTP to `127.0.0.1:8181` unless a different activation port is selected.
+- Use `--object-store=file` and the instance `data/` directory.
+- Derive a stable node ID from the instance ID.
+- Add a distinct stable cluster ID for Enterprise.
+- Use `--without-auth` for isolated managed benchmark instances.
+
+Enterprise requires an active license. Trial/home activation supplies the email
+and license type only to the server process; neither value is written to the
+instance manifest. A license-file setup records only its absolute path and
+never copies or reads the JWT contents.

--- a/.agents/skills/setup-influxdb3/references/setup.md
+++ b/.agents/skills/setup-influxdb3/references/setup.md
@@ -34,4 +34,11 @@ Intel macOS and Windows are intentionally unsupported by the managed workflow.
 Enterprise requires an active license. Trial/home activation supplies the email
 and license type only to the server process; neither value is written to the
 instance manifest. A license-file setup records only its absolute path and
-never copies or reads the JWT contents.
+never copies or reads the JWT contents. Use `--license-email-stdin` for a
+one-line secret input; it overrides the compatible environment-variable path.
+Activation logs redact both the supplied value and email-shaped text while
+streaming, then receive a final scrub on cleanup.
+
+Port probes enable `SO_REUSEADDR` and retry briefly so a recently stopped local
+server in TCP `TIME_WAIT` does not cause a false conflict. An active listener is
+still rejected.

--- a/.agents/skills/setup-influxdb3/scripts/setup.py
+++ b/.agents/skills/setup-influxdb3/scripts/setup.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Install and prepare reusable local InfluxDB 3 instances."""
+"""Install and prepare reusable local InfluxDB 3 database workspaces."""
 
 from __future__ import annotations
 
@@ -30,7 +30,7 @@ SCRIPT_PATH = Path(__file__).resolve()
 REPO_ROOT = SCRIPT_PATH.parents[4]
 DEFAULT_ROOT = REPO_ROOT / ".benchmarks" / "influxdb3"
 DEFAULT_INSTALL_ROOT = DEFAULT_ROOT / "installations"
-DEFAULT_INSTANCE_ROOT = DEFAULT_ROOT / "instances"
+DEFAULT_DATABASE_ROOT = DEFAULT_ROOT / "databases"
 BASE_URL = "https://dl.influxdata.com/influxdb/releases"
 OFFICIAL_INSTALLER_URL = "https://www.influxdata.com/d/install_influxdb3.sh"
 USER_AGENT = "tsbs-influxdb3-setup/1.0"
@@ -336,41 +336,41 @@ def install(args: argparse.Namespace) -> dict[str, Any]:
             shutil.rmtree(temporary)
 
 
-def instance_path(args: argparse.Namespace) -> Path:
-    return (args.instance_root or DEFAULT_INSTANCE_ROOT).expanduser().resolve() / args.instance_id
+def database_path(args: argparse.Namespace) -> Path:
+    return (args.database_root or DEFAULT_DATABASE_ROOT).expanduser().resolve() / args.database_id
 
 
-def validate_instance(path: Path, expected_id: str | None = None) -> dict[str, Any]:
+def validate_database(path: Path, expected_id: str | None = None) -> dict[str, Any]:
     manifest = read_json(path / "manifest.json")
-    required = {"schema_version", "kind", "instance_id", "edition", "version", "installation_path", "binary_sha256", "node_id", "cluster_id", "license", "database", "binding"}
-    if manifest.get("schema_version") != SCHEMA_VERSION or manifest.get("kind") != "influxdb3-instance" or not required.issubset(manifest):
-        raise SetupError(f"malformed instance manifest: {path / 'manifest.json'}")
-    if expected_id and manifest["instance_id"] != expected_id:
-        raise SetupError("instance identity mismatch")
+    required = {"schema_version", "kind", "database_id", "edition", "version", "installation_path", "binary_sha256", "node_id", "cluster_id", "license", "database", "binding"}
+    if manifest.get("schema_version") != SCHEMA_VERSION or manifest.get("kind") != "influxdb3-database" or not required.issubset(manifest):
+        raise SetupError(f"malformed database manifest: {path / 'manifest.json'}")
+    if expected_id and manifest["database_id"] != expected_id:
+        raise SetupError("database identity mismatch")
     installation = Path(manifest["installation_path"])
     installed = validate_installation(installation, manifest["edition"], manifest["version"])
     if installed["binary_sha256"] != manifest["binary_sha256"]:
-        raise SetupError("instance installation checksum mismatch")
+        raise SetupError("database installation checksum mismatch")
     return manifest
 
 
 def prepare(args: argparse.Namespace) -> dict[str, Any]:
     installation = installation_path(args)
     installed = validate_installation(installation, args.edition, args.version)
-    path = instance_path(args)
+    path = database_path(args)
     if (path / "manifest.json").exists():
-        manifest = validate_instance(path, args.instance_id)
+        manifest = validate_database(path, args.database_id)
         identity = (manifest["edition"], manifest["version"], manifest["binary_sha256"])
         expected = (args.edition, args.version, installed["binary_sha256"])
         if identity != expected:
-            raise SetupError("instance is already bound to another edition, version, or binary")
-        return {**manifest, "instance_path": str(path), "reused": True}
+            raise SetupError("database is already bound to another edition, version, or binary")
+        return {**manifest, "database_path": str(path), "reused": True}
     path.mkdir(parents=True, exist_ok=True)
     (path / "data").mkdir(); (path / "logs").mkdir()
-    stem = re.sub(r"[^A-Za-z0-9-]", "-", args.instance_id)
+    stem = re.sub(r"[^A-Za-z0-9-]", "-", args.database_id)
     manifest = {
-        "schema_version": SCHEMA_VERSION, "kind": "influxdb3-instance",
-        "instance_id": args.instance_id, "edition": args.edition, "version": args.version,
+        "schema_version": SCHEMA_VERSION, "kind": "influxdb3-database",
+        "database_id": args.database_id, "edition": args.edition, "version": args.version,
         "version_source": args.version_source,
         "installation_path": str(installation), "binary_sha256": installed["binary_sha256"],
         "node_id": f"{stem}-node", "cluster_id": f"{stem}-cluster" if args.edition == "enterprise" else None,
@@ -378,7 +378,7 @@ def prepare(args: argparse.Namespace) -> dict[str, Any]:
         "database": None, "binding": None,
     }
     save_json(path / "manifest.json", manifest)
-    return {**manifest, "instance_path": str(path), "reused": False}
+    return {**manifest, "database_path": str(path), "reused": False}
 
 
 def wait_health(url: str, process: subprocess.Popen[Any], timeout: int) -> bool:
@@ -447,9 +447,9 @@ def scrub_log(path: Path, secrets: Sequence[str]) -> None:
 
 
 def activate(args: argparse.Namespace) -> dict[str, Any]:
-    path = instance_path(args); manifest = validate_instance(path, args.instance_id)
+    path = database_path(args); manifest = validate_database(path, args.database_id)
     if manifest["edition"] != "enterprise":
-        raise SetupError("license activation is only valid for Enterprise instances")
+        raise SetupError("license activation is only valid for Enterprise databases")
     if not wait_port_available(args.http_port):
         raise SetupError(f"HTTP port {args.http_port} is unavailable")
     installation = Path(manifest["installation_path"]); binary = installation / "influxdb3"
@@ -493,7 +493,7 @@ def activate(args: argparse.Namespace) -> dict[str, Any]:
     manifest["updated_at"] = utc_now(); save_json(path / "manifest.json", manifest)
     if not ready:
         raise SetupError(f"Enterprise was not ready within {args.activation_timeout}s; verify the email if required and see {log_path}")
-    return {**manifest, "instance_path": str(path)}
+    return {**manifest, "database_path": str(path)}
 
 
 def print_value(value: Any) -> None:
@@ -503,19 +503,19 @@ def print_value(value: Any) -> None:
 def make_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description=__doc__); sub = parser.add_subparsers(dest="command", required=True)
     install_parser = sub.add_parser("install"); install_parser.add_argument("--edition", choices=("core", "enterprise"), required=True); install_parser.add_argument("--version"); install_parser.add_argument("--install-root", type=Path); install_parser.add_argument("--reinstall", action="store_true")
-    prepare_parser = sub.add_parser("prepare"); prepare_parser.add_argument("--instance-id", required=True); prepare_parser.add_argument("--edition", choices=("core", "enterprise"), required=True); prepare_parser.add_argument("--version"); prepare_parser.add_argument("--install-root", type=Path); prepare_parser.add_argument("--instance-root", type=Path)
-    activate_parser = sub.add_parser("activate"); activate_parser.add_argument("--instance-id", required=True); activate_parser.add_argument("--instance-root", type=Path); license_group = activate_parser.add_mutually_exclusive_group(required=True); license_group.add_argument("--license-file", type=Path); license_group.add_argument("--license-type", choices=("trial", "home")); activate_parser.add_argument("--license-email-env", default="INFLUXDB3_LICENSE_EMAIL"); activate_parser.add_argument("--license-email-stdin", action="store_true", help="read the activation email securely from one line of standard input"); activate_parser.add_argument("--http-port", type=int, default=8181); activate_parser.add_argument("--activation-timeout", type=int, default=600)
-    list_parser = sub.add_parser("list"); list_parser.add_argument("--instance-root", type=Path)
-    inspect_parser = sub.add_parser("inspect"); inspect_parser.add_argument("--instance-id", required=True); inspect_parser.add_argument("--instance-root", type=Path)
-    verify_parser = sub.add_parser("verify"); verify_parser.add_argument("--instance-id", required=True); verify_parser.add_argument("--instance-root", type=Path)
+    prepare_parser = sub.add_parser("prepare"); prepare_parser.add_argument("--database-id", required=True); prepare_parser.add_argument("--edition", choices=("core", "enterprise"), required=True); prepare_parser.add_argument("--version"); prepare_parser.add_argument("--install-root", type=Path); prepare_parser.add_argument("--database-root", type=Path)
+    activate_parser = sub.add_parser("activate"); activate_parser.add_argument("--database-id", required=True); activate_parser.add_argument("--database-root", type=Path); license_group = activate_parser.add_mutually_exclusive_group(required=True); license_group.add_argument("--license-file", type=Path); license_group.add_argument("--license-type", choices=("trial", "home")); activate_parser.add_argument("--license-email-env", default="INFLUXDB3_LICENSE_EMAIL"); activate_parser.add_argument("--license-email-stdin", action="store_true", help="read the activation email securely from one line of standard input"); activate_parser.add_argument("--http-port", type=int, default=8181); activate_parser.add_argument("--activation-timeout", type=int, default=600)
+    list_parser = sub.add_parser("list"); list_parser.add_argument("--database-root", type=Path)
+    inspect_parser = sub.add_parser("inspect"); inspect_parser.add_argument("--database-id", required=True); inspect_parser.add_argument("--database-root", type=Path)
+    verify_parser = sub.add_parser("verify"); verify_parser.add_argument("--database-id", required=True); verify_parser.add_argument("--database-root", type=Path)
     return parser
 
 
 def validate_args(args: argparse.Namespace) -> None:
     if hasattr(args, "version") and args.version is not None and not VERSION_RE.fullmatch(args.version):
         raise SetupError("--version must be omitted or be an exact semantic version such as 3.11.1")
-    if hasattr(args, "instance_id") and not ID_RE.fullmatch(args.instance_id):
-        raise SetupError("--instance-id contains invalid characters")
+    if hasattr(args, "database_id") and not ID_RE.fullmatch(args.database_id):
+        raise SetupError("--database-id contains invalid characters")
     if args.command == "activate":
         if args.license_email_stdin and not args.license_type:
             raise SetupError("--license-email-stdin requires --license-type")
@@ -535,13 +535,13 @@ def main(argv: Sequence[str] | None = None) -> int:
         elif args.command == "prepare": value = prepare(args)
         elif args.command == "activate": value = activate(args)
         elif args.command in ("inspect", "verify"):
-            path = instance_path(args); value = {**validate_instance(path, args.instance_id), "instance_path": str(path)}
+            path = database_path(args); value = {**validate_database(path, args.database_id), "database_path": str(path)}
         else:
-            root = (args.instance_root or DEFAULT_INSTANCE_ROOT).expanduser().resolve(); value = []
+            root = (args.database_root or DEFAULT_DATABASE_ROOT).expanduser().resolve(); value = []
             if root.exists():
                 for path in sorted(root.iterdir()):
                     if path.is_dir():
-                        try: value.append({**validate_instance(path), "instance_path": str(path)})
+                        try: value.append({**validate_database(path), "database_path": str(path)})
                         except SetupError: continue
         print_value(value); return 0
     except (SetupError, OSError, tarfile.TarError, KeyError, TypeError) as exc:

--- a/.agents/skills/setup-influxdb3/scripts/setup.py
+++ b/.agents/skills/setup-influxdb3/scripts/setup.py
@@ -20,7 +20,7 @@ import tempfile
 import time
 import urllib.error
 import urllib.request
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 from typing import Any, Sequence
 
 
@@ -30,7 +30,10 @@ DEFAULT_ROOT = REPO_ROOT / ".benchmarks" / "influxdb3"
 DEFAULT_INSTALL_ROOT = DEFAULT_ROOT / "installations"
 DEFAULT_INSTANCE_ROOT = DEFAULT_ROOT / "instances"
 BASE_URL = "https://dl.influxdata.com/influxdb/releases"
+OFFICIAL_INSTALLER_URL = "https://www.influxdata.com/d/install_influxdb3.sh"
+USER_AGENT = "tsbs-influxdb3-setup/1.0"
 SCHEMA_VERSION = 1
+INSTALLATION_SCHEMA_VERSION = 2
 ID_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]*$")
 VERSION_RE = re.compile(r"^[0-9]+\.[0-9]+\.[0-9]+(?:[-+][A-Za-z0-9.-]+)?$")
 
@@ -86,48 +89,196 @@ def artifact_name(edition: str, version: str, target: str) -> str:
     return f"influxdb3-{edition}-{version}_{target}.tar.gz"
 
 
+def request(url: str) -> urllib.request.Request:
+    return urllib.request.Request(
+        url,
+        headers={"User-Agent": USER_AGENT, "Accept": "application/octet-stream,*/*"},
+    )
+
+
+def download_text(url: str) -> str:
+    try:
+        with urllib.request.urlopen(request(url), timeout=60) as response:
+            return response.read().decode("utf-8")
+    except (OSError, UnicodeError, urllib.error.URLError) as exc:
+        raise SetupError(f"could not download {url}: {exc}") from exc
+
+
+def resolve_official_version(edition: str) -> str:
+    variable = "INFLUXDB_OSS_VERSION" if edition == "core" else "INFLUXDB_ENT_VERSION"
+    script = download_text(OFFICIAL_INSTALLER_URL)
+    matches = re.findall(
+        rf'^\s*{re.escape(variable)}=["\']([^"\']+)["\']\s*$',
+        script,
+        flags=re.MULTILINE,
+    )
+    if len(matches) != 1 or not VERSION_RE.fullmatch(matches[0]):
+        raise SetupError(
+            f"could not resolve the official latest {edition} version; "
+            "provide an exact --version"
+        )
+    return matches[0]
+
+
+def resolve_args_version(args: argparse.Namespace) -> None:
+    if args.version is None:
+        args.version = resolve_official_version(args.edition)
+        args.version_source = "official-installer"
+    else:
+        args.version_source = "explicit"
+
+
 def installation_path(args: argparse.Namespace, target: str | None = None) -> Path:
     root = (args.install_root or DEFAULT_INSTALL_ROOT).expanduser().resolve()
     return root / args.edition / args.version / (target or platform_tag())
 
 
+def distribution_sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    entries = sorted(
+        (entry for entry in path.rglob("*") if entry.relative_to(path).as_posix() != "manifest.json"),
+        key=lambda entry: entry.relative_to(path).as_posix(),
+    )
+    for entry in entries:
+        relative = entry.relative_to(path).as_posix()
+        stat = entry.lstat()
+        mode = stat.st_mode & 0o7777
+        if entry.is_symlink():
+            kind = "symlink"
+            content = os.readlink(entry).encode()
+        elif entry.is_file():
+            kind = "file"
+            content = bytes.fromhex(sha256_file(entry))
+        elif entry.is_dir():
+            kind = "directory"
+            content = b""
+        else:
+            raise SetupError(f"unsupported installation entry: {entry}")
+        digest.update(f"{kind}\0{relative}\0{mode:o}\0".encode())
+        digest.update(content)
+        digest.update(b"\0")
+    return digest.hexdigest()
+
+
+def verify_binary(binary: Path, edition: str, version: str) -> None:
+    try:
+        result = subprocess.run(
+            [str(binary), "--version"],
+            cwd=binary.parent,
+            capture_output=True,
+            text=True,
+            timeout=15,
+            check=False,
+        )
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        raise SetupError(
+            f"InfluxDB 3 installation is not runnable: {binary}; reinstall with --reinstall: {exc}"
+        ) from exc
+    output = f"{result.stdout}\n{result.stderr}"
+    edition_name = "Core" if edition == "core" else "Enterprise"
+    reported = re.search(r"InfluxDB 3 (Core|Enterprise), ([^,\s]+)", output)
+    if result.returncode != 0 or reported is None or reported.groups() != (edition_name, version):
+        raise SetupError(
+            f"InfluxDB 3 installation failed version validation for {edition} {version}; "
+            "reinstall with --reinstall"
+        )
+
+
 def validate_installation(path: Path, edition: str | None = None, version: str | None = None) -> dict[str, Any]:
     manifest = read_json(path / "manifest.json")
     required = {"schema_version", "kind", "edition", "version", "platform", "binary", "binary_sha256", "archive_sha256"}
-    if manifest.get("schema_version") != SCHEMA_VERSION or manifest.get("kind") != "influxdb3-installation" or not required.issubset(manifest):
+    schema_version = manifest.get("schema_version")
+    if schema_version not in (1, INSTALLATION_SCHEMA_VERSION) or manifest.get("kind") != "influxdb3-installation" or not required.issubset(manifest):
+        raise SetupError(f"malformed installation manifest: {path / 'manifest.json'}")
+    if schema_version == INSTALLATION_SCHEMA_VERSION and (
+        manifest.get("version_source") not in ("explicit", "official-installer")
+        or not isinstance(manifest.get("distribution_sha256"), str)
+    ):
         raise SetupError(f"malformed installation manifest: {path / 'manifest.json'}")
     if edition and manifest["edition"] != edition:
         raise SetupError("installation edition mismatch")
     if version and manifest["version"] != version:
         raise SetupError("installation version mismatch")
     binary = path / manifest["binary"]
-    if not binary.is_file() or sha256_file(binary) != manifest["binary_sha256"]:
+    if not binary.is_file() or not os.access(binary, os.X_OK) or sha256_file(binary) != manifest["binary_sha256"]:
         raise SetupError(f"installation binary checksum mismatch: {binary}")
+    if schema_version == INSTALLATION_SCHEMA_VERSION:
+        expected_distribution = manifest.get("distribution_sha256")
+        if not isinstance(expected_distribution, str) or distribution_sha256(path) != expected_distribution:
+            raise SetupError(f"installation distribution checksum mismatch: {path}")
+    verify_binary(binary, manifest["edition"], manifest["version"])
     return manifest
 
 
 def download(url: str, destination: Path) -> None:
     try:
-        with urllib.request.urlopen(url, timeout=60) as response, destination.open("wb") as output:
+        with urllib.request.urlopen(request(url), timeout=60) as response, destination.open("wb") as output:
             shutil.copyfileobj(response, output)
     except (OSError, urllib.error.URLError) as exc:
         raise SetupError(f"could not download {url}: {exc}") from exc
 
 
-def safe_extract_binary(archive: Path, destination: Path) -> Path:
+def safe_extract_distribution(archive: Path, destination: Path, expected_root: str) -> Path:
     with tarfile.open(archive, "r:gz") as bundle:
-        members = [member for member in bundle.getmembers() if Path(member.name).name == "influxdb3" and member.isfile()]
-        if len(members) != 1:
-            raise SetupError("archive must contain exactly one influxdb3 binary")
-        member = members[0]
-        source = bundle.extractfile(member)
-        if source is None:
-            raise SetupError("could not read influxdb3 binary from archive")
-        binary = destination / "influxdb3"
-        with binary.open("wb") as output:
-            shutil.copyfileobj(source, output)
-        binary.chmod(0o755)
-        return binary
+        members = bundle.getmembers()
+        if not members:
+            raise SetupError("archive is empty")
+        validated: list[tuple[tarfile.TarInfo, PurePosixPath]] = []
+        for member in members:
+            source_path = PurePosixPath(member.name)
+            if source_path.is_absolute() or not source_path.parts or source_path.parts[0] != expected_root:
+                raise SetupError("archive must contain exactly the expected top-level directory")
+            relative = PurePosixPath(*source_path.parts[1:])
+            if any(part in ("", ".", "..") for part in relative.parts):
+                raise SetupError(f"unsafe archive path: {member.name}")
+            if member.islnk() or member.isdev() or member.isfifo():
+                raise SetupError(f"unsupported archive member: {member.name}")
+            if not (member.isdir() or member.isfile() or member.issym()):
+                raise SetupError(f"unsupported archive member: {member.name}")
+            if member.issym():
+                link = PurePosixPath(member.linkname)
+                if link.is_absolute():
+                    raise SetupError(f"unsafe archive symlink: {member.name}")
+                resolved: list[str] = list(relative.parent.parts)
+                for part in link.parts:
+                    if part in ("", "."):
+                        continue
+                    if part == "..":
+                        if not resolved:
+                            raise SetupError(f"archive symlink escapes distribution: {member.name}")
+                        resolved.pop()
+                    else:
+                        resolved.append(part)
+            validated.append((member, relative))
+
+        for member, relative in validated:
+            if not relative.parts or not member.isdir():
+                continue
+            target = destination.joinpath(*relative.parts)
+            target.mkdir(parents=True, exist_ok=True)
+            target.chmod(member.mode & 0o7777)
+        for member, relative in validated:
+            if not relative.parts or not member.isfile():
+                continue
+            target = destination.joinpath(*relative.parts)
+            target.parent.mkdir(parents=True, exist_ok=True)
+            source = bundle.extractfile(member)
+            if source is None:
+                raise SetupError(f"could not read archive member: {member.name}")
+            with source, target.open("wb") as output:
+                shutil.copyfileobj(source, output)
+            target.chmod(member.mode & 0o7777)
+        for member, relative in validated:
+            if not relative.parts or not member.issym():
+                continue
+            target = destination.joinpath(*relative.parts)
+            target.parent.mkdir(parents=True, exist_ok=True)
+            os.symlink(member.linkname, target)
+
+    binary = destination / "influxdb3"
+    if not binary.is_file():
+        raise SetupError("archive must contain exactly one root influxdb3 binary")
+    return binary
 
 
 def install(args: argparse.Namespace) -> dict[str, Any]:
@@ -151,15 +302,19 @@ def install(args: argparse.Namespace) -> dict[str, Any]:
         actual = sha256_file(archive)
         if actual != expected:
             raise SetupError(f"archive checksum mismatch: expected {expected}, got {actual}")
-        binary = safe_extract_binary(archive, temporary)
+        expected_root = f"influxdb3-{args.edition}-{args.version}"
+        binary = safe_extract_distribution(archive, temporary, expected_root)
+        archive.unlink(); checksum_file.unlink()
         manifest = {
-            "schema_version": SCHEMA_VERSION, "kind": "influxdb3-installation",
+            "schema_version": INSTALLATION_SCHEMA_VERSION, "kind": "influxdb3-installation",
             "edition": args.edition, "version": args.version, "platform": target,
+            "version_source": args.version_source,
             "created_at": utc_now(), "source_url": f"{BASE_URL}/{name}",
             "archive_sha256": actual, "binary": binary.name,
             "binary_sha256": sha256_file(binary),
+            "distribution_sha256": distribution_sha256(temporary),
         }
-        archive.unlink(); checksum_file.unlink(); save_json(temporary / "manifest.json", manifest)
+        save_json(temporary / "manifest.json", manifest)
         validate_installation(temporary, args.edition, args.version)
         if destination.exists():
             backup = destination.with_name(f".{destination.name}.old-{os.getpid()}")
@@ -213,6 +368,7 @@ def prepare(args: argparse.Namespace) -> dict[str, Any]:
     manifest = {
         "schema_version": SCHEMA_VERSION, "kind": "influxdb3-instance",
         "instance_id": args.instance_id, "edition": args.edition, "version": args.version,
+        "version_source": args.version_source,
         "installation_path": str(installation), "binary_sha256": installed["binary_sha256"],
         "node_id": f"{stem}-node", "cluster_id": f"{stem}-cluster" if args.edition == "enterprise" else None,
         "created_at": utc_now(), "updated_at": utc_now(), "license": {"status": "not-required" if args.edition == "core" else "unconfigured", "source": None},
@@ -297,8 +453,8 @@ def print_value(value: Any) -> None:
 
 def make_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description=__doc__); sub = parser.add_subparsers(dest="command", required=True)
-    install_parser = sub.add_parser("install"); install_parser.add_argument("--edition", choices=("core", "enterprise"), required=True); install_parser.add_argument("--version", required=True); install_parser.add_argument("--install-root", type=Path); install_parser.add_argument("--reinstall", action="store_true")
-    prepare_parser = sub.add_parser("prepare"); prepare_parser.add_argument("--instance-id", required=True); prepare_parser.add_argument("--edition", choices=("core", "enterprise"), required=True); prepare_parser.add_argument("--version", required=True); prepare_parser.add_argument("--install-root", type=Path); prepare_parser.add_argument("--instance-root", type=Path)
+    install_parser = sub.add_parser("install"); install_parser.add_argument("--edition", choices=("core", "enterprise"), required=True); install_parser.add_argument("--version"); install_parser.add_argument("--install-root", type=Path); install_parser.add_argument("--reinstall", action="store_true")
+    prepare_parser = sub.add_parser("prepare"); prepare_parser.add_argument("--instance-id", required=True); prepare_parser.add_argument("--edition", choices=("core", "enterprise"), required=True); prepare_parser.add_argument("--version"); prepare_parser.add_argument("--install-root", type=Path); prepare_parser.add_argument("--instance-root", type=Path)
     activate_parser = sub.add_parser("activate"); activate_parser.add_argument("--instance-id", required=True); activate_parser.add_argument("--instance-root", type=Path); license_group = activate_parser.add_mutually_exclusive_group(required=True); license_group.add_argument("--license-file", type=Path); license_group.add_argument("--license-type", choices=("trial", "home")); activate_parser.add_argument("--license-email-env", default="INFLUXDB3_LICENSE_EMAIL"); activate_parser.add_argument("--http-port", type=int, default=8181); activate_parser.add_argument("--activation-timeout", type=int, default=600)
     list_parser = sub.add_parser("list"); list_parser.add_argument("--instance-root", type=Path)
     inspect_parser = sub.add_parser("inspect"); inspect_parser.add_argument("--instance-id", required=True); inspect_parser.add_argument("--instance-root", type=Path)
@@ -307,8 +463,8 @@ def make_parser() -> argparse.ArgumentParser:
 
 
 def validate_args(args: argparse.Namespace) -> None:
-    if hasattr(args, "version") and not VERSION_RE.fullmatch(args.version):
-        raise SetupError("--version must be an exact semantic version such as 3.11.1")
+    if hasattr(args, "version") and args.version is not None and not VERSION_RE.fullmatch(args.version):
+        raise SetupError("--version must be omitted or be an exact semantic version such as 3.11.1")
     if hasattr(args, "instance_id") and not ID_RE.fullmatch(args.instance_id):
         raise SetupError("--instance-id contains invalid characters")
     if args.command == "activate":
@@ -322,6 +478,8 @@ def main(argv: Sequence[str] | None = None) -> int:
     args = make_parser().parse_args(argv)
     try:
         validate_args(args)
+        if args.command in ("install", "prepare"):
+            resolve_args_version(args)
         if args.command == "install": value = install(args)
         elif args.command == "prepare": value = prepare(args)
         elif args.command == "activate": value = activate(args)

--- a/.agents/skills/setup-influxdb3/scripts/setup.py
+++ b/.agents/skills/setup-influxdb3/scripts/setup.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import argparse
 import datetime as dt
+import getpass
 import hashlib
 import json
 import os
@@ -17,6 +18,7 @@ import subprocess
 import sys
 import tarfile
 import tempfile
+import threading
 import time
 import urllib.error
 import urllib.request
@@ -36,6 +38,7 @@ SCHEMA_VERSION = 1
 INSTALLATION_SCHEMA_VERSION = 2
 ID_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]*$")
 VERSION_RE = re.compile(r"^[0-9]+\.[0-9]+\.[0-9]+(?:[-+][A-Za-z0-9.-]+)?$")
+EMAIL_RE = re.compile(r"(?<![\w.+-])[\w.+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}(?![\w.-])")
 
 
 class SetupError(RuntimeError):
@@ -395,17 +398,59 @@ def wait_health(url: str, process: subprocess.Popen[Any], timeout: int) -> bool:
 
 def port_available(port: int) -> bool:
     with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
         try:
             sock.bind(("127.0.0.1", port)); return True
         except OSError:
             return False
 
 
+def wait_port_available(port: int, timeout: float = 2.0) -> bool:
+    deadline = time.monotonic() + timeout
+    while not port_available(port):
+        if time.monotonic() >= deadline:
+            return False
+        time.sleep(0.1)
+    return True
+
+
+def redact_emails(text: str, secrets: Sequence[str] = ()) -> str:
+    for secret in secrets:
+        if secret:
+            text = text.replace(secret, "<redacted-email>")
+    return EMAIL_RE.sub("<redacted-email>", text)
+
+
+def read_license_email(args: argparse.Namespace) -> str:
+    if args.license_email_stdin:
+        value = getpass.getpass("InfluxDB 3 license email: ") if sys.stdin.isatty() else sys.stdin.readline().rstrip("\r\n")
+    else:
+        value = os.environ.get(args.license_email_env, "")
+    if not value:
+        source = "standard input" if args.license_email_stdin else f"${args.license_email_env}"
+        raise SetupError(f"trial/home activation requires an email from {source}")
+    return value
+
+
+def stream_redacted_output(stream: Any, log: Any, secrets: Sequence[str]) -> None:
+    try:
+        for line in stream:
+            log.write(redact_emails(line, secrets)); log.flush()
+    finally:
+        stream.close()
+
+
+def scrub_log(path: Path, secrets: Sequence[str]) -> None:
+    if path.exists():
+        text = path.read_text(encoding="utf-8", errors="replace")
+        path.write_text(redact_emails(text, secrets), encoding="utf-8")
+
+
 def activate(args: argparse.Namespace) -> dict[str, Any]:
     path = instance_path(args); manifest = validate_instance(path, args.instance_id)
     if manifest["edition"] != "enterprise":
         raise SetupError("license activation is only valid for Enterprise instances")
-    if not port_available(args.http_port):
+    if not wait_port_available(args.http_port):
         raise SetupError(f"HTTP port {args.http_port} is unavailable")
     installation = Path(manifest["installation_path"]); binary = installation / "influxdb3"
     command = [str(binary), "serve", "--object-store=file", f"--data-dir={path / 'data'}", f"--node-id={manifest['node_id']}", f"--cluster-id={manifest['cluster_id']}", f"--http-bind=127.0.0.1:{args.http_port}", "--without-auth"]
@@ -416,27 +461,31 @@ def activate(args: argparse.Namespace) -> dict[str, Any]:
             raise SetupError(f"license file does not exist: {license_file}")
         command.append(f"--license-file={license_file}"); source = "file"
     else:
-        license_email = os.environ[args.license_email_env]
+        license_email = read_license_email(args)
         env["INFLUXDB3_LICENSE_EMAIL"] = license_email
         env["INFLUXDB3_LICENSE_TYPE"] = args.license_type
         source = args.license_type
     log_path = path / "logs" / "license-activation.log"
-    with log_path.open("a", encoding="utf-8") as log:
-        log.write(f"\nActivation attempt at {utc_now()} (source={source})\n"); log.flush()
-        process = subprocess.Popen(command, cwd=path, env=env, stdout=log, stderr=subprocess.STDOUT, start_new_session=True)
-        ready = False
-        try:
-            ready = wait_health(f"http://127.0.0.1:{args.http_port}", process, args.activation_timeout)
-        finally:
-            if process.poll() is None:
-                os.killpg(process.pid, signal.SIGTERM)
-                try: process.wait(timeout=15)
-                except subprocess.TimeoutExpired:
-                    os.killpg(process.pid, signal.SIGKILL); process.wait(timeout=5)
-    if args.license_type:
-        text = log_path.read_text(encoding="utf-8", errors="replace")
-        if license_email in text:
-            log_path.write_text(text.replace(license_email, "<redacted-email>"), encoding="utf-8")
+    secrets = (license_email,) if args.license_type else ()
+    try:
+        with log_path.open("a", encoding="utf-8") as log:
+            log.write(f"\nActivation attempt at {utc_now()} (source={source})\n"); log.flush()
+            process = subprocess.Popen(command, cwd=path, env=env, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True, bufsize=1, start_new_session=True)
+            assert process.stdout is not None
+            reader = threading.Thread(target=stream_redacted_output, args=(process.stdout, log, secrets), daemon=True)
+            reader.start()
+            ready = False
+            try:
+                ready = wait_health(f"http://127.0.0.1:{args.http_port}", process, args.activation_timeout)
+            finally:
+                if process.poll() is None:
+                    os.killpg(process.pid, signal.SIGTERM)
+                    try: process.wait(timeout=15)
+                    except subprocess.TimeoutExpired:
+                        os.killpg(process.pid, signal.SIGKILL); process.wait(timeout=5)
+                reader.join(timeout=5)
+    finally:
+        scrub_log(log_path, secrets)
     manifest["license"] = {
         "status": "active" if ready else "pending", "source": source,
         "path": str(license_file) if args.license_file else None,
@@ -455,7 +504,7 @@ def make_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description=__doc__); sub = parser.add_subparsers(dest="command", required=True)
     install_parser = sub.add_parser("install"); install_parser.add_argument("--edition", choices=("core", "enterprise"), required=True); install_parser.add_argument("--version"); install_parser.add_argument("--install-root", type=Path); install_parser.add_argument("--reinstall", action="store_true")
     prepare_parser = sub.add_parser("prepare"); prepare_parser.add_argument("--instance-id", required=True); prepare_parser.add_argument("--edition", choices=("core", "enterprise"), required=True); prepare_parser.add_argument("--version"); prepare_parser.add_argument("--install-root", type=Path); prepare_parser.add_argument("--instance-root", type=Path)
-    activate_parser = sub.add_parser("activate"); activate_parser.add_argument("--instance-id", required=True); activate_parser.add_argument("--instance-root", type=Path); license_group = activate_parser.add_mutually_exclusive_group(required=True); license_group.add_argument("--license-file", type=Path); license_group.add_argument("--license-type", choices=("trial", "home")); activate_parser.add_argument("--license-email-env", default="INFLUXDB3_LICENSE_EMAIL"); activate_parser.add_argument("--http-port", type=int, default=8181); activate_parser.add_argument("--activation-timeout", type=int, default=600)
+    activate_parser = sub.add_parser("activate"); activate_parser.add_argument("--instance-id", required=True); activate_parser.add_argument("--instance-root", type=Path); license_group = activate_parser.add_mutually_exclusive_group(required=True); license_group.add_argument("--license-file", type=Path); license_group.add_argument("--license-type", choices=("trial", "home")); activate_parser.add_argument("--license-email-env", default="INFLUXDB3_LICENSE_EMAIL"); activate_parser.add_argument("--license-email-stdin", action="store_true", help="read the activation email securely from one line of standard input"); activate_parser.add_argument("--http-port", type=int, default=8181); activate_parser.add_argument("--activation-timeout", type=int, default=600)
     list_parser = sub.add_parser("list"); list_parser.add_argument("--instance-root", type=Path)
     inspect_parser = sub.add_parser("inspect"); inspect_parser.add_argument("--instance-id", required=True); inspect_parser.add_argument("--instance-root", type=Path)
     verify_parser = sub.add_parser("verify"); verify_parser.add_argument("--instance-id", required=True); verify_parser.add_argument("--instance-root", type=Path)
@@ -468,7 +517,9 @@ def validate_args(args: argparse.Namespace) -> None:
     if hasattr(args, "instance_id") and not ID_RE.fullmatch(args.instance_id):
         raise SetupError("--instance-id contains invalid characters")
     if args.command == "activate":
-        if args.license_type and not os.environ.get(args.license_email_env):
+        if args.license_email_stdin and not args.license_type:
+            raise SetupError("--license-email-stdin requires --license-type")
+        if args.license_type and not args.license_email_stdin and not os.environ.get(args.license_email_env):
             raise SetupError(f"trial/home activation requires email in ${args.license_email_env}")
         if args.activation_timeout <= 0 or not 1 <= args.http_port <= 65535:
             raise SetupError("activation timeout and HTTP port must be positive and valid")

--- a/.agents/skills/setup-influxdb3/scripts/setup.py
+++ b/.agents/skills/setup-influxdb3/scripts/setup.py
@@ -1,0 +1,343 @@
+#!/usr/bin/env python3
+"""Install and prepare reusable local InfluxDB 3 instances."""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import hashlib
+import json
+import os
+import platform
+import re
+import shutil
+import signal
+import socket
+import subprocess
+import sys
+import tarfile
+import tempfile
+import time
+import urllib.error
+import urllib.request
+from pathlib import Path
+from typing import Any, Sequence
+
+
+SCRIPT_PATH = Path(__file__).resolve()
+REPO_ROOT = SCRIPT_PATH.parents[4]
+DEFAULT_ROOT = REPO_ROOT / ".benchmarks" / "influxdb3"
+DEFAULT_INSTALL_ROOT = DEFAULT_ROOT / "installations"
+DEFAULT_INSTANCE_ROOT = DEFAULT_ROOT / "instances"
+BASE_URL = "https://dl.influxdata.com/influxdb/releases"
+SCHEMA_VERSION = 1
+ID_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]*$")
+VERSION_RE = re.compile(r"^[0-9]+\.[0-9]+\.[0-9]+(?:[-+][A-Za-z0-9.-]+)?$")
+
+
+class SetupError(RuntimeError):
+    """Raised for an actionable setup failure."""
+
+
+def utc_now() -> str:
+    return dt.datetime.now(dt.timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def save_json(path: Path, value: Any) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temporary = path.with_name(f"{path.name}.tmp-{os.getpid()}")
+    temporary.write_text(json.dumps(value, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    os.replace(temporary, path)
+
+
+def read_json(path: Path) -> dict[str, Any]:
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except FileNotFoundError as exc:
+        raise SetupError(f"missing manifest: {path}") from exc
+    except json.JSONDecodeError as exc:
+        raise SetupError(f"invalid JSON manifest {path}: {exc}") from exc
+    if not isinstance(value, dict):
+        raise SetupError(f"manifest must be an object: {path}")
+    return value
+
+
+def sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as stream:
+        for chunk in iter(lambda: stream.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def platform_tag(system: str | None = None, machine: str | None = None) -> str:
+    system = system or platform.system()
+    machine = (machine or platform.machine()).lower()
+    if system == "Linux" and machine in ("x86_64", "amd64"):
+        return "linux_amd64"
+    if system == "Linux" and machine in ("aarch64", "arm64"):
+        return "linux_arm64"
+    if system == "Darwin" and machine in ("arm64", "aarch64"):
+        return "darwin_arm64"
+    raise SetupError(f"unsupported native platform: {system} {machine}")
+
+
+def artifact_name(edition: str, version: str, target: str) -> str:
+    return f"influxdb3-{edition}-{version}_{target}.tar.gz"
+
+
+def installation_path(args: argparse.Namespace, target: str | None = None) -> Path:
+    root = (args.install_root or DEFAULT_INSTALL_ROOT).expanduser().resolve()
+    return root / args.edition / args.version / (target or platform_tag())
+
+
+def validate_installation(path: Path, edition: str | None = None, version: str | None = None) -> dict[str, Any]:
+    manifest = read_json(path / "manifest.json")
+    required = {"schema_version", "kind", "edition", "version", "platform", "binary", "binary_sha256", "archive_sha256"}
+    if manifest.get("schema_version") != SCHEMA_VERSION or manifest.get("kind") != "influxdb3-installation" or not required.issubset(manifest):
+        raise SetupError(f"malformed installation manifest: {path / 'manifest.json'}")
+    if edition and manifest["edition"] != edition:
+        raise SetupError("installation edition mismatch")
+    if version and manifest["version"] != version:
+        raise SetupError("installation version mismatch")
+    binary = path / manifest["binary"]
+    if not binary.is_file() or sha256_file(binary) != manifest["binary_sha256"]:
+        raise SetupError(f"installation binary checksum mismatch: {binary}")
+    return manifest
+
+
+def download(url: str, destination: Path) -> None:
+    try:
+        with urllib.request.urlopen(url, timeout=60) as response, destination.open("wb") as output:
+            shutil.copyfileobj(response, output)
+    except (OSError, urllib.error.URLError) as exc:
+        raise SetupError(f"could not download {url}: {exc}") from exc
+
+
+def safe_extract_binary(archive: Path, destination: Path) -> Path:
+    with tarfile.open(archive, "r:gz") as bundle:
+        members = [member for member in bundle.getmembers() if Path(member.name).name == "influxdb3" and member.isfile()]
+        if len(members) != 1:
+            raise SetupError("archive must contain exactly one influxdb3 binary")
+        member = members[0]
+        source = bundle.extractfile(member)
+        if source is None:
+            raise SetupError("could not read influxdb3 binary from archive")
+        binary = destination / "influxdb3"
+        with binary.open("wb") as output:
+            shutil.copyfileobj(source, output)
+        binary.chmod(0o755)
+        return binary
+
+
+def install(args: argparse.Namespace) -> dict[str, Any]:
+    target = platform_tag()
+    destination = installation_path(args, target)
+    if destination.exists() and not args.reinstall:
+        manifest = validate_installation(destination, args.edition, args.version)
+        return {**manifest, "installation_path": str(destination), "reused": True}
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    name = artifact_name(args.edition, args.version, target)
+    temporary = Path(tempfile.mkdtemp(prefix=f".{args.edition}-{args.version}-", dir=destination.parent))
+    try:
+        archive = temporary / name
+        checksum_file = temporary / f"{name}.sha256"
+        download(f"{BASE_URL}/{name}", archive)
+        download(f"{BASE_URL}/{name}.sha256", checksum_file)
+        checksum_match = re.search(r"\b([0-9a-fA-F]{64})\b", checksum_file.read_text(encoding="utf-8"))
+        if not checksum_match:
+            raise SetupError("vendor checksum file is malformed")
+        expected = checksum_match.group(1).lower()
+        actual = sha256_file(archive)
+        if actual != expected:
+            raise SetupError(f"archive checksum mismatch: expected {expected}, got {actual}")
+        binary = safe_extract_binary(archive, temporary)
+        manifest = {
+            "schema_version": SCHEMA_VERSION, "kind": "influxdb3-installation",
+            "edition": args.edition, "version": args.version, "platform": target,
+            "created_at": utc_now(), "source_url": f"{BASE_URL}/{name}",
+            "archive_sha256": actual, "binary": binary.name,
+            "binary_sha256": sha256_file(binary),
+        }
+        archive.unlink(); checksum_file.unlink(); save_json(temporary / "manifest.json", manifest)
+        validate_installation(temporary, args.edition, args.version)
+        if destination.exists():
+            backup = destination.with_name(f".{destination.name}.old-{os.getpid()}")
+            os.replace(destination, backup)
+            try:
+                os.replace(temporary, destination)
+            except Exception:
+                os.replace(backup, destination)
+                raise
+            shutil.rmtree(backup)
+        else:
+            os.replace(temporary, destination)
+        return {**manifest, "installation_path": str(destination), "reused": False}
+    finally:
+        if temporary.exists():
+            shutil.rmtree(temporary)
+
+
+def instance_path(args: argparse.Namespace) -> Path:
+    return (args.instance_root or DEFAULT_INSTANCE_ROOT).expanduser().resolve() / args.instance_id
+
+
+def validate_instance(path: Path, expected_id: str | None = None) -> dict[str, Any]:
+    manifest = read_json(path / "manifest.json")
+    required = {"schema_version", "kind", "instance_id", "edition", "version", "installation_path", "binary_sha256", "node_id", "cluster_id", "license", "database", "binding"}
+    if manifest.get("schema_version") != SCHEMA_VERSION or manifest.get("kind") != "influxdb3-instance" or not required.issubset(manifest):
+        raise SetupError(f"malformed instance manifest: {path / 'manifest.json'}")
+    if expected_id and manifest["instance_id"] != expected_id:
+        raise SetupError("instance identity mismatch")
+    installation = Path(manifest["installation_path"])
+    installed = validate_installation(installation, manifest["edition"], manifest["version"])
+    if installed["binary_sha256"] != manifest["binary_sha256"]:
+        raise SetupError("instance installation checksum mismatch")
+    return manifest
+
+
+def prepare(args: argparse.Namespace) -> dict[str, Any]:
+    installation = installation_path(args)
+    installed = validate_installation(installation, args.edition, args.version)
+    path = instance_path(args)
+    if (path / "manifest.json").exists():
+        manifest = validate_instance(path, args.instance_id)
+        identity = (manifest["edition"], manifest["version"], manifest["binary_sha256"])
+        expected = (args.edition, args.version, installed["binary_sha256"])
+        if identity != expected:
+            raise SetupError("instance is already bound to another edition, version, or binary")
+        return {**manifest, "instance_path": str(path), "reused": True}
+    path.mkdir(parents=True, exist_ok=True)
+    (path / "data").mkdir(); (path / "logs").mkdir()
+    stem = re.sub(r"[^A-Za-z0-9-]", "-", args.instance_id)
+    manifest = {
+        "schema_version": SCHEMA_VERSION, "kind": "influxdb3-instance",
+        "instance_id": args.instance_id, "edition": args.edition, "version": args.version,
+        "installation_path": str(installation), "binary_sha256": installed["binary_sha256"],
+        "node_id": f"{stem}-node", "cluster_id": f"{stem}-cluster" if args.edition == "enterprise" else None,
+        "created_at": utc_now(), "updated_at": utc_now(), "license": {"status": "not-required" if args.edition == "core" else "unconfigured", "source": None},
+        "database": None, "binding": None,
+    }
+    save_json(path / "manifest.json", manifest)
+    return {**manifest, "instance_path": str(path), "reused": False}
+
+
+def wait_health(url: str, process: subprocess.Popen[Any], timeout: int) -> bool:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if process.poll() is not None:
+            return False
+        try:
+            with urllib.request.urlopen(url + "/health", timeout=2) as response:
+                if response.status == 200:
+                    return True
+        except (OSError, urllib.error.URLError):
+            pass
+        time.sleep(1)
+    return False
+
+
+def port_available(port: int) -> bool:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        try:
+            sock.bind(("127.0.0.1", port)); return True
+        except OSError:
+            return False
+
+
+def activate(args: argparse.Namespace) -> dict[str, Any]:
+    path = instance_path(args); manifest = validate_instance(path, args.instance_id)
+    if manifest["edition"] != "enterprise":
+        raise SetupError("license activation is only valid for Enterprise instances")
+    if not port_available(args.http_port):
+        raise SetupError(f"HTTP port {args.http_port} is unavailable")
+    installation = Path(manifest["installation_path"]); binary = installation / "influxdb3"
+    command = [str(binary), "serve", "--object-store=file", f"--data-dir={path / 'data'}", f"--node-id={manifest['node_id']}", f"--cluster-id={manifest['cluster_id']}", f"--http-bind=127.0.0.1:{args.http_port}", "--without-auth"]
+    env = os.environ.copy(); source: str
+    if args.license_file:
+        license_file = args.license_file.expanduser().resolve()
+        if not license_file.is_file():
+            raise SetupError(f"license file does not exist: {license_file}")
+        command.append(f"--license-file={license_file}"); source = "file"
+    else:
+        license_email = os.environ[args.license_email_env]
+        env["INFLUXDB3_LICENSE_EMAIL"] = license_email
+        env["INFLUXDB3_LICENSE_TYPE"] = args.license_type
+        source = args.license_type
+    log_path = path / "logs" / "license-activation.log"
+    with log_path.open("a", encoding="utf-8") as log:
+        log.write(f"\nActivation attempt at {utc_now()} (source={source})\n"); log.flush()
+        process = subprocess.Popen(command, cwd=path, env=env, stdout=log, stderr=subprocess.STDOUT, start_new_session=True)
+        ready = False
+        try:
+            ready = wait_health(f"http://127.0.0.1:{args.http_port}", process, args.activation_timeout)
+        finally:
+            if process.poll() is None:
+                os.killpg(process.pid, signal.SIGTERM)
+                try: process.wait(timeout=15)
+                except subprocess.TimeoutExpired:
+                    os.killpg(process.pid, signal.SIGKILL); process.wait(timeout=5)
+    if args.license_type:
+        text = log_path.read_text(encoding="utf-8", errors="replace")
+        if license_email in text:
+            log_path.write_text(text.replace(license_email, "<redacted-email>"), encoding="utf-8")
+    manifest["license"] = {
+        "status": "active" if ready else "pending", "source": source,
+        "path": str(license_file) if args.license_file else None,
+    }
+    manifest["updated_at"] = utc_now(); save_json(path / "manifest.json", manifest)
+    if not ready:
+        raise SetupError(f"Enterprise was not ready within {args.activation_timeout}s; verify the email if required and see {log_path}")
+    return {**manifest, "instance_path": str(path)}
+
+
+def print_value(value: Any) -> None:
+    print(json.dumps(value, indent=2, sort_keys=True))
+
+
+def make_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__); sub = parser.add_subparsers(dest="command", required=True)
+    install_parser = sub.add_parser("install"); install_parser.add_argument("--edition", choices=("core", "enterprise"), required=True); install_parser.add_argument("--version", required=True); install_parser.add_argument("--install-root", type=Path); install_parser.add_argument("--reinstall", action="store_true")
+    prepare_parser = sub.add_parser("prepare"); prepare_parser.add_argument("--instance-id", required=True); prepare_parser.add_argument("--edition", choices=("core", "enterprise"), required=True); prepare_parser.add_argument("--version", required=True); prepare_parser.add_argument("--install-root", type=Path); prepare_parser.add_argument("--instance-root", type=Path)
+    activate_parser = sub.add_parser("activate"); activate_parser.add_argument("--instance-id", required=True); activate_parser.add_argument("--instance-root", type=Path); license_group = activate_parser.add_mutually_exclusive_group(required=True); license_group.add_argument("--license-file", type=Path); license_group.add_argument("--license-type", choices=("trial", "home")); activate_parser.add_argument("--license-email-env", default="INFLUXDB3_LICENSE_EMAIL"); activate_parser.add_argument("--http-port", type=int, default=8181); activate_parser.add_argument("--activation-timeout", type=int, default=600)
+    list_parser = sub.add_parser("list"); list_parser.add_argument("--instance-root", type=Path)
+    inspect_parser = sub.add_parser("inspect"); inspect_parser.add_argument("--instance-id", required=True); inspect_parser.add_argument("--instance-root", type=Path)
+    verify_parser = sub.add_parser("verify"); verify_parser.add_argument("--instance-id", required=True); verify_parser.add_argument("--instance-root", type=Path)
+    return parser
+
+
+def validate_args(args: argparse.Namespace) -> None:
+    if hasattr(args, "version") and not VERSION_RE.fullmatch(args.version):
+        raise SetupError("--version must be an exact semantic version such as 3.11.1")
+    if hasattr(args, "instance_id") and not ID_RE.fullmatch(args.instance_id):
+        raise SetupError("--instance-id contains invalid characters")
+    if args.command == "activate":
+        if args.license_type and not os.environ.get(args.license_email_env):
+            raise SetupError(f"trial/home activation requires email in ${args.license_email_env}")
+        if args.activation_timeout <= 0 or not 1 <= args.http_port <= 65535:
+            raise SetupError("activation timeout and HTTP port must be positive and valid")
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = make_parser().parse_args(argv)
+    try:
+        validate_args(args)
+        if args.command == "install": value = install(args)
+        elif args.command == "prepare": value = prepare(args)
+        elif args.command == "activate": value = activate(args)
+        elif args.command in ("inspect", "verify"):
+            path = instance_path(args); value = {**validate_instance(path, args.instance_id), "instance_path": str(path)}
+        else:
+            root = (args.instance_root or DEFAULT_INSTANCE_ROOT).expanduser().resolve(); value = []
+            if root.exists():
+                for path in sorted(root.iterdir()):
+                    if path.is_dir():
+                        try: value.append({**validate_instance(path), "instance_path": str(path)})
+                        except SetupError: continue
+        print_value(value); return 0
+    except (SetupError, OSError, tarfile.TarError, KeyError, TypeError) as exc:
+        print(f"error: {exc}", file=sys.stderr); return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.agents/skills/setup-influxdb3/tests/test_setup.py
+++ b/.agents/skills/setup-influxdb3/tests/test_setup.py
@@ -4,6 +4,7 @@ import argparse
 import hashlib
 import io
 import json
+import os
 import sys
 import tarfile
 import tempfile
@@ -32,16 +33,28 @@ class PlatformTests(unittest.TestCase):
 
 
 class InstallationTests(unittest.TestCase):
-    def archive(self, path: Path, content: bytes = b"binary") -> str:
-        payload = path / "payload"
-        payload.write_bytes(content)
+    binary_content = b"#!/bin/sh\necho 'influxdb3 InfluxDB 3 Core, 3.11.1, revision test'\n"
+
+    def archive(self, path: Path, *, unsafe: str | None = None) -> str:
+        root = path / "influxdb3-core-3.11.1"
+        (root / "python/lib").mkdir(parents=True)
+        binary = root / "influxdb3"
+        binary.write_bytes(self.binary_content)
+        binary.chmod(0o755)
+        (root / "python/lib/libpython3.so").write_bytes(b"python")
+        os.symlink("libpython3.so", root / "python/lib/libpython.so")
         with tarfile.open(path / "artifact.tar.gz", "w:gz") as bundle:
-            bundle.add(payload, arcname="influxdb3")
+            bundle.add(root, arcname=root.name, recursive=True)
+            if unsafe is not None:
+                member = tarfile.TarInfo(unsafe)
+                member.size = 1
+                bundle.addfile(member, io.BytesIO(b"x"))
         return hashlib.sha256((path / "artifact.tar.gz").read_bytes()).hexdigest()
 
     def args(self, root: Path, reinstall: bool = False) -> argparse.Namespace:
         return argparse.Namespace(
-            edition="core", version="3.11.1", install_root=root, reinstall=reinstall
+            edition="core", version="3.11.1", version_source="explicit",
+            install_root=root, reinstall=reinstall
         )
 
     def test_install_verifies_and_reuses(self) -> None:
@@ -60,7 +73,11 @@ class InstallationTests(unittest.TestCase):
                 second = setup.install(self.args(root / "installations"))
             self.assertFalse(first["reused"])
             self.assertTrue(second["reused"])
-            self.assertEqual(first["binary_sha256"], hashlib.sha256(b"binary").hexdigest())
+            self.assertEqual(first["schema_version"], setup.INSTALLATION_SCHEMA_VERSION)
+            self.assertEqual(first["binary_sha256"], hashlib.sha256(self.binary_content).hexdigest())
+            installation = Path(first["installation_path"])
+            self.assertTrue((installation / "python/lib/libpython3.so").is_file())
+            self.assertTrue((installation / "python/lib/libpython.so").is_symlink())
 
     def test_checksum_failure_is_atomic(self) -> None:
         with tempfile.TemporaryDirectory() as temp:
@@ -76,11 +93,73 @@ class InstallationTests(unittest.TestCase):
                     setup.install(args)
             self.assertFalse(setup.installation_path(args, "linux_amd64").exists())
 
+    def test_distribution_corruption_is_detected(self) -> None:
+        with tempfile.TemporaryDirectory() as temp:
+            root = Path(temp); source = root / "source"; source.mkdir(); checksum = self.archive(source)
+            def download(_url: str, destination: Path) -> None:
+                if destination.name.endswith(".sha256"):
+                    destination.write_text(checksum, encoding="utf-8")
+                else:
+                    destination.write_bytes((source / "artifact.tar.gz").read_bytes())
+            args = self.args(root / "installations")
+            with mock.patch.object(setup, "platform_tag", return_value="linux_amd64"), mock.patch.object(setup, "download", side_effect=download):
+                value = setup.install(args)
+            (Path(value["installation_path"]) / "python/lib/libpython3.so").write_bytes(b"corrupt")
+            with self.assertRaisesRegex(setup.SetupError, "distribution checksum mismatch"):
+                setup.validate_installation(Path(value["installation_path"]))
+
+    def test_unsafe_archive_is_rejected_atomically(self) -> None:
+        with tempfile.TemporaryDirectory() as temp:
+            root = Path(temp); source = root / "source"; source.mkdir(); checksum = self.archive(source, unsafe="../escape")
+            def download(_url: str, destination: Path) -> None:
+                if destination.name.endswith(".sha256"):
+                    destination.write_text(checksum, encoding="utf-8")
+                else:
+                    destination.write_bytes((source / "artifact.tar.gz").read_bytes())
+            args = self.args(root / "installations")
+            with mock.patch.object(setup, "platform_tag", return_value="linux_amd64"), mock.patch.object(setup, "download", side_effect=download):
+                with self.assertRaisesRegex(setup.SetupError, "top-level directory"):
+                    setup.install(args)
+            self.assertFalse(setup.installation_path(args, "linux_amd64").exists())
+
+
+class VersionResolutionTests(unittest.TestCase):
+    def test_download_request_uses_explicit_identity_and_accept_header(self) -> None:
+        request = setup.request("https://example.test/artifact")
+        self.assertEqual(request.get_header("User-agent"), setup.USER_AGENT)
+        self.assertEqual(request.get_header("Accept"), "application/octet-stream,*/*")
+
+    def test_core_and_enterprise_resolve_from_official_installer(self) -> None:
+        script = 'INFLUXDB_OSS_VERSION="3.11.1"\nINFLUXDB_ENT_VERSION="3.12.0"\n'
+        with mock.patch.object(setup, "download_text", return_value=script):
+            self.assertEqual(setup.resolve_official_version("core"), "3.11.1")
+            self.assertEqual(setup.resolve_official_version("enterprise"), "3.12.0")
+
+    def test_resolution_requires_one_semantic_assignment(self) -> None:
+        for script in ('', 'INFLUXDB_OSS_VERSION="latest"', 'INFLUXDB_OSS_VERSION="3.11.1"\nINFLUXDB_OSS_VERSION="3.12.0"'):
+            with self.subTest(script=script), mock.patch.object(setup, "download_text", return_value=script):
+                with self.assertRaisesRegex(setup.SetupError, "provide an exact --version"):
+                    setup.resolve_official_version("core")
+
+    def test_explicit_version_bypasses_resolution(self) -> None:
+        explicit = setup.make_parser().parse_args(["install", "--edition", "core", "--version", "3.10.5"])
+        with mock.patch.object(setup, "resolve_official_version") as resolver:
+            setup.resolve_args_version(explicit)
+        resolver.assert_not_called()
+        self.assertEqual((explicit.version, explicit.version_source), ("3.10.5", "explicit"))
+
+        latest = setup.make_parser().parse_args(["prepare", "--edition", "core", "--instance-id", "core-a"])
+        with mock.patch.object(setup, "resolve_official_version", return_value="3.11.1"):
+            setup.resolve_args_version(latest)
+        self.assertEqual((latest.version, latest.version_source), ("3.11.1", "official-installer"))
+
 
 class InstanceTests(unittest.TestCase):
     def make_installation(self, root: Path, edition: str = "core") -> Path:
         path = root / "installations" / edition / "3.11.1" / "linux_amd64"
-        path.mkdir(parents=True); binary = path / "influxdb3"; binary.write_bytes(b"binary")
+        path.mkdir(parents=True); binary = path / "influxdb3"
+        name = "Core" if edition == "core" else "Enterprise"
+        binary.write_text(f"#!/bin/sh\necho 'influxdb3 InfluxDB 3 {name}, 3.11.1, revision test'\n", encoding="utf-8")
         binary.chmod(0o755)
         setup.save_json(path / "manifest.json", {
             "schema_version": 1, "kind": "influxdb3-installation", "edition": edition,
@@ -92,6 +171,7 @@ class InstanceTests(unittest.TestCase):
     def args(self, root: Path, edition: str = "core") -> argparse.Namespace:
         return argparse.Namespace(
             instance_id=f"{edition}-a", edition=edition, version="3.11.1",
+            version_source="explicit",
             install_root=root / "installations", instance_root=root / "instances",
         )
 
@@ -105,6 +185,7 @@ class InstanceTests(unittest.TestCase):
                     value = setup.prepare(args)
                     reused = setup.prepare(args)
                 self.assertEqual(value["edition"], edition)
+                self.assertEqual(value["version_source"], "explicit")
                 self.assertEqual(value["cluster_id"] is not None, edition == "enterprise")
                 self.assertTrue(reused["reused"])
 
@@ -121,7 +202,7 @@ class InstanceTests(unittest.TestCase):
             )
             process = mock.Mock(); process.poll.return_value = None; process.pid = 123
             process.wait.return_value = 0
-            with mock.patch.dict("os.environ", {"PRIVATE_LICENSE_EMAIL": "private@example.com"}), mock.patch.object(setup, "port_available", return_value=True), mock.patch.object(setup.subprocess, "Popen", return_value=process), mock.patch.object(setup, "wait_health", return_value=True), mock.patch.object(setup.os, "killpg"):
+            with mock.patch.dict("os.environ", {"PRIVATE_LICENSE_EMAIL": "private@example.com"}), mock.patch.object(setup, "verify_binary"), mock.patch.object(setup, "port_available", return_value=True), mock.patch.object(setup.subprocess, "Popen", return_value=process), mock.patch.object(setup, "wait_health", return_value=True), mock.patch.object(setup.os, "killpg"):
                 value = setup.activate(args)
             persisted = json.dumps(value)
             self.assertNotIn("private@example.com", persisted)
@@ -129,10 +210,11 @@ class InstanceTests(unittest.TestCase):
 
 
 class ArgumentTests(unittest.TestCase):
-    def test_exact_version_and_activation_email_are_required(self) -> None:
+    def test_version_must_be_omitted_or_exact_and_activation_email_is_required(self) -> None:
         args = setup.make_parser().parse_args(["install", "--edition", "core", "--version", "latest"])
-        with self.assertRaisesRegex(setup.SetupError, "exact semantic version"):
+        with self.assertRaisesRegex(setup.SetupError, "omitted or be an exact semantic version"):
             setup.validate_args(args)
+        setup.validate_args(setup.make_parser().parse_args(["install", "--edition", "core"]))
         args = setup.make_parser().parse_args(["activate", "--instance-id", "ent", "--license-type", "home"])
         with mock.patch.dict("os.environ", {}, clear=True):
             with self.assertRaisesRegex(setup.SetupError, "INFLUXDB3_LICENSE_EMAIL"):

--- a/.agents/skills/setup-influxdb3/tests/test_setup.py
+++ b/.agents/skills/setup-influxdb3/tests/test_setup.py
@@ -148,13 +148,13 @@ class VersionResolutionTests(unittest.TestCase):
         resolver.assert_not_called()
         self.assertEqual((explicit.version, explicit.version_source), ("3.10.5", "explicit"))
 
-        latest = setup.make_parser().parse_args(["prepare", "--edition", "core", "--instance-id", "core-a"])
+        latest = setup.make_parser().parse_args(["prepare", "--edition", "core", "--database-id", "core-a"])
         with mock.patch.object(setup, "resolve_official_version", return_value="3.11.1"):
             setup.resolve_args_version(latest)
         self.assertEqual((latest.version, latest.version_source), ("3.11.1", "official-installer"))
 
 
-class InstanceTests(unittest.TestCase):
+class DatabaseTests(unittest.TestCase):
     def make_installation(self, root: Path, edition: str = "core") -> Path:
         path = root / "installations" / edition / "3.11.1" / "linux_amd64"
         path.mkdir(parents=True); binary = path / "influxdb3"
@@ -170,9 +170,9 @@ class InstanceTests(unittest.TestCase):
 
     def args(self, root: Path, edition: str = "core") -> argparse.Namespace:
         return argparse.Namespace(
-            instance_id=f"{edition}-a", edition=edition, version="3.11.1",
+            database_id=f"{edition}-a", edition=edition, version="3.11.1",
             version_source="explicit",
-            install_root=root / "installations", instance_root=root / "instances",
+            install_root=root / "installations", database_root=root / "databases",
         )
 
     def test_prepare_core_and_enterprise_identities(self) -> None:
@@ -196,7 +196,7 @@ class InstanceTests(unittest.TestCase):
             with mock.patch.object(setup, "platform_tag", return_value="linux_amd64"):
                 setup.prepare(prepare_args)
             args = argparse.Namespace(
-                instance_id="enterprise-a", instance_root=root / "instances",
+                database_id="enterprise-a", database_root=root / "databases",
                 license_file=None, license_type="trial", license_email_env="PRIVATE_LICENSE_EMAIL",
                 license_email_stdin=False,
                 http_port=8181, activation_timeout=5,
@@ -208,14 +208,14 @@ class InstanceTests(unittest.TestCase):
                 value = setup.activate(args)
             persisted = json.dumps(value)
             self.assertNotIn("private@example.com", persisted)
-            activation_log = root / "instances/enterprise-a/logs/license-activation.log"
+            activation_log = root / "databases/enterprise-a/logs/license-activation.log"
             self.assertNotIn("private@example.com", activation_log.read_text())
             self.assertIn("<redacted-email>", activation_log.read_text())
             self.assertEqual(value["license"], {"status": "active", "source": "trial", "path": None})
 
     def test_stdin_email_takes_precedence_and_generic_emails_are_redacted(self) -> None:
         args = setup.make_parser().parse_args([
-            "activate", "--instance-id", "enterprise-a", "--license-type", "home",
+            "activate", "--database-id", "enterprise-a", "--license-type", "home",
             "--license-email-stdin",
         ])
         stdin = mock.Mock(); stdin.isatty.return_value = False; stdin.readline.return_value = "stdin@example.com\n"
@@ -242,11 +242,11 @@ class ArgumentTests(unittest.TestCase):
         with self.assertRaisesRegex(setup.SetupError, "omitted or be an exact semantic version"):
             setup.validate_args(args)
         setup.validate_args(setup.make_parser().parse_args(["install", "--edition", "core"]))
-        args = setup.make_parser().parse_args(["activate", "--instance-id", "ent", "--license-type", "home"])
+        args = setup.make_parser().parse_args(["activate", "--database-id", "ent", "--license-type", "home"])
         with mock.patch.dict("os.environ", {}, clear=True):
             with self.assertRaisesRegex(setup.SetupError, "INFLUXDB3_LICENSE_EMAIL"):
                 setup.validate_args(args)
-        stdin_args = setup.make_parser().parse_args(["activate", "--instance-id", "ent", "--license-type", "home", "--license-email-stdin"])
+        stdin_args = setup.make_parser().parse_args(["activate", "--database-id", "ent", "--license-type", "home", "--license-email-stdin"])
         with mock.patch.dict("os.environ", {}, clear=True):
             setup.validate_args(stdin_args)
 

--- a/.agents/skills/setup-influxdb3/tests/test_setup.py
+++ b/.agents/skills/setup-influxdb3/tests/test_setup.py
@@ -1,0 +1,143 @@
+from __future__ import annotations
+
+import argparse
+import hashlib
+import io
+import json
+import sys
+import tarfile
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+
+SCRIPTS = Path(__file__).resolve().parents[1] / "scripts"
+sys.path.insert(0, str(SCRIPTS))
+
+import setup  # noqa: E402
+
+
+class PlatformTests(unittest.TestCase):
+    def test_supported_platforms_and_artifact_names(self) -> None:
+        self.assertEqual(setup.platform_tag("Linux", "x86_64"), "linux_amd64")
+        self.assertEqual(setup.platform_tag("Linux", "aarch64"), "linux_arm64")
+        self.assertEqual(setup.platform_tag("Darwin", "arm64"), "darwin_arm64")
+        self.assertEqual(
+            setup.artifact_name("enterprise", "3.11.1", "linux_amd64"),
+            "influxdb3-enterprise-3.11.1_linux_amd64.tar.gz",
+        )
+        with self.assertRaises(setup.SetupError):
+            setup.platform_tag("Darwin", "x86_64")
+
+
+class InstallationTests(unittest.TestCase):
+    def archive(self, path: Path, content: bytes = b"binary") -> str:
+        payload = path / "payload"
+        payload.write_bytes(content)
+        with tarfile.open(path / "artifact.tar.gz", "w:gz") as bundle:
+            bundle.add(payload, arcname="influxdb3")
+        return hashlib.sha256((path / "artifact.tar.gz").read_bytes()).hexdigest()
+
+    def args(self, root: Path, reinstall: bool = False) -> argparse.Namespace:
+        return argparse.Namespace(
+            edition="core", version="3.11.1", install_root=root, reinstall=reinstall
+        )
+
+    def test_install_verifies_and_reuses(self) -> None:
+        with tempfile.TemporaryDirectory() as temp:
+            root = Path(temp); source = root / "source"; source.mkdir()
+            checksum = self.archive(source)
+
+            def download(_url: str, destination: Path) -> None:
+                if destination.name.endswith(".sha256"):
+                    destination.write_text(checksum + "  archive.tar.gz\n", encoding="utf-8")
+                else:
+                    destination.write_bytes((source / "artifact.tar.gz").read_bytes())
+
+            with mock.patch.object(setup, "platform_tag", return_value="linux_amd64"), mock.patch.object(setup, "download", side_effect=download):
+                first = setup.install(self.args(root / "installations"))
+                second = setup.install(self.args(root / "installations"))
+            self.assertFalse(first["reused"])
+            self.assertTrue(second["reused"])
+            self.assertEqual(first["binary_sha256"], hashlib.sha256(b"binary").hexdigest())
+
+    def test_checksum_failure_is_atomic(self) -> None:
+        with tempfile.TemporaryDirectory() as temp:
+            root = Path(temp); source = root / "source"; source.mkdir(); self.archive(source)
+            def download(_url: str, destination: Path) -> None:
+                if destination.name.endswith(".sha256"):
+                    destination.write_text("0" * 64, encoding="utf-8")
+                else:
+                    destination.write_bytes((source / "artifact.tar.gz").read_bytes())
+            args = self.args(root / "installations")
+            with mock.patch.object(setup, "platform_tag", return_value="linux_amd64"), mock.patch.object(setup, "download", side_effect=download):
+                with self.assertRaisesRegex(setup.SetupError, "checksum mismatch"):
+                    setup.install(args)
+            self.assertFalse(setup.installation_path(args, "linux_amd64").exists())
+
+
+class InstanceTests(unittest.TestCase):
+    def make_installation(self, root: Path, edition: str = "core") -> Path:
+        path = root / "installations" / edition / "3.11.1" / "linux_amd64"
+        path.mkdir(parents=True); binary = path / "influxdb3"; binary.write_bytes(b"binary")
+        binary.chmod(0o755)
+        setup.save_json(path / "manifest.json", {
+            "schema_version": 1, "kind": "influxdb3-installation", "edition": edition,
+            "version": "3.11.1", "platform": "linux_amd64", "binary": "influxdb3",
+            "binary_sha256": setup.sha256_file(binary), "archive_sha256": "a" * 64,
+        })
+        return path
+
+    def args(self, root: Path, edition: str = "core") -> argparse.Namespace:
+        return argparse.Namespace(
+            instance_id=f"{edition}-a", edition=edition, version="3.11.1",
+            install_root=root / "installations", instance_root=root / "instances",
+        )
+
+    def test_prepare_core_and_enterprise_identities(self) -> None:
+        with tempfile.TemporaryDirectory() as temp:
+            root = Path(temp)
+            for edition in ("core", "enterprise"):
+                self.make_installation(root, edition)
+                args = self.args(root, edition)
+                with mock.patch.object(setup, "platform_tag", return_value="linux_amd64"):
+                    value = setup.prepare(args)
+                    reused = setup.prepare(args)
+                self.assertEqual(value["edition"], edition)
+                self.assertEqual(value["cluster_id"] is not None, edition == "enterprise")
+                self.assertTrue(reused["reused"])
+
+    def test_activation_manifest_does_not_store_email(self) -> None:
+        with tempfile.TemporaryDirectory() as temp:
+            root = Path(temp); self.make_installation(root, "enterprise")
+            prepare_args = self.args(root, "enterprise")
+            with mock.patch.object(setup, "platform_tag", return_value="linux_amd64"):
+                setup.prepare(prepare_args)
+            args = argparse.Namespace(
+                instance_id="enterprise-a", instance_root=root / "instances",
+                license_file=None, license_type="trial", license_email_env="PRIVATE_LICENSE_EMAIL",
+                http_port=8181, activation_timeout=5,
+            )
+            process = mock.Mock(); process.poll.return_value = None; process.pid = 123
+            process.wait.return_value = 0
+            with mock.patch.dict("os.environ", {"PRIVATE_LICENSE_EMAIL": "private@example.com"}), mock.patch.object(setup, "port_available", return_value=True), mock.patch.object(setup.subprocess, "Popen", return_value=process), mock.patch.object(setup, "wait_health", return_value=True), mock.patch.object(setup.os, "killpg"):
+                value = setup.activate(args)
+            persisted = json.dumps(value)
+            self.assertNotIn("private@example.com", persisted)
+            self.assertEqual(value["license"], {"status": "active", "source": "trial", "path": None})
+
+
+class ArgumentTests(unittest.TestCase):
+    def test_exact_version_and_activation_email_are_required(self) -> None:
+        args = setup.make_parser().parse_args(["install", "--edition", "core", "--version", "latest"])
+        with self.assertRaisesRegex(setup.SetupError, "exact semantic version"):
+            setup.validate_args(args)
+        args = setup.make_parser().parse_args(["activate", "--instance-id", "ent", "--license-type", "home"])
+        with mock.patch.dict("os.environ", {}, clear=True):
+            with self.assertRaisesRegex(setup.SetupError, "INFLUXDB3_LICENSE_EMAIL"):
+                setup.validate_args(args)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.agents/skills/setup-influxdb3/tests/test_setup.py
+++ b/.agents/skills/setup-influxdb3/tests/test_setup.py
@@ -198,15 +198,42 @@ class InstanceTests(unittest.TestCase):
             args = argparse.Namespace(
                 instance_id="enterprise-a", instance_root=root / "instances",
                 license_file=None, license_type="trial", license_email_env="PRIVATE_LICENSE_EMAIL",
+                license_email_stdin=False,
                 http_port=8181, activation_timeout=5,
             )
             process = mock.Mock(); process.poll.return_value = None; process.pid = 123
+            process.stdout = io.StringIO("activation for private@example.com\n")
             process.wait.return_value = 0
             with mock.patch.dict("os.environ", {"PRIVATE_LICENSE_EMAIL": "private@example.com"}), mock.patch.object(setup, "verify_binary"), mock.patch.object(setup, "port_available", return_value=True), mock.patch.object(setup.subprocess, "Popen", return_value=process), mock.patch.object(setup, "wait_health", return_value=True), mock.patch.object(setup.os, "killpg"):
                 value = setup.activate(args)
             persisted = json.dumps(value)
             self.assertNotIn("private@example.com", persisted)
+            activation_log = root / "instances/enterprise-a/logs/license-activation.log"
+            self.assertNotIn("private@example.com", activation_log.read_text())
+            self.assertIn("<redacted-email>", activation_log.read_text())
             self.assertEqual(value["license"], {"status": "active", "source": "trial", "path": None})
+
+    def test_stdin_email_takes_precedence_and_generic_emails_are_redacted(self) -> None:
+        args = setup.make_parser().parse_args([
+            "activate", "--instance-id", "enterprise-a", "--license-type", "home",
+            "--license-email-stdin",
+        ])
+        stdin = mock.Mock(); stdin.isatty.return_value = False; stdin.readline.return_value = "stdin@example.com\n"
+        with mock.patch.object(setup.sys, "stdin", stdin), mock.patch.dict("os.environ", {"INFLUXDB3_LICENSE_EMAIL": "env@example.com"}):
+            self.assertEqual(setup.read_license_email(args), "stdin@example.com")
+        self.assertEqual(
+            setup.redact_emails("known stdin@example.com unknown other@example.org", ("stdin@example.com",)),
+            "known <redacted-email> unknown <redacted-email>",
+        )
+
+    def test_port_probe_enables_address_reuse_and_retries(self) -> None:
+        sock = mock.MagicMock()
+        sock.__enter__.return_value = sock
+        with mock.patch.object(setup.socket, "socket", return_value=sock):
+            self.assertTrue(setup.port_available(8181))
+        sock.setsockopt.assert_called_once_with(setup.socket.SOL_SOCKET, setup.socket.SO_REUSEADDR, 1)
+        with mock.patch.object(setup, "port_available", side_effect=[False, True]), mock.patch.object(setup.time, "sleep"):
+            self.assertTrue(setup.wait_port_available(8181))
 
 
 class ArgumentTests(unittest.TestCase):
@@ -219,6 +246,9 @@ class ArgumentTests(unittest.TestCase):
         with mock.patch.dict("os.environ", {}, clear=True):
             with self.assertRaisesRegex(setup.SetupError, "INFLUXDB3_LICENSE_EMAIL"):
                 setup.validate_args(args)
+        stdin_args = setup.make_parser().parse_args(["activate", "--instance-id", "ent", "--license-type", "home", "--license-email-stdin"])
+        with mock.patch.dict("os.environ", {}, clear=True):
+            setup.validate_args(stdin_args)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## What changed

- add a `setup-influxdb3` skill for checksum-verified, version-pinned Core and Enterprise installations
- add reusable managed instance setup with Enterprise trial, home, and license-file activation flows
- add a `benchmark-influxdb3` skill for managed instances and multi-endpoint external targets
- reuse shared TSBS datasets and immutable InfluxDB 3 SQL query sets
- record edition, version, durability settings, ingestion throughput, query latency, and diagnostics

## Why

TSBS already has a reusable GreptimeDB benchmarking workflow and InfluxDB 3 client support, but no equivalent agent skill for installing or benchmarking InfluxDB 3 Core and Enterprise. These skills provide a repeatable workflow while preserving database-reset safety and comparable artifacts.

## Impact

Users can prepare local Core or licensed Enterprise instances without modifying system packages or `PATH`, or benchmark existing external clusters. Credentials and license emails are excluded from manifests and command logs.

## Validation

- setup skill unit tests: 6 passed
- InfluxDB 3 benchmark skill unit tests: 18 passed
- GreptimeDB benchmark regression tests: 15 passed
- shared TSBS dataset tests: 11 passed
- relevant InfluxDB 3 Go package tests passed
- both skill validators passed
- end-to-end `influx3` query-generation smoke run passed
