### PR TITLE
refactor: share benchmark skill logic

### DIFF
--- a/.agents/lib/tsbs_benchmark.py
+++ b/.agents/lib/tsbs_benchmark.py
@@ -1,0 +1,437 @@
+"""Shared, database-neutral helpers for repository TSBS benchmark skills."""
+
+from __future__ import annotations
+
+import argparse
+import contextlib
+import datetime as dt
+import fcntl
+import hashlib
+import json
+import math
+import os
+import re
+from pathlib import Path
+from typing import Any, Callable, Iterator, Sequence, TypeVar
+
+
+RESULT_FORMAT_VERSION = "0.2"
+LEGACY_RESULT_FORMAT_VERSION = "0.1"
+
+QUERY_COUNTS_MANUAL = {
+    "cpu-max-all-1": 100,
+    "cpu-max-all-8": 100,
+    "double-groupby-1": 50,
+    "double-groupby-5": 50,
+    "double-groupby-all": 50,
+    "groupby-orderby-limit": 50,
+    "high-cpu-1": 100,
+    "high-cpu-all": 50,
+    "lastpoint": 10,
+    "single-groupby-1-1-1": 100,
+    "single-groupby-1-1-12": 100,
+    "single-groupby-1-8-1": 100,
+    "single-groupby-5-1-1": 100,
+    "single-groupby-5-1-12": 100,
+    "single-groupby-5-8-1": 100,
+}
+QUERY_TYPES = tuple(QUERY_COUNTS_MANUAL)
+PROFILES = {
+    "manual": {
+        "start": "2023-06-11T00:00:00Z",
+        "end": "2023-06-14T00:00:00Z",
+        "scale": 4000,
+        "seed": 123,
+        "log_interval": "10s",
+        "load_workers": 6,
+        "query_workers": 1,
+        "batch_size": 3000,
+        "query_counts": QUERY_COUNTS_MANUAL,
+    },
+    "smoke": {
+        "start": "2023-06-11T00:00:00Z",
+        "end": "2023-06-12T00:00:00Z",
+        "scale": 10,
+        "seed": 123,
+        "log_interval": "10s",
+        "load_workers": 2,
+        "query_workers": 1,
+        "batch_size": 3000,
+        "query_counts": {query_type: 10 for query_type in QUERY_TYPES},
+    },
+}
+
+METRIC_RE = re.compile(
+    r"loaded\s+(?P<count>\d+)\s+metrics\s+in\s+(?P<seconds>[0-9.]+)sec.*?"
+    r"mean rate\s+(?P<rate>[0-9.]+)\s+metrics/sec"
+)
+ROW_RE = re.compile(
+    r"loaded\s+(?P<count>\d+)\s+rows\s+in\s+(?P<seconds>[0-9.]+)sec.*?"
+    r"mean rate\s+(?P<rate>[0-9.]+)\s+rows/sec"
+)
+QUERY_RE = re.compile(
+    r"all queries\s*:\s*\n\s*"
+    r"min:.*?mean:\s*(?P<mean>[0-9.]+)ms,.*?count:\s*(?P<count>\d+)",
+    re.DOTALL,
+)
+
+
+class SummaryError(ValueError):
+    """Raised when a completed TSBS result or legacy log cannot be parsed."""
+
+
+ErrorType = TypeVar("ErrorType", bound=Exception)
+
+
+def utc_now() -> str:
+    return dt.datetime.now(dt.timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def canonical_json(value: Any) -> str:
+    return json.dumps(value, sort_keys=True, separators=(",", ":"), ensure_ascii=True)
+
+
+def sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as stream:
+        for chunk in iter(lambda: stream.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def save_json(path: Path, value: Any) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temporary = path.with_name(f"{path.name}.tmp-{os.getpid()}")
+    temporary.write_text(
+        json.dumps(value, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+    )
+    os.replace(temporary, path)
+
+
+def read_json(path: Path, error_type: type[ErrorType]) -> dict[str, Any]:
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except FileNotFoundError as exc:
+        raise error_type(f"missing manifest: {path}") from exc
+    except json.JSONDecodeError as exc:
+        raise error_type(f"invalid JSON manifest {path}: {exc}") from exc
+    if not isinstance(value, dict):
+        raise error_type(f"manifest must be an object: {path}")
+    return value
+
+
+def new_run_dir(run_root: Path) -> Path:
+    run_root.mkdir(parents=True, exist_ok=True)
+    base = dt.datetime.now(dt.timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    candidate = run_root / base
+    suffix = 1
+    while candidate.exists():
+        candidate = run_root / f"{base}-{suffix:02d}"
+        suffix += 1
+    return candidate
+
+
+def add_one_second(timestamp: str) -> str:
+    parsed = dt.datetime.fromisoformat(timestamp.replace("Z", "+00:00"))
+    return (parsed + dt.timedelta(seconds=1)).isoformat().replace("+00:00", "Z")
+
+
+def build_workload(
+    args: argparse.Namespace, base: dict[str, Any] | None = None
+) -> dict[str, Any]:
+    if base is not None and not args.profile:
+        workload = json.loads(json.dumps(base))
+    else:
+        workload = json.loads(json.dumps(PROFILES[args.profile or "manual"]))
+    for attr in (
+        "start",
+        "end",
+        "scale",
+        "seed",
+        "log_interval",
+        "load_workers",
+        "query_workers",
+        "batch_size",
+    ):
+        value = getattr(args, attr, None)
+        if value is not None:
+            workload[attr] = value
+    selected = sorted(set(args.query_type or workload["query_counts"]))
+    count_override = getattr(args, "queries", None)
+    workload["query_counts"] = {
+        query_type: count_override
+        if count_override is not None
+        else workload["query_counts"][query_type]
+        for query_type in selected
+    }
+    return workload
+
+
+def relative(run_dir: Path, path: Path) -> str:
+    return str(path.relative_to(run_dir))
+
+
+def query_file_path(query_dir: Path, query_type: str) -> Path:
+    return query_dir / "queries" / f"{query_type}.dat"
+
+
+def dataset_binding(dataset: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "dataset_id": dataset["dataset_id"],
+        "spec": dataset["spec"],
+        "format": dataset["format"],
+        "bytes": dataset["bytes"],
+        "sha256": dataset["sha256"],
+    }
+
+
+def next_attempt(
+    events: Sequence[dict[str, Any]], query_type: str | None = None
+) -> int:
+    matching = [
+        event
+        for event in events
+        if query_type is None or event.get("query_type") == query_type
+    ]
+    return max((int(event["attempt"]) for event in matching), default=0) + 1
+
+
+@contextlib.contextmanager
+def lock_directory(
+    path: Path, error_type: type[ErrorType], description: str
+) -> Iterator[None]:
+    descriptor = os.open(path, os.O_RDONLY)
+    try:
+        try:
+            fcntl.flock(descriptor, fcntl.LOCK_EX | fcntl.LOCK_NB)
+        except BlockingIOError as exc:
+            raise error_type(f"{description} is locked: {path}") from exc
+        yield
+    finally:
+        fcntl.flock(descriptor, fcntl.LOCK_UN)
+        os.close(descriptor)
+
+
+def _mapping(value: Any, field: str) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        raise SummaryError(f"result field {field} must be an object")
+    return value
+
+
+def _number(value: Any, field: str) -> float:
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        raise SummaryError(f"result field {field} must be a number")
+    result = float(value)
+    if not math.isfinite(result) or result < 0:
+        raise SummaryError(
+            f"result field {field} must be a non-negative finite number"
+        )
+    return result
+
+
+def _count(value: Any, field: str) -> int:
+    if isinstance(value, bool) or not isinstance(value, int) or value < 0:
+        raise SummaryError(f"result field {field} must be a non-negative integer")
+    return value
+
+
+def parse_load_result(result: dict[str, Any]) -> dict[str, Any]:
+    totals = _mapping(result.get("Totals"), "Totals")
+    metrics = _count(totals.get("metricCount"), "Totals.metricCount")
+    metric_rate = _number(totals.get("metricRate"), "Totals.metricRate")
+    rows = _count(totals.get("rowCount"), "Totals.rowCount")
+    row_rate = _number(totals.get("rowRate"), "Totals.rowRate")
+    parsed: dict[str, Any] = {
+        "metrics": metrics,
+        "duration_seconds": _number(result.get("DurationMillis"), "DurationMillis")
+        / 1000.0,
+        "metrics_per_second": metric_rate,
+    }
+    if rows > 0:
+        parsed.update({"rows": rows, "rows_per_second": row_rate})
+    return parsed
+
+
+def parse_query_result(result: dict[str, Any]) -> dict[str, Any]:
+    totals = _mapping(result.get("Totals"), "Totals")
+    overall_stats = _mapping(totals.get("overallStats"), "Totals.overallStats")
+    all_queries = _mapping(
+        overall_stats.get("all_queries"), "Totals.overallStats.all_queries"
+    )
+    return {
+        "mean_milliseconds": _number(
+            all_queries.get("meanMilliseconds"),
+            "Totals.overallStats.all_queries.meanMilliseconds",
+        ),
+        "count": _count(
+            all_queries.get("count"), "Totals.overallStats.all_queries.count"
+        ),
+    }
+
+
+def parse_load_log(text: str) -> dict[str, Any]:
+    metric_matches = list(METRIC_RE.finditer(text))
+    if not metric_matches:
+        raise SummaryError("load log has no final metric summary")
+    metric = metric_matches[-1]
+    result: dict[str, Any] = {
+        "metrics": int(metric.group("count")),
+        "duration_seconds": float(metric.group("seconds")),
+        "metrics_per_second": float(metric.group("rate")),
+    }
+    row_matches = list(ROW_RE.finditer(text))
+    if row_matches:
+        row = row_matches[-1]
+        result.update(
+            {
+                "rows": int(row.group("count")),
+                "rows_per_second": float(row.group("rate")),
+            }
+        )
+    return result
+
+
+def parse_query_log(text: str) -> dict[str, Any]:
+    marker = text.rfind("Run complete after")
+    if marker < 0:
+        raise SummaryError("query log has no final run marker")
+    matches = list(QUERY_RE.finditer(text[marker:]))
+    if not matches:
+        raise SummaryError("query log has no final all-queries summary")
+    match = matches[-1]
+    return {
+        "mean_milliseconds": float(match.group("mean")),
+        "count": int(match.group("count")),
+    }
+
+
+def read_log(run_dir: Path, relative_path: str) -> str:
+    return (run_dir / relative_path).read_text(encoding="utf-8", errors="replace")
+
+
+def _read_event_result(
+    run_dir: Path, event: dict[str, Any]
+) -> dict[str, Any] | None:
+    relative_path = event.get("results")
+    if not relative_path:
+        return None
+    path = run_dir / relative_path
+    try:
+        result = json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        raise SummaryError(f"malformed result JSON {relative_path}: {exc}") from exc
+    result = _mapping(result, str(relative_path))
+    version = result.get("ResultFormatVersion")
+    if version == LEGACY_RESULT_FORMAT_VERSION:
+        return None
+    if version != RESULT_FORMAT_VERSION:
+        raise SummaryError(
+            f"unsupported result format version {version!r} in {relative_path}"
+        )
+    return result
+
+
+def _parse_event(
+    run_dir: Path,
+    event: dict[str, Any],
+    result_parser: Callable[[dict[str, Any]], dict[str, Any]],
+    log_parser: Callable[[str], dict[str, Any]],
+) -> dict[str, Any]:
+    result = _read_event_result(run_dir, event)
+    if result is not None:
+        return result_parser(result)
+    return log_parser(read_log(run_dir, event["log"]))
+
+
+def build_summary(run_dir: Path, manifest: dict[str, Any]) -> dict[str, Any]:
+    failures: list[dict[str, str]] = []
+    ingestion_runs: list[dict[str, Any]] = []
+    query_runs: list[dict[str, Any]] = []
+
+    for event in manifest.get("events", {}).get("loads", []):
+        if event.get("status") == "reused":
+            continue
+        base = {
+            "attempt": event["attempt"],
+            "database": event["database"],
+            "mode": event["database_mode"],
+            "log": event["log"],
+        }
+        if event.get("status") != "completed":
+            failures.append(
+                {
+                    "stage": "load",
+                    "log": event["log"],
+                    "reason": event.get("status", "failed"),
+                }
+            )
+            continue
+        try:
+            base.update(
+                _parse_event(run_dir, event, parse_load_result, parse_load_log)
+            )
+            ingestion_runs.append(base)
+        except (OSError, SummaryError) as exc:
+            failures.append(
+                {"stage": "load", "log": event["log"], "reason": str(exc)}
+            )
+
+    for event in manifest.get("events", {}).get("queries", []):
+        base = {
+            "query_type": event["query_type"],
+            "attempt": event["attempt"],
+            "database": event["database"],
+            "log": event["log"],
+        }
+        if event.get("status") != "completed":
+            failures.append(
+                {
+                    "stage": "query",
+                    "log": event["log"],
+                    "reason": event.get("status", "failed"),
+                }
+            )
+            continue
+        try:
+            base.update(
+                _parse_event(run_dir, event, parse_query_result, parse_query_log)
+            )
+            query_runs.append(base)
+        except (OSError, SummaryError) as exc:
+            failures.append(
+                {"stage": "query", "log": event["log"], "reason": str(exc)}
+            )
+
+    grouped: dict[tuple[str, str], list[dict[str, Any]]] = {}
+    for run in query_runs:
+        key = (run["database"], run["query_type"])
+        grouped.setdefault(key, []).append(run)
+
+    queries: list[dict[str, Any]] = []
+    for database, query_type in sorted(grouped):
+        runs = grouped[(database, query_type)]
+        count = sum(run["count"] for run in runs)
+        weighted = sum(run["mean_milliseconds"] * run["count"] for run in runs)
+        queries.append(
+            {
+                "database": database,
+                "query_type": query_type,
+                "repetitions": len(runs),
+                "query_count": count,
+                "weighted_mean_milliseconds": weighted / count if count else 0.0,
+                "runs": runs,
+            }
+        )
+
+    return {
+        "run_id": manifest.get("run_id", run_dir.name),
+        "profile": manifest.get("profile"),
+        "database": manifest.get("database"),
+        "target": manifest.get("target"),
+        "dataset": manifest.get("dataset"),
+        "query_set": manifest.get("query_set"),
+        "workload": manifest.get("workload", {}),
+        "ingestion_runs": ingestion_runs,
+        "queries": queries,
+        "failures": failures,
+    }

--- a/.agents/skills/benchmark-greptimedb/scripts/benchmark.py
+++ b/.agents/skills/benchmark-greptimedb/scripts/benchmark.py
@@ -5,8 +5,6 @@ from __future__ import annotations
 
 import argparse
 import contextlib
-import datetime as dt
-import fcntl
 import hashlib
 import json
 import os
@@ -24,10 +22,29 @@ import urllib.request
 from pathlib import Path
 from typing import Any, Iterator, Sequence
 
+SCRIPT_PATH = Path(__file__).resolve()
+sys.path.insert(0, str(SCRIPT_PATH.parents[3] / "lib"))
+
+from tsbs_benchmark import (  # noqa: E402
+    PROFILES,
+    QUERY_TYPES,
+    add_one_second,
+    build_workload,
+    canonical_json,
+    dataset_binding,
+    lock_directory,
+    new_run_dir as shared_new_run_dir,
+    next_attempt,
+    query_file_path,
+    read_json as shared_read_json,
+    relative,
+    save_json,
+    sha256_file,
+    utc_now,
+)
 from summarize import write_summary
 
 
-SCRIPT_PATH = Path(__file__).resolve()
 REPO_ROOT = SCRIPT_PATH.parents[4]
 BENCHMARK_ROOT = REPO_ROOT / ".benchmarks"
 DEFAULT_RUN_ROOT = BENCHMARK_ROOT / "greptimedb" / "runs"
@@ -39,29 +56,6 @@ DEFAULT_DATABASE = "benchmark"
 SCHEMA_VERSION = 1
 ID_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]*$")
 DATA_WORKLOAD_OPTIONS = ("start", "end", "scale", "seed", "log_interval")
-
-QUERY_COUNTS_MANUAL = {
-    "cpu-max-all-1": 100, "cpu-max-all-8": 100, "double-groupby-1": 50,
-    "double-groupby-5": 50, "double-groupby-all": 50, "groupby-orderby-limit": 50,
-    "high-cpu-1": 100, "high-cpu-all": 50, "lastpoint": 10,
-    "single-groupby-1-1-1": 100, "single-groupby-1-1-12": 100,
-    "single-groupby-1-8-1": 100, "single-groupby-5-1-1": 100,
-    "single-groupby-5-1-12": 100, "single-groupby-5-8-1": 100,
-}
-QUERY_TYPES = tuple(QUERY_COUNTS_MANUAL)
-PROFILES = {
-    "manual": {
-        "start": "2023-06-11T00:00:00Z", "end": "2023-06-14T00:00:00Z",
-        "scale": 4000, "seed": 123, "log_interval": "10s", "load_workers": 6,
-        "query_workers": 1, "batch_size": 3000, "query_counts": QUERY_COUNTS_MANUAL,
-    },
-    "smoke": {
-        "start": "2023-06-11T00:00:00Z", "end": "2023-06-12T00:00:00Z",
-        "scale": 10, "seed": 123, "log_interval": "10s", "load_workers": 2,
-        "query_workers": 1, "batch_size": 3000,
-        "query_counts": {query_type: 10 for query_type in QUERY_TYPES},
-    },
-}
 BINARIES = {"queries": "tsbs_generate_queries", "load": "tsbs_load_greptime", "query": "tsbs_run_queries_influx"}
 BUILT_THIS_PROCESS: set[str] = set()
 
@@ -70,55 +64,12 @@ class BenchmarkError(RuntimeError):
     """Raised for an actionable benchmark failure."""
 
 
-def utc_now() -> str:
-    return dt.datetime.now(dt.timezone.utc).isoformat().replace("+00:00", "Z")
-
-
-def canonical_json(value: Any) -> str:
-    return json.dumps(value, sort_keys=True, separators=(",", ":"), ensure_ascii=True)
-
-
-def sha256_file(path: Path) -> str:
-    digest = hashlib.sha256()
-    with path.open("rb") as stream:
-        for chunk in iter(lambda: stream.read(1024 * 1024), b""):
-            digest.update(chunk)
-    return digest.hexdigest()
-
-
-def save_json(path: Path, value: Any) -> None:
-    path.parent.mkdir(parents=True, exist_ok=True)
-    temporary = path.with_name(f"{path.name}.tmp-{os.getpid()}")
-    temporary.write_text(json.dumps(value, indent=2, sort_keys=True) + "\n", encoding="utf-8")
-    os.replace(temporary, path)
-
-
 def read_json(path: Path) -> dict[str, Any]:
-    try:
-        value = json.loads(path.read_text(encoding="utf-8"))
-    except FileNotFoundError as exc:
-        raise BenchmarkError(f"missing manifest: {path}") from exc
-    except json.JSONDecodeError as exc:
-        raise BenchmarkError(f"invalid JSON manifest {path}: {exc}") from exc
-    if not isinstance(value, dict):
-        raise BenchmarkError(f"manifest must be an object: {path}")
-    return value
+    return shared_read_json(path, BenchmarkError)
 
 
 def new_run_dir(run_root: Path = DEFAULT_RUN_ROOT) -> Path:
-    run_root.mkdir(parents=True, exist_ok=True)
-    base = dt.datetime.now(dt.timezone.utc).strftime("%Y%m%dT%H%M%SZ")
-    candidate = run_root / base
-    suffix = 1
-    while candidate.exists():
-        candidate = run_root / f"{base}-{suffix:02d}"
-        suffix += 1
-    return candidate
-
-
-def add_one_second(timestamp: str) -> str:
-    parsed = dt.datetime.fromisoformat(timestamp.replace("Z", "+00:00"))
-    return (parsed + dt.timedelta(seconds=1)).isoformat().replace("+00:00", "Z")
+    return shared_new_run_dir(run_root)
 
 
 def validate_run_manifest(manifest: dict[str, Any], path: Path) -> None:
@@ -176,25 +127,6 @@ def prepare_run(args: argparse.Namespace) -> tuple[Path, dict[str, Any]]:
         raise BenchmarkError("--database conflicts with the database pinned by this run")
     save_manifest(run_dir, manifest)
     return run_dir, manifest
-
-
-def build_workload(args: argparse.Namespace, base: dict[str, Any] | None = None) -> dict[str, Any]:
-    if base is not None and not args.profile:
-        workload = json.loads(json.dumps(base))
-    else:
-        workload = json.loads(json.dumps(PROFILES[args.profile or "manual"]))
-    for attr in ("start", "end", "scale", "seed", "log_interval", "load_workers", "query_workers", "batch_size"):
-        value = getattr(args, attr, None)
-        if value is not None:
-            workload[attr] = value
-    selected = sorted(set(args.query_type or workload["query_counts"]))
-    count_override = getattr(args, "queries", None)
-    workload["query_counts"] = {query_type: count_override if count_override is not None else workload["query_counts"][query_type] for query_type in selected}
-    return workload
-
-
-def relative(run_dir: Path, path: Path) -> str:
-    return str(path.relative_to(run_dir))
 
 
 def display_command(command: Sequence[str]) -> str:
@@ -316,10 +248,6 @@ def query_set_path(query_root: Path, dataset_id: str, set_id: str) -> Path:
     return query_root / dataset_id / "greptime" / set_id
 
 
-def query_file_path(query_dir: Path, query_type: str) -> Path:
-    return query_dir / "queries" / f"{query_type}.dat"
-
-
 def validate_query_set(query_dir: Path, expected_spec: dict[str, Any]) -> dict[str, Any]:
     manifest_path = query_dir / "manifest.json"; manifest = read_json(manifest_path)
     required = {"schema_version", "kind", "query_set_id", "created_at", "spec", "generator", "files"}
@@ -435,22 +363,8 @@ def prepare_database_workspace(args: argparse.Namespace) -> tuple[Path, dict[str
 
 @contextlib.contextmanager
 def lock_database(path: Path) -> Iterator[None]:
-    descriptor = os.open(path, os.O_RDONLY)
-    try:
-        try: fcntl.flock(descriptor, fcntl.LOCK_EX | fcntl.LOCK_NB)
-        except BlockingIOError as exc: raise BenchmarkError(f"managed database workspace is locked: {path}") from exc
+    with lock_directory(path, BenchmarkError, "managed database workspace"):
         yield
-    finally:
-        fcntl.flock(descriptor, fcntl.LOCK_UN); os.close(descriptor)
-
-
-def dataset_binding(dataset: dict[str, Any]) -> dict[str, Any]:
-    return {"dataset_id": dataset["dataset_id"], "spec": dataset["spec"], "format": dataset["format"], "bytes": dataset["bytes"], "sha256": dataset["sha256"]}
-
-
-def next_attempt(events: Sequence[dict[str, Any]], query_type: str | None = None) -> int:
-    matching = [event for event in events if query_type is None or event.get("query_type") == query_type]
-    return max((int(event["attempt"]) for event in matching), default=0) + 1
 
 
 def load_data(args: argparse.Namespace, run_dir: Path, manifest: dict[str, Any], endpoint: str, managed: bool, database_manifest: dict[str, Any] | None = None, database_path: Path | None = None) -> None:

--- a/.agents/skills/benchmark-greptimedb/scripts/summarize.py
+++ b/.agents/skills/benchmark-greptimedb/scripts/summarize.py
@@ -5,235 +5,22 @@ from __future__ import annotations
 
 import argparse
 import json
-import math
-import re
+import sys
 from pathlib import Path
-from typing import Any, Callable
+from typing import Any
 
 
-RESULT_FORMAT_VERSION = "0.2"
-LEGACY_RESULT_FORMAT_VERSION = "0.1"
+SCRIPT_PATH = Path(__file__).resolve()
+sys.path.insert(0, str(SCRIPT_PATH.parents[3] / "lib"))
 
-
-METRIC_RE = re.compile(
-    r"loaded\s+(?P<count>\d+)\s+metrics\s+in\s+(?P<seconds>[0-9.]+)sec.*?"
-    r"mean rate\s+(?P<rate>[0-9.]+)\s+metrics/sec"
+from tsbs_benchmark import (  # noqa: E402
+    SummaryError,
+    build_summary,
+    parse_load_log,
+    parse_load_result,
+    parse_query_log,
+    parse_query_result,
 )
-ROW_RE = re.compile(
-    r"loaded\s+(?P<count>\d+)\s+rows\s+in\s+(?P<seconds>[0-9.]+)sec.*?"
-    r"mean rate\s+(?P<rate>[0-9.]+)\s+rows/sec"
-)
-QUERY_RE = re.compile(
-    r"all queries\s*:\s*\n\s*"
-    r"min:.*?mean:\s*(?P<mean>[0-9.]+)ms,.*?count:\s*(?P<count>\d+)",
-    re.DOTALL,
-)
-
-
-class SummaryError(ValueError):
-    """Raised when a completed TSBS result or legacy log cannot be parsed."""
-
-
-def _mapping(value: Any, field: str) -> dict[str, Any]:
-    if not isinstance(value, dict):
-        raise SummaryError(f"result field {field} must be an object")
-    return value
-
-
-def _number(value: Any, field: str) -> float:
-    if isinstance(value, bool) or not isinstance(value, (int, float)):
-        raise SummaryError(f"result field {field} must be a number")
-    result = float(value)
-    if not math.isfinite(result) or result < 0:
-        raise SummaryError(f"result field {field} must be a non-negative finite number")
-    return result
-
-
-def _count(value: Any, field: str) -> int:
-    if isinstance(value, bool) or not isinstance(value, int) or value < 0:
-        raise SummaryError(f"result field {field} must be a non-negative integer")
-    return value
-
-
-def parse_load_result(result: dict[str, Any]) -> dict[str, Any]:
-    totals = _mapping(result.get("Totals"), "Totals")
-    metrics = _count(totals.get("metricCount"), "Totals.metricCount")
-    metric_rate = _number(totals.get("metricRate"), "Totals.metricRate")
-    rows = _count(totals.get("rowCount"), "Totals.rowCount")
-    row_rate = _number(totals.get("rowRate"), "Totals.rowRate")
-    parsed: dict[str, Any] = {
-        "metrics": metrics,
-        "duration_seconds": _number(result.get("DurationMillis"), "DurationMillis") / 1000.0,
-        "metrics_per_second": metric_rate,
-    }
-    if rows > 0:
-        parsed.update({"rows": rows, "rows_per_second": row_rate})
-    return parsed
-
-
-def parse_query_result(result: dict[str, Any]) -> dict[str, Any]:
-    totals = _mapping(result.get("Totals"), "Totals")
-    overall_stats = _mapping(totals.get("overallStats"), "Totals.overallStats")
-    all_queries = _mapping(
-        overall_stats.get("all_queries"), "Totals.overallStats.all_queries"
-    )
-    return {
-        "mean_milliseconds": _number(
-            all_queries.get("meanMilliseconds"),
-            "Totals.overallStats.all_queries.meanMilliseconds",
-        ),
-        "count": _count(
-            all_queries.get("count"), "Totals.overallStats.all_queries.count"
-        ),
-    }
-
-
-def parse_load_log(text: str) -> dict[str, Any]:
-    metric_matches = list(METRIC_RE.finditer(text))
-    if not metric_matches:
-        raise SummaryError("load log has no final metric summary")
-    metric = metric_matches[-1]
-    result: dict[str, Any] = {
-        "metrics": int(metric.group("count")),
-        "duration_seconds": float(metric.group("seconds")),
-        "metrics_per_second": float(metric.group("rate")),
-    }
-    row_matches = list(ROW_RE.finditer(text))
-    if row_matches:
-        row = row_matches[-1]
-        result.update(
-            {
-                "rows": int(row.group("count")),
-                "rows_per_second": float(row.group("rate")),
-            }
-        )
-    return result
-
-
-def parse_query_log(text: str) -> dict[str, Any]:
-    marker = text.rfind("Run complete after")
-    if marker < 0:
-        raise SummaryError("query log has no final run marker")
-    matches = list(QUERY_RE.finditer(text[marker:]))
-    if not matches:
-        raise SummaryError("query log has no final all-queries summary")
-    match = matches[-1]
-    return {
-        "mean_milliseconds": float(match.group("mean")),
-        "count": int(match.group("count")),
-    }
-
-
-def _read_log(run_dir: Path, relative_path: str) -> str:
-    return (run_dir / relative_path).read_text(encoding="utf-8", errors="replace")
-
-
-def _read_event_result(run_dir: Path, event: dict[str, Any]) -> dict[str, Any] | None:
-    relative_path = event.get("results")
-    if not relative_path:
-        return None
-    path = run_dir / relative_path
-    try:
-        result = json.loads(path.read_text(encoding="utf-8"))
-    except json.JSONDecodeError as exc:
-        raise SummaryError(f"malformed result JSON {relative_path}: {exc}") from exc
-    result = _mapping(result, str(relative_path))
-    version = result.get("ResultFormatVersion")
-    if version == LEGACY_RESULT_FORMAT_VERSION:
-        return None
-    if version != RESULT_FORMAT_VERSION:
-        raise SummaryError(f"unsupported result format version {version!r} in {relative_path}")
-    return result
-
-
-def _parse_event(
-    run_dir: Path,
-    event: dict[str, Any],
-    result_parser: Callable[[dict[str, Any]], dict[str, Any]],
-    log_parser: Callable[[str], dict[str, Any]],
-) -> dict[str, Any]:
-    result = _read_event_result(run_dir, event)
-    if result is not None:
-        return result_parser(result)
-    return log_parser(_read_log(run_dir, event["log"]))
-
-
-def build_summary(run_dir: Path, manifest: dict[str, Any]) -> dict[str, Any]:
-    failures: list[dict[str, str]] = []
-    ingestion_runs: list[dict[str, Any]] = []
-    query_runs: list[dict[str, Any]] = []
-
-    for event in manifest.get("events", {}).get("loads", []):
-        if event.get("status") == "reused":
-            continue
-        base = {
-            "attempt": event["attempt"],
-            "database": event["database"],
-            "mode": event["database_mode"],
-            "log": event["log"],
-        }
-        if event.get("status") != "completed":
-            failures.append(
-                {"stage": "load", "log": event["log"], "reason": event.get("status", "failed")}
-            )
-            continue
-        try:
-            base.update(_parse_event(run_dir, event, parse_load_result, parse_load_log))
-            ingestion_runs.append(base)
-        except (OSError, SummaryError) as exc:
-            failures.append({"stage": "load", "log": event["log"], "reason": str(exc)})
-
-    for event in manifest.get("events", {}).get("queries", []):
-        base = {
-            "query_type": event["query_type"],
-            "attempt": event["attempt"],
-            "database": event["database"],
-            "log": event["log"],
-        }
-        if event.get("status") != "completed":
-            failures.append(
-                {"stage": "query", "log": event["log"], "reason": event.get("status", "failed")}
-            )
-            continue
-        try:
-            base.update(_parse_event(run_dir, event, parse_query_result, parse_query_log))
-            query_runs.append(base)
-        except (OSError, SummaryError) as exc:
-            failures.append({"stage": "query", "log": event["log"], "reason": str(exc)})
-
-    grouped: dict[tuple[str, str], list[dict[str, Any]]] = {}
-    for run in query_runs:
-        key = (run["database"], run["query_type"])
-        grouped.setdefault(key, []).append(run)
-
-    queries: list[dict[str, Any]] = []
-    for database, query_type in sorted(grouped):
-        runs = grouped[(database, query_type)]
-        count = sum(run["count"] for run in runs)
-        weighted = sum(run["mean_milliseconds"] * run["count"] for run in runs)
-        queries.append(
-            {
-                "database": database,
-                "query_type": query_type,
-                "repetitions": len(runs),
-                "query_count": count,
-                "weighted_mean_milliseconds": weighted / count if count else 0.0,
-                "runs": runs,
-            }
-        )
-
-    return {
-        "run_id": manifest.get("run_id", run_dir.name),
-        "profile": manifest.get("profile"),
-        "database": manifest.get("database"),
-        "target": manifest.get("target"),
-        "dataset": manifest.get("dataset"),
-        "query_set": manifest.get("query_set"),
-        "workload": manifest.get("workload", {}),
-        "ingestion_runs": ingestion_runs,
-        "queries": queries,
-        "failures": failures,
-    }
 
 
 def render_markdown(summary: dict[str, Any]) -> str:
@@ -274,7 +61,11 @@ def render_markdown(summary: dict[str, Any]) -> str:
             ]
         )
         for run in summary["ingestion_runs"]:
-            rows_per_second = f"{run['rows_per_second']:.2f}" if "rows_per_second" in run else "-"
+            rows_per_second = (
+                f"{run['rows_per_second']:.2f}"
+                if "rows_per_second" in run
+                else "-"
+            )
             lines.append(
                 f"| `{run['database']}` | {run['attempt']} | {run['mode']} | {run['metrics']} | "
                 f"{run['metrics_per_second']:.2f} | {run.get('rows', '-')} | {rows_per_second} | "
@@ -301,7 +92,15 @@ def render_markdown(summary: dict[str, Any]) -> str:
         lines.append("No completed query runs.")
 
     if summary["failures"]:
-        lines.extend(["", "## Failures", "", "| Stage | Log | Reason |", "| --- | --- | --- |"])
+        lines.extend(
+            [
+                "",
+                "## Failures",
+                "",
+                "| Stage | Log | Reason |",
+                "| --- | --- | --- |",
+            ]
+        )
         for failure in summary["failures"]:
             reason = failure["reason"].replace("|", "\\|")
             lines.append(f"| {failure['stage']} | `{failure['log']}` | {reason} |")
@@ -311,7 +110,9 @@ def render_markdown(summary: dict[str, Any]) -> str:
 
 def write_summary(run_dir: Path, manifest: dict[str, Any]) -> dict[str, Any]:
     summary = build_summary(run_dir, manifest)
-    (run_dir / "summary.json").write_text(json.dumps(summary, indent=2) + "\n", encoding="utf-8")
+    (run_dir / "summary.json").write_text(
+        json.dumps(summary, indent=2) + "\n", encoding="utf-8"
+    )
     (run_dir / "summary.md").write_text(render_markdown(summary), encoding="utf-8")
     return summary
 

--- a/.agents/skills/benchmark-greptimedb/tests/test_benchmark.py
+++ b/.agents/skills/benchmark-greptimedb/tests/test_benchmark.py
@@ -16,235 +16,25 @@ import benchmark  # noqa: E402
 import summarize  # noqa: E402
 
 
-class SummaryTests(unittest.TestCase):
-    def write_json(self, root: Path, relative: str, value: dict) -> None:
-        path = root / relative
-        path.parent.mkdir(parents=True, exist_ok=True)
-        path.write_text(json.dumps(value), encoding="utf-8")
-
-    def test_reused_load_without_log_is_not_a_failure(self) -> None:
+class SummaryIntegrationTests(unittest.TestCase):
+    def test_greptimedb_target_identity_is_rendered(self) -> None:
         with tempfile.TemporaryDirectory() as temp:
             summary = summarize.build_summary(
                 Path(temp),
                 {
-                    "events": {
-                        "loads": [
-                            {
-                                "attempt": 1,
-                                "database": "benchmark",
-                                "database_mode": "reuse",
-                                "status": "reused",
-                            }
-                        ],
-                        "queries": [],
-                    }
-                },
-            )
-
-        self.assertEqual(summary["ingestion_runs"], [])
-        self.assertEqual(summary["failures"], [])
-
-    def test_structured_results_do_not_require_logs(self) -> None:
-        with tempfile.TemporaryDirectory() as temp:
-            run_dir = Path(temp)
-            self.write_json(
-                run_dir,
-                "results/load.json",
-                {
-                    "ResultFormatVersion": "0.2",
-                    "DurationMillis": 2000,
-                    "Totals": {
-                        "metricCount": 200,
-                        "metricRate": 100.0,
-                        "rowCount": 40,
-                        "rowRate": 20.0,
-                    },
-                },
-            )
-            for name, count, mean in (("query-1.json", 10, 2.0), ("query-2.json", 30, 4.0)):
-                self.write_json(
-                    run_dir,
-                    f"results/{name}",
-                    {
-                        "ResultFormatVersion": "0.2",
-                        "DurationMillis": 1000,
-                        "Totals": {
-                            "overallStats": {
-                                "all_queries": {
-                                    "count": count,
-                                    "meanMilliseconds": mean,
-                                }
-                            }
-                        },
-                    },
-                )
-            summary = summarize.build_summary(
-                run_dir,
-                {
-                    "events": {
-                        "loads": [
-                            {
-                                "attempt": 1,
-                                "database": "benchmark",
-                                "database_mode": "create",
-                                "status": "completed",
-                                "log": "logs/missing-load.log",
-                                "results": "results/load.json",
-                            }
-                        ],
-                        "queries": [
-                            {
-                                "query_type": "lastpoint",
-                                "attempt": attempt,
-                                "database": "benchmark",
-                                "status": "completed",
-                                "log": f"logs/missing-query-{attempt}.log",
-                                "results": f"results/query-{attempt}.json",
-                            }
-                            for attempt in (1, 2)
-                        ],
-                    }
-                },
-            )
-
-        self.assertEqual(summary["failures"], [])
-        self.assertEqual(summary["ingestion_runs"][0]["metrics"], 200)
-        self.assertEqual(summary["ingestion_runs"][0]["duration_seconds"], 2.0)
-        self.assertEqual(summary["queries"][0]["query_count"], 40)
-        self.assertEqual(summary["queries"][0]["weighted_mean_milliseconds"], 3.5)
-
-    def test_legacy_result_uses_log_fallback(self) -> None:
-        with tempfile.TemporaryDirectory() as temp:
-            run_dir = Path(temp)
-            self.write_json(
-                run_dir,
-                "results/query.json",
-                {"ResultFormatVersion": "0.1", "Totals": {}},
-            )
-            log = run_dir / "logs/query.log"
-            log.parent.mkdir()
-            log.write_text(
-                "Run complete after 10 queries\nall queries:\n"
-                "min: 1ms, mean: 3.50ms, max: 4ms, count: 10\n",
-                encoding="utf-8",
-            )
-            summary = summarize.build_summary(
-                run_dir,
-                {
-                    "events": {
-                        "loads": [],
-                        "queries": [
-                            {
-                                "query_type": "lastpoint",
-                                "attempt": 1,
-                                "database": "benchmark",
-                                "status": "completed",
-                                "log": "logs/query.log",
-                                "results": "results/query.json",
-                            }
-                        ],
-                    }
-                },
-            )
-
-        self.assertEqual(summary["failures"], [])
-        self.assertEqual(summary["queries"][0]["weighted_mean_milliseconds"], 3.5)
-
-    def test_incomplete_current_result_is_a_failure(self) -> None:
-        with tempfile.TemporaryDirectory() as temp:
-            run_dir = Path(temp)
-            self.write_json(
-                run_dir,
-                "results/query.json",
-                {"ResultFormatVersion": "0.2", "Totals": {"overallStats": {}}},
-            )
-            summary = summarize.build_summary(
-                run_dir,
-                {
-                    "events": {
-                        "loads": [],
-                        "queries": [
-                            {
-                                "query_type": "lastpoint",
-                                "attempt": 1,
-                                "database": "benchmark",
-                                "status": "completed",
-                                "log": "logs/query.log",
-                                "results": "results/query.json",
-                            }
-                        ],
-                    }
-                },
-            )
-
-        self.assertEqual(summary["queries"], [])
-        self.assertIn("all_queries", summary["failures"][0]["reason"])
-        self.assertEqual(summary["failures"][0]["log"], "logs/query.log")
-
-    def test_malformed_current_result_is_a_failure(self) -> None:
-        with tempfile.TemporaryDirectory() as temp:
-            run_dir = Path(temp)
-            result = run_dir / "results/query.json"
-            result.parent.mkdir()
-            result.write_text("{not-json", encoding="utf-8")
-            summary = summarize.build_summary(
-                run_dir,
-                {
-                    "events": {
-                        "loads": [],
-                        "queries": [
-                            {
-                                "query_type": "lastpoint",
-                                "attempt": 1,
-                                "database": "benchmark",
-                                "status": "completed",
-                                "log": "logs/query.log",
-                                "results": "results/query.json",
-                            }
-                        ],
-                    }
-                },
-            )
-
-        self.assertEqual(summary["queries"], [])
-        self.assertIn("malformed result JSON", summary["failures"][0]["reason"])
-
-    def test_parsers_and_target_identity(self) -> None:
-        structured_load = summarize.parse_load_result(
-            {
-                "DurationMillis": 2000,
-                "Totals": {
-                    "metricCount": 200,
-                    "metricRate": 100.0,
-                    "rowCount": 0,
-                    "rowRate": 0.0,
-                },
-            }
-        )
-        self.assertNotIn("rows", structured_load)
-        load = summarize.parse_load_log(
-            "loaded 200 metrics in 2.000sec (mean rate 100.00 metrics/sec)\n"
-            "loaded 40 rows in 2.000sec (mean rate 20.00 rows/sec)\n"
-        )
-        self.assertEqual(load["metrics_per_second"], 100.0)
-        query = summarize.parse_query_log(
-            "Run complete after 10 queries\nall queries:\n"
-            "min: 1ms, mean: 3.50ms, max: 4ms, count: 10\n"
-        )
-        self.assertEqual(query, {"mean_milliseconds": 3.5, "count": 10})
-        with tempfile.TemporaryDirectory() as temp:
-            summary = summarize.build_summary(
-                Path(temp),
-                {
-                    "run_id": "run", "profile": "smoke", "database": "benchmark",
+                    "run_id": "run",
+                    "profile": "smoke",
+                    "database": "benchmark",
                     "target": {"mode": "managed", "database_id": "db-a"},
                     "dataset": {"dataset_id": "data-a"},
-                    "query_set": {"query_set_id": "set-a", "manifest_sha256": "abc"},
+                    "query_set": {
+                        "query_set_id": "set-a",
+                        "manifest_sha256": "abc",
+                    },
                     "events": {"loads": [], "queries": []},
                 },
             )
-        self.assertEqual(summary["target"]["database_id"], "db-a")
-        self.assertEqual(summary["query_set"]["query_set_id"], "set-a")
+
         rendered = summarize.render_markdown(summary)
         self.assertIn("managed:db-a", rendered)
         self.assertIn("set-a", rendered)

--- a/.agents/skills/benchmark-influxdb3/scripts/benchmark.py
+++ b/.agents/skills/benchmark-influxdb3/scripts/benchmark.py
@@ -5,8 +5,6 @@ from __future__ import annotations
 
 import argparse
 import contextlib
-import datetime as dt
-import fcntl
 import hashlib
 import json
 import os
@@ -24,10 +22,29 @@ import urllib.request
 from pathlib import Path
 from typing import Any, Iterator, Sequence
 
+SCRIPT_PATH = Path(__file__).resolve()
+sys.path.insert(0, str(SCRIPT_PATH.parents[3] / "lib"))
+
+from tsbs_benchmark import (  # noqa: E402
+    PROFILES,
+    QUERY_TYPES,
+    add_one_second,
+    build_workload,
+    canonical_json,
+    dataset_binding,
+    lock_directory,
+    new_run_dir as shared_new_run_dir,
+    next_attempt,
+    query_file_path,
+    read_json as shared_read_json,
+    relative,
+    save_json,
+    sha256_file,
+    utc_now,
+)
 from summarize import write_summary
 
 
-SCRIPT_PATH = Path(__file__).resolve()
 REPO_ROOT = SCRIPT_PATH.parents[4]
 BENCHMARK_ROOT = REPO_ROOT / ".benchmarks"
 DEFAULT_RUN_ROOT = BENCHMARK_ROOT / "influxdb3" / "runs"
@@ -39,29 +56,6 @@ DEFAULT_DATABASE = "benchmark"
 SCHEMA_VERSION = 1
 ID_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]*$")
 DATA_WORKLOAD_OPTIONS = ("start", "end", "scale", "seed", "log_interval")
-
-QUERY_COUNTS_MANUAL = {
-    "cpu-max-all-1": 100, "cpu-max-all-8": 100, "double-groupby-1": 50,
-    "double-groupby-5": 50, "double-groupby-all": 50, "groupby-orderby-limit": 50,
-    "high-cpu-1": 100, "high-cpu-all": 50, "lastpoint": 10,
-    "single-groupby-1-1-1": 100, "single-groupby-1-1-12": 100,
-    "single-groupby-1-8-1": 100, "single-groupby-5-1-1": 100,
-    "single-groupby-5-1-12": 100, "single-groupby-5-8-1": 100,
-}
-QUERY_TYPES = tuple(QUERY_COUNTS_MANUAL)
-PROFILES = {
-    "manual": {
-        "start": "2023-06-11T00:00:00Z", "end": "2023-06-14T00:00:00Z",
-        "scale": 4000, "seed": 123, "log_interval": "10s", "load_workers": 6,
-        "query_workers": 1, "batch_size": 3000, "query_counts": QUERY_COUNTS_MANUAL,
-    },
-    "smoke": {
-        "start": "2023-06-11T00:00:00Z", "end": "2023-06-12T00:00:00Z",
-        "scale": 10, "seed": 123, "log_interval": "10s", "load_workers": 2,
-        "query_workers": 1, "batch_size": 3000,
-        "query_counts": {query_type: 10 for query_type in QUERY_TYPES},
-    },
-}
 BINARIES = {"queries": "tsbs_generate_queries", "load": "tsbs_load_influx3", "query": "tsbs_run_queries_influx3"}
 BUILT_THIS_PROCESS: set[str] = set()
 
@@ -70,55 +64,12 @@ class BenchmarkError(RuntimeError):
     """Raised for an actionable benchmark failure."""
 
 
-def utc_now() -> str:
-    return dt.datetime.now(dt.timezone.utc).isoformat().replace("+00:00", "Z")
-
-
-def canonical_json(value: Any) -> str:
-    return json.dumps(value, sort_keys=True, separators=(",", ":"), ensure_ascii=True)
-
-
-def sha256_file(path: Path) -> str:
-    digest = hashlib.sha256()
-    with path.open("rb") as stream:
-        for chunk in iter(lambda: stream.read(1024 * 1024), b""):
-            digest.update(chunk)
-    return digest.hexdigest()
-
-
-def save_json(path: Path, value: Any) -> None:
-    path.parent.mkdir(parents=True, exist_ok=True)
-    temporary = path.with_name(f"{path.name}.tmp-{os.getpid()}")
-    temporary.write_text(json.dumps(value, indent=2, sort_keys=True) + "\n", encoding="utf-8")
-    os.replace(temporary, path)
-
-
 def read_json(path: Path) -> dict[str, Any]:
-    try:
-        value = json.loads(path.read_text(encoding="utf-8"))
-    except FileNotFoundError as exc:
-        raise BenchmarkError(f"missing manifest: {path}") from exc
-    except json.JSONDecodeError as exc:
-        raise BenchmarkError(f"invalid JSON manifest {path}: {exc}") from exc
-    if not isinstance(value, dict):
-        raise BenchmarkError(f"manifest must be an object: {path}")
-    return value
+    return shared_read_json(path, BenchmarkError)
 
 
 def new_run_dir(run_root: Path = DEFAULT_RUN_ROOT) -> Path:
-    run_root.mkdir(parents=True, exist_ok=True)
-    base = dt.datetime.now(dt.timezone.utc).strftime("%Y%m%dT%H%M%SZ")
-    candidate = run_root / base
-    suffix = 1
-    while candidate.exists():
-        candidate = run_root / f"{base}-{suffix:02d}"
-        suffix += 1
-    return candidate
-
-
-def add_one_second(timestamp: str) -> str:
-    parsed = dt.datetime.fromisoformat(timestamp.replace("Z", "+00:00"))
-    return (parsed + dt.timedelta(seconds=1)).isoformat().replace("+00:00", "Z")
+    return shared_new_run_dir(run_root)
 
 
 def validate_run_manifest(manifest: dict[str, Any], path: Path) -> None:
@@ -176,25 +127,6 @@ def prepare_run(args: argparse.Namespace) -> tuple[Path, dict[str, Any]]:
         raise BenchmarkError("--database conflicts with the database pinned by this run")
     save_manifest(run_dir, manifest)
     return run_dir, manifest
-
-
-def build_workload(args: argparse.Namespace, base: dict[str, Any] | None = None) -> dict[str, Any]:
-    if base is not None and not args.profile:
-        workload = json.loads(json.dumps(base))
-    else:
-        workload = json.loads(json.dumps(PROFILES[args.profile or "manual"]))
-    for attr in ("start", "end", "scale", "seed", "log_interval", "load_workers", "query_workers", "batch_size"):
-        value = getattr(args, attr, None)
-        if value is not None:
-            workload[attr] = value
-    selected = sorted(set(args.query_type or workload["query_counts"]))
-    count_override = getattr(args, "queries", None)
-    workload["query_counts"] = {query_type: count_override if count_override is not None else workload["query_counts"][query_type] for query_type in selected}
-    return workload
-
-
-def relative(run_dir: Path, path: Path) -> str:
-    return str(path.relative_to(run_dir))
 
 
 def display_command(command: Sequence[str]) -> str:
@@ -319,10 +251,6 @@ def query_set_id(spec: dict[str, Any]) -> str:
 
 def query_set_path(query_root: Path, dataset_id: str, set_id: str) -> Path:
     return query_root / dataset_id / "influx3" / set_id
-
-
-def query_file_path(query_dir: Path, query_type: str) -> Path:
-    return query_dir / "queries" / f"{query_type}.dat"
 
 
 def validate_query_set(query_dir: Path, expected_spec: dict[str, Any]) -> dict[str, Any]:
@@ -473,22 +401,8 @@ def prepare_database_workspace(args: argparse.Namespace) -> tuple[Path, dict[str
 
 @contextlib.contextmanager
 def lock_database(path: Path) -> Iterator[None]:
-    descriptor = os.open(path, os.O_RDONLY)
-    try:
-        try: fcntl.flock(descriptor, fcntl.LOCK_EX | fcntl.LOCK_NB)
-        except BlockingIOError as exc: raise BenchmarkError(f"managed database workspace is locked: {path}") from exc
+    with lock_directory(path, BenchmarkError, "managed database workspace"):
         yield
-    finally:
-        fcntl.flock(descriptor, fcntl.LOCK_UN); os.close(descriptor)
-
-
-def dataset_binding(dataset: dict[str, Any]) -> dict[str, Any]:
-    return {"dataset_id": dataset["dataset_id"], "spec": dataset["spec"], "format": dataset["format"], "bytes": dataset["bytes"], "sha256": dataset["sha256"]}
-
-
-def next_attempt(events: Sequence[dict[str, Any]], query_type: str | None = None) -> int:
-    matching = [event for event in events if query_type is None or event.get("query_type") == query_type]
-    return max((int(event["attempt"]) for event in matching), default=0) + 1
 
 
 def credential_args(args: argparse.Namespace, *, include_admin: bool) -> list[str]:

--- a/.agents/skills/benchmark-influxdb3/scripts/summarize.py
+++ b/.agents/skills/benchmark-influxdb3/scripts/summarize.py
@@ -5,179 +5,79 @@ from __future__ import annotations
 
 import argparse
 import json
-import math
 import re
+import sys
 from pathlib import Path
-from typing import Any, Callable
+from typing import Any
 
 
-RESULT_FORMAT_VERSION = "0.2"
-LEGACY_RESULT_FORMAT_VERSION = "0.1"
+SCRIPT_PATH = Path(__file__).resolve()
+sys.path.insert(0, str(SCRIPT_PATH.parents[3] / "lib"))
+
+from tsbs_benchmark import (  # noqa: E402
+    SummaryError,
+    build_summary as build_common_summary,
+    parse_load_log,
+    parse_load_result,
+    parse_query_log,
+    parse_query_result,
+    read_log,
+)
+
+
 MAX_SERVER_DIAGNOSTIC_SAMPLES = 20
-EMAIL_RE = re.compile(r"(?<![\w.+-])[\w.+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}(?![\w.-])")
+EMAIL_RE = re.compile(
+    r"(?<![\w.+-])[\w.+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}(?![\w.-])"
+)
 PANIC_RE = re.compile(r"\bpanic(?:ked)?\b|fatal runtime error", re.IGNORECASE)
 FATAL_RE = re.compile(r"\bfatal\b", re.IGNORECASE)
 ERROR_RE = re.compile(r"(?:^|\s)ERROR(?:\s|$)", re.IGNORECASE)
-WARNING_RE = re.compile(r"(?:^|\s)WARN(?:ING)?(?:\s|$)|<jemalloc>:", re.IGNORECASE)
-
-
-METRIC_RE = re.compile(
-    r"loaded\s+(?P<count>\d+)\s+metrics\s+in\s+(?P<seconds>[0-9.]+)sec.*?"
-    r"mean rate\s+(?P<rate>[0-9.]+)\s+metrics/sec"
-)
-ROW_RE = re.compile(
-    r"loaded\s+(?P<count>\d+)\s+rows\s+in\s+(?P<seconds>[0-9.]+)sec.*?"
-    r"mean rate\s+(?P<rate>[0-9.]+)\s+rows/sec"
-)
-QUERY_RE = re.compile(
-    r"all queries\s*:\s*\n\s*"
-    r"min:.*?mean:\s*(?P<mean>[0-9.]+)ms,.*?count:\s*(?P<count>\d+)",
-    re.DOTALL,
+WARNING_RE = re.compile(
+    r"(?:^|\s)WARN(?:ING)?(?:\s|$)|<jemalloc>:", re.IGNORECASE
 )
 
 
-class SummaryError(ValueError):
-    """Raised when a completed TSBS result or legacy log cannot be parsed."""
-
-
-def _mapping(value: Any, field: str) -> dict[str, Any]:
-    if not isinstance(value, dict):
-        raise SummaryError(f"result field {field} must be an object")
-    return value
-
-
-def _number(value: Any, field: str) -> float:
-    if isinstance(value, bool) or not isinstance(value, (int, float)):
-        raise SummaryError(f"result field {field} must be a number")
-    result = float(value)
-    if not math.isfinite(result) or result < 0:
-        raise SummaryError(f"result field {field} must be a non-negative finite number")
-    return result
-
-
-def _count(value: Any, field: str) -> int:
-    if isinstance(value, bool) or not isinstance(value, int) or value < 0:
-        raise SummaryError(f"result field {field} must be a non-negative integer")
-    return value
-
-
-def parse_load_result(result: dict[str, Any]) -> dict[str, Any]:
-    totals = _mapping(result.get("Totals"), "Totals")
-    metrics = _count(totals.get("metricCount"), "Totals.metricCount")
-    metric_rate = _number(totals.get("metricRate"), "Totals.metricRate")
-    rows = _count(totals.get("rowCount"), "Totals.rowCount")
-    row_rate = _number(totals.get("rowRate"), "Totals.rowRate")
-    parsed: dict[str, Any] = {
-        "metrics": metrics,
-        "duration_seconds": _number(result.get("DurationMillis"), "DurationMillis") / 1000.0,
-        "metrics_per_second": metric_rate,
-    }
-    if rows > 0:
-        parsed.update({"rows": rows, "rows_per_second": row_rate})
-    return parsed
-
-
-def parse_query_result(result: dict[str, Any]) -> dict[str, Any]:
-    totals = _mapping(result.get("Totals"), "Totals")
-    overall_stats = _mapping(totals.get("overallStats"), "Totals.overallStats")
-    all_queries = _mapping(
-        overall_stats.get("all_queries"), "Totals.overallStats.all_queries"
-    )
-    return {
-        "mean_milliseconds": _number(
-            all_queries.get("meanMilliseconds"),
-            "Totals.overallStats.all_queries.meanMilliseconds",
-        ),
-        "count": _count(
-            all_queries.get("count"), "Totals.overallStats.all_queries.count"
-        ),
-    }
-
-
-def parse_load_log(text: str) -> dict[str, Any]:
-    metric_matches = list(METRIC_RE.finditer(text))
-    if not metric_matches:
-        raise SummaryError("load log has no final metric summary")
-    metric = metric_matches[-1]
-    result: dict[str, Any] = {
-        "metrics": int(metric.group("count")),
-        "duration_seconds": float(metric.group("seconds")),
-        "metrics_per_second": float(metric.group("rate")),
-    }
-    row_matches = list(ROW_RE.finditer(text))
-    if row_matches:
-        row = row_matches[-1]
-        result.update(
-            {
-                "rows": int(row.group("count")),
-                "rows_per_second": float(row.group("rate")),
-            }
-        )
-    return result
-
-
-def parse_query_log(text: str) -> dict[str, Any]:
-    marker = text.rfind("Run complete after")
-    if marker < 0:
-        raise SummaryError("query log has no final run marker")
-    matches = list(QUERY_RE.finditer(text[marker:]))
-    if not matches:
-        raise SummaryError("query log has no final all-queries summary")
-    match = matches[-1]
-    return {
-        "mean_milliseconds": float(match.group("mean")),
-        "count": int(match.group("count")),
-    }
-
-
-def _read_log(run_dir: Path, relative_path: str) -> str:
-    return (run_dir / relative_path).read_text(encoding="utf-8", errors="replace")
-
-
-def _read_event_result(run_dir: Path, event: dict[str, Any]) -> dict[str, Any] | None:
-    relative_path = event.get("results")
-    if not relative_path:
-        return None
-    path = run_dir / relative_path
-    try:
-        result = json.loads(path.read_text(encoding="utf-8"))
-    except json.JSONDecodeError as exc:
-        raise SummaryError(f"malformed result JSON {relative_path}: {exc}") from exc
-    result = _mapping(result, str(relative_path))
-    version = result.get("ResultFormatVersion")
-    if version == LEGACY_RESULT_FORMAT_VERSION:
-        return None
-    if version != RESULT_FORMAT_VERSION:
-        raise SummaryError(f"unsupported result format version {version!r} in {relative_path}")
-    return result
-
-
-def _parse_event(
+def server_diagnostics(
     run_dir: Path,
-    event: dict[str, Any],
-    result_parser: Callable[[dict[str, Any]], dict[str, Any]],
-    log_parser: Callable[[str], dict[str, Any]],
+    manifest: dict[str, Any],
+    failures: list[dict[str, str]],
 ) -> dict[str, Any]:
-    result = _read_event_result(run_dir, event)
-    if result is not None:
-        return result_parser(result)
-    return log_parser(_read_log(run_dir, event["log"]))
-
-
-def server_diagnostics(run_dir: Path, manifest: dict[str, Any], failures: list[dict[str, str]]) -> dict[str, Any]:
     counts = {"warning": 0, "error": 0, "fatal": 0, "panic": 0}
     samples: list[dict[str, str]] = []
     attempts: list[dict[str, Any]] = []
-    failing_statuses = {"starting", "startup_failed", "startup_timeout", "unexpected_exit", "forced_shutdown"}
+    failing_statuses = {
+        "starting",
+        "startup_failed",
+        "startup_timeout",
+        "unexpected_exit",
+        "forced_shutdown",
+    }
     for event in manifest.get("events", {}).get("servers", []):
         log = event.get("log", "")
-        attempt = {key: event.get(key) for key in ("attempt", "log", "status", "started_at", "ready_at", "finished_at", "exit_code", "forced_shutdown", "unexpected_exit")}
+        attempt = {
+            key: event.get(key)
+            for key in (
+                "attempt",
+                "log",
+                "status",
+                "started_at",
+                "ready_at",
+                "finished_at",
+                "exit_code",
+                "forced_shutdown",
+                "unexpected_exit",
+            )
+        }
         attempts.append(attempt)
         status = event.get("status", "unknown")
-        if status in failing_statuses or event.get("unexpected_exit") or event.get("forced_shutdown"):
+        if (
+            status in failing_statuses
+            or event.get("unexpected_exit")
+            or event.get("forced_shutdown")
+        ):
             failures.append({"stage": "server", "log": log, "reason": status})
         try:
-            lines = _read_log(run_dir, log).splitlines()
+            lines = read_log(run_dir, log).splitlines()
         except OSError as exc:
             failures.append({"stage": "server", "log": log, "reason": str(exc)})
             continue
@@ -185,99 +85,43 @@ def server_diagnostics(run_dir: Path, manifest: dict[str, Any], failures: list[d
         for raw_line in lines:
             line = EMAIL_RE.sub("<redacted-email>", raw_line.strip())
             severity = None
-            if PANIC_RE.search(line): severity = "panic"
-            elif FATAL_RE.search(line): severity = "fatal"
-            elif ERROR_RE.search(line): severity = "error"
-            elif WARNING_RE.search(line): severity = "warning"
+            if PANIC_RE.search(line):
+                severity = "panic"
+            elif FATAL_RE.search(line):
+                severity = "fatal"
+            elif ERROR_RE.search(line):
+                severity = "error"
+            elif WARNING_RE.search(line):
+                severity = "warning"
             if severity is None:
                 continue
             counts[severity] += 1
             if len(samples) < MAX_SERVER_DIAGNOSTIC_SAMPLES:
-                samples.append({"severity": severity, "log": log, "message": line})
+                samples.append(
+                    {"severity": severity, "log": log, "message": line}
+                )
             fatal_or_panic = fatal_or_panic or severity in ("fatal", "panic")
         if fatal_or_panic:
-            failures.append({"stage": "server", "log": log, "reason": "server log contains fatal or panic diagnostics"})
-    return {**{f"{name}_count": value for name, value in counts.items()}, "samples": samples, "attempts": attempts}
+            failures.append(
+                {
+                    "stage": "server",
+                    "log": log,
+                    "reason": "server log contains fatal or panic diagnostics",
+                }
+            )
+    return {
+        **{f"{name}_count": value for name, value in counts.items()},
+        "samples": samples,
+        "attempts": attempts,
+    }
 
 
 def build_summary(run_dir: Path, manifest: dict[str, Any]) -> dict[str, Any]:
-    failures: list[dict[str, str]] = []
-    ingestion_runs: list[dict[str, Any]] = []
-    query_runs: list[dict[str, Any]] = []
-
-    for event in manifest.get("events", {}).get("loads", []):
-        if event.get("status") == "reused":
-            continue
-        base = {
-            "attempt": event["attempt"],
-            "database": event["database"],
-            "mode": event["database_mode"],
-            "log": event["log"],
-        }
-        if event.get("status") != "completed":
-            failures.append(
-                {"stage": "load", "log": event["log"], "reason": event.get("status", "failed")}
-            )
-            continue
-        try:
-            base.update(_parse_event(run_dir, event, parse_load_result, parse_load_log))
-            ingestion_runs.append(base)
-        except (OSError, SummaryError) as exc:
-            failures.append({"stage": "load", "log": event["log"], "reason": str(exc)})
-
-    for event in manifest.get("events", {}).get("queries", []):
-        base = {
-            "query_type": event["query_type"],
-            "attempt": event["attempt"],
-            "database": event["database"],
-            "log": event["log"],
-        }
-        if event.get("status") != "completed":
-            failures.append(
-                {"stage": "query", "log": event["log"], "reason": event.get("status", "failed")}
-            )
-            continue
-        try:
-            base.update(_parse_event(run_dir, event, parse_query_result, parse_query_log))
-            query_runs.append(base)
-        except (OSError, SummaryError) as exc:
-            failures.append({"stage": "query", "log": event["log"], "reason": str(exc)})
-
-    grouped: dict[tuple[str, str], list[dict[str, Any]]] = {}
-    for run in query_runs:
-        key = (run["database"], run["query_type"])
-        grouped.setdefault(key, []).append(run)
-
-    queries: list[dict[str, Any]] = []
-    for database, query_type in sorted(grouped):
-        runs = grouped[(database, query_type)]
-        count = sum(run["count"] for run in runs)
-        weighted = sum(run["mean_milliseconds"] * run["count"] for run in runs)
-        queries.append(
-            {
-                "database": database,
-                "query_type": query_type,
-                "repetitions": len(runs),
-                "query_count": count,
-                "weighted_mean_milliseconds": weighted / count if count else 0.0,
-                "runs": runs,
-            }
-        )
-
-    diagnostics = server_diagnostics(run_dir, manifest, failures)
-    return {
-        "run_id": manifest.get("run_id", run_dir.name),
-        "profile": manifest.get("profile"),
-        "database": manifest.get("database"),
-        "target": manifest.get("target"),
-        "dataset": manifest.get("dataset"),
-        "query_set": manifest.get("query_set"),
-        "workload": manifest.get("workload", {}),
-        "ingestion_runs": ingestion_runs,
-        "queries": queries,
-        "server_diagnostics": diagnostics,
-        "failures": failures,
-    }
+    summary = build_common_summary(run_dir, manifest)
+    summary["server_diagnostics"] = server_diagnostics(
+        run_dir, manifest, summary["failures"]
+    )
+    return summary
 
 
 def render_markdown(summary: dict[str, Any]) -> str:
@@ -294,8 +138,12 @@ def render_markdown(summary: dict[str, Any]) -> str:
         lines.append(f"- Edition: `{target.get('edition')}`")
         if target.get("version"):
             lines.append(f"- Version: `{target.get('version')}`")
-        lines.append(f"- Durable WAL acknowledgement: `{not target.get('no_sync', False)}`")
-        lines.append(f"- Partial batch acceptance: `{target.get('accept_partial', False)}`")
+        lines.append(
+            f"- Durable WAL acknowledgement: `{not target.get('no_sync', False)}`"
+        )
+        lines.append(
+            f"- Partial batch acceptance: `{target.get('accept_partial', False)}`"
+        )
     dataset = summary.get("dataset")
     if dataset:
         lines.extend(
@@ -323,7 +171,11 @@ def render_markdown(summary: dict[str, Any]) -> str:
             ]
         )
         for run in summary["ingestion_runs"]:
-            rows_per_second = f"{run['rows_per_second']:.2f}" if "rows_per_second" in run else "-"
+            rows_per_second = (
+                f"{run['rows_per_second']:.2f}"
+                if "rows_per_second" in run
+                else "-"
+            )
             lines.append(
                 f"| `{run['database']}` | {run['attempt']} | {run['mode']} | {run['metrics']} | "
                 f"{run['metrics_per_second']:.2f} | {run.get('rows', '-')} | {rows_per_second} | "
@@ -352,17 +204,31 @@ def render_markdown(summary: dict[str, Any]) -> str:
     diagnostics = summary.get("server_diagnostics", {})
     lines.extend(["", "## Server diagnostics", ""])
     lines.append(
-        f"Warnings: {diagnostics.get('warning_count', 0)}; errors: {diagnostics.get('error_count', 0)}; "
-        f"fatals: {diagnostics.get('fatal_count', 0)}; panics: {diagnostics.get('panic_count', 0)}."
+        f"Warnings: {diagnostics.get('warning_count', 0)}; "
+        f"errors: {diagnostics.get('error_count', 0)}; "
+        f"fatals: {diagnostics.get('fatal_count', 0)}; "
+        f"panics: {diagnostics.get('panic_count', 0)}."
     )
     if diagnostics.get("samples"):
-        lines.extend(["", "| Severity | Log | Sample |", "| --- | --- | --- |"])
+        lines.extend(
+            ["", "| Severity | Log | Sample |", "| --- | --- | --- |"]
+        )
         for sample in diagnostics["samples"]:
             message = sample["message"].replace("|", "\\|")
-            lines.append(f"| {sample['severity']} | `{sample['log']}` | {message} |")
+            lines.append(
+                f"| {sample['severity']} | `{sample['log']}` | {message} |"
+            )
 
     if summary["failures"]:
-        lines.extend(["", "## Failures", "", "| Stage | Log | Reason |", "| --- | --- | --- |"])
+        lines.extend(
+            [
+                "",
+                "## Failures",
+                "",
+                "| Stage | Log | Reason |",
+                "| --- | --- | --- |",
+            ]
+        )
         for failure in summary["failures"]:
             reason = failure["reason"].replace("|", "\\|")
             lines.append(f"| {failure['stage']} | `{failure['log']}` | {reason} |")
@@ -372,7 +238,9 @@ def render_markdown(summary: dict[str, Any]) -> str:
 
 def write_summary(run_dir: Path, manifest: dict[str, Any]) -> dict[str, Any]:
     summary = build_summary(run_dir, manifest)
-    (run_dir / "summary.json").write_text(json.dumps(summary, indent=2) + "\n", encoding="utf-8")
+    (run_dir / "summary.json").write_text(
+        json.dumps(summary, indent=2) + "\n", encoding="utf-8"
+    )
     (run_dir / "summary.md").write_text(render_markdown(summary), encoding="utf-8")
     return summary
 

--- a/.agents/skills/benchmark-influxdb3/tests/test_benchmark.py
+++ b/.agents/skills/benchmark-influxdb3/tests/test_benchmark.py
@@ -17,258 +17,90 @@ import benchmark  # noqa: E402
 import summarize  # noqa: E402
 
 
-class SummaryTests(unittest.TestCase):
-    def write_json(self, root: Path, relative: str, value: dict) -> None:
-        path = root / relative
-        path.parent.mkdir(parents=True, exist_ok=True)
-        path.write_text(json.dumps(value), encoding="utf-8")
-
-    def test_reused_load_without_log_is_not_a_failure(self) -> None:
-        with tempfile.TemporaryDirectory() as temp:
-            summary = summarize.build_summary(
-                Path(temp),
-                {
-                    "events": {
-                        "loads": [
-                            {
-                                "attempt": 1,
-                                "database": "benchmark",
-                                "database_mode": "reuse",
-                                "status": "reused",
-                            }
-                        ],
-                        "queries": [],
-                    }
-                },
-            )
-
-        self.assertEqual(summary["ingestion_runs"], [])
-        self.assertEqual(summary["failures"], [])
-
+class SummaryIntegrationTests(unittest.TestCase):
     def test_server_warnings_are_diagnostics_but_fatal_output_fails(self) -> None:
         with tempfile.TemporaryDirectory() as temp:
-            run_dir = Path(temp); logs = run_dir / "logs"; logs.mkdir()
-            (logs / "server-1.log").write_text(" WARN retrying for person@example.com\n ERROR request recovered\n")
-            manifest = {"events": {"loads": [], "queries": [], "servers": [{"attempt": 1, "log": "logs/server-1.log", "status": "stopped"}]}}
+            run_dir = Path(temp)
+            logs = run_dir / "logs"
+            logs.mkdir()
+            (logs / "server-1.log").write_text(
+                " WARN retrying for person@example.com\n ERROR request recovered\n"
+            )
+            manifest = {
+                "events": {
+                    "loads": [],
+                    "queries": [],
+                    "servers": [
+                        {
+                            "attempt": 1,
+                            "log": "logs/server-1.log",
+                            "status": "stopped",
+                        }
+                    ],
+                }
+            }
             summary = summarize.build_summary(run_dir, manifest)
             self.assertEqual(summary["failures"], [])
             self.assertEqual(summary["server_diagnostics"]["warning_count"], 1)
             self.assertEqual(summary["server_diagnostics"]["error_count"], 1)
             self.assertNotIn("person@example.com", json.dumps(summary))
 
-            (logs / "server-1.log").write_text("thread worker panicked at secret@example.com\n")
+            (logs / "server-1.log").write_text(
+                "thread worker panicked at secret@example.com\n"
+            )
             failed = summarize.build_summary(run_dir, manifest)
             self.assertEqual(failed["failures"][0]["stage"], "server")
             self.assertEqual(failed["server_diagnostics"]["panic_count"], 1)
 
     def test_server_lifecycle_failure_is_reported(self) -> None:
         with tempfile.TemporaryDirectory() as temp:
-            run_dir = Path(temp); logs = run_dir / "logs"; logs.mkdir()
+            run_dir = Path(temp)
+            logs = run_dir / "logs"
+            logs.mkdir()
             (logs / "server.log").write_text("startup ended\n")
-            summary = summarize.build_summary(run_dir, {"events": {"loads": [], "queries": [], "servers": [{"attempt": 1, "log": "logs/server.log", "status": "unexpected_exit", "unexpected_exit": True}]}})
+            summary = summarize.build_summary(
+                run_dir,
+                {
+                    "events": {
+                        "loads": [],
+                        "queries": [],
+                        "servers": [
+                            {
+                                "attempt": 1,
+                                "log": "logs/server.log",
+                                "status": "unexpected_exit",
+                                "unexpected_exit": True,
+                            }
+                        ],
+                    }
+                },
+            )
+
         self.assertEqual(summary["failures"][0]["stage"], "server")
 
-    def test_structured_results_do_not_require_logs(self) -> None:
-        with tempfile.TemporaryDirectory() as temp:
-            run_dir = Path(temp)
-            self.write_json(
-                run_dir,
-                "results/load.json",
-                {
-                    "ResultFormatVersion": "0.2",
-                    "DurationMillis": 2000,
-                    "Totals": {
-                        "metricCount": 200,
-                        "metricRate": 100.0,
-                        "rowCount": 40,
-                        "rowRate": 20.0,
-                    },
-                },
-            )
-            for name, count, mean in (("query-1.json", 10, 2.0), ("query-2.json", 30, 4.0)):
-                self.write_json(
-                    run_dir,
-                    f"results/{name}",
-                    {
-                        "ResultFormatVersion": "0.2",
-                        "DurationMillis": 1000,
-                        "Totals": {
-                            "overallStats": {
-                                "all_queries": {
-                                    "count": count,
-                                    "meanMilliseconds": mean,
-                                }
-                            }
-                        },
-                    },
-                )
-            summary = summarize.build_summary(
-                run_dir,
-                {
-                    "events": {
-                        "loads": [
-                            {
-                                "attempt": 1,
-                                "database": "benchmark",
-                                "database_mode": "create",
-                                "status": "completed",
-                                "log": "logs/missing-load.log",
-                                "results": "results/load.json",
-                            }
-                        ],
-                        "queries": [
-                            {
-                                "query_type": "lastpoint",
-                                "attempt": attempt,
-                                "database": "benchmark",
-                                "status": "completed",
-                                "log": f"logs/missing-query-{attempt}.log",
-                                "results": f"results/query-{attempt}.json",
-                            }
-                            for attempt in (1, 2)
-                        ],
-                    }
-                },
-            )
-
-        self.assertEqual(summary["failures"], [])
-        self.assertEqual(summary["ingestion_runs"][0]["metrics"], 200)
-        self.assertEqual(summary["ingestion_runs"][0]["duration_seconds"], 2.0)
-        self.assertEqual(summary["queries"][0]["query_count"], 40)
-        self.assertEqual(summary["queries"][0]["weighted_mean_milliseconds"], 3.5)
-
-    def test_legacy_result_uses_log_fallback(self) -> None:
-        with tempfile.TemporaryDirectory() as temp:
-            run_dir = Path(temp)
-            self.write_json(
-                run_dir,
-                "results/query.json",
-                {"ResultFormatVersion": "0.1", "Totals": {}},
-            )
-            log = run_dir / "logs/query.log"
-            log.parent.mkdir()
-            log.write_text(
-                "Run complete after 10 queries\nall queries:\n"
-                "min: 1ms, mean: 3.50ms, max: 4ms, count: 10\n",
-                encoding="utf-8",
-            )
-            summary = summarize.build_summary(
-                run_dir,
-                {
-                    "events": {
-                        "loads": [],
-                        "queries": [
-                            {
-                                "query_type": "lastpoint",
-                                "attempt": 1,
-                                "database": "benchmark",
-                                "status": "completed",
-                                "log": "logs/query.log",
-                                "results": "results/query.json",
-                            }
-                        ],
-                    }
-                },
-            )
-
-        self.assertEqual(summary["failures"], [])
-        self.assertEqual(summary["queries"][0]["weighted_mean_milliseconds"], 3.5)
-
-    def test_incomplete_current_result_is_a_failure(self) -> None:
-        with tempfile.TemporaryDirectory() as temp:
-            run_dir = Path(temp)
-            self.write_json(
-                run_dir,
-                "results/query.json",
-                {"ResultFormatVersion": "0.2", "Totals": {"overallStats": {}}},
-            )
-            summary = summarize.build_summary(
-                run_dir,
-                {
-                    "events": {
-                        "loads": [],
-                        "queries": [
-                            {
-                                "query_type": "lastpoint",
-                                "attempt": 1,
-                                "database": "benchmark",
-                                "status": "completed",
-                                "log": "logs/query.log",
-                                "results": "results/query.json",
-                            }
-                        ],
-                    }
-                },
-            )
-
-        self.assertEqual(summary["queries"], [])
-        self.assertIn("all_queries", summary["failures"][0]["reason"])
-        self.assertEqual(summary["failures"][0]["log"], "logs/query.log")
-
-    def test_malformed_current_result_is_a_failure(self) -> None:
-        with tempfile.TemporaryDirectory() as temp:
-            run_dir = Path(temp)
-            result = run_dir / "results/query.json"
-            result.parent.mkdir()
-            result.write_text("{not-json", encoding="utf-8")
-            summary = summarize.build_summary(
-                run_dir,
-                {
-                    "events": {
-                        "loads": [],
-                        "queries": [
-                            {
-                                "query_type": "lastpoint",
-                                "attempt": 1,
-                                "database": "benchmark",
-                                "status": "completed",
-                                "log": "logs/query.log",
-                                "results": "results/query.json",
-                            }
-                        ],
-                    }
-                },
-            )
-
-        self.assertEqual(summary["queries"], [])
-        self.assertIn("malformed result JSON", summary["failures"][0]["reason"])
-
-    def test_parsers_and_target_identity(self) -> None:
-        structured_load = summarize.parse_load_result(
-            {
-                "DurationMillis": 2000,
-                "Totals": {
-                    "metricCount": 200,
-                    "metricRate": 100.0,
-                    "rowCount": 0,
-                    "rowRate": 0.0,
-                },
-            }
-        )
-        self.assertNotIn("rows", structured_load)
-        load = summarize.parse_load_log(
-            "loaded 200 metrics in 2.000sec (mean rate 100.00 metrics/sec)\n"
-            "loaded 40 rows in 2.000sec (mean rate 20.00 rows/sec)\n"
-        )
-        self.assertEqual(load["metrics_per_second"], 100.0)
-        query = summarize.parse_query_log(
-            "Run complete after 10 queries\nall queries:\n"
-            "min: 1ms, mean: 3.50ms, max: 4ms, count: 10\n"
-        )
-        self.assertEqual(query, {"mean_milliseconds": 3.5, "count": 10})
+    def test_influxdb3_target_identity_is_rendered(self) -> None:
         with tempfile.TemporaryDirectory() as temp:
             summary = summarize.build_summary(
                 Path(temp),
                 {
-                    "run_id": "run", "profile": "smoke", "database": "benchmark",
-                    "target": {"mode": "managed", "database_id": "db-a", "edition": "core", "urls": ["http://localhost:8181"]},
+                    "run_id": "run",
+                    "profile": "smoke",
+                    "database": "benchmark",
+                    "target": {
+                        "mode": "managed",
+                        "database_id": "db-a",
+                        "edition": "core",
+                        "urls": ["http://localhost:8181"],
+                    },
                     "dataset": {"dataset_id": "data-a"},
-                    "query_set": {"query_set_id": "set-a", "manifest_sha256": "abc"},
-                    "events": {"loads": [], "queries": []},
+                    "query_set": {
+                        "query_set_id": "set-a",
+                        "manifest_sha256": "abc",
+                    },
+                    "events": {"loads": [], "queries": [], "servers": []},
                 },
             )
-        self.assertEqual(summary["target"]["database_id"], "db-a")
-        self.assertEqual(summary["query_set"]["query_set_id"], "set-a")
+
         rendered = summarize.render_markdown(summary)
         self.assertIn("managed:db-a", rendered)
         self.assertIn("set-a", rendered)

--- a/.agents/tests/test_tsbs_benchmark.py
+++ b/.agents/tests/test_tsbs_benchmark.py
@@ -145,13 +145,115 @@ class ResultTests(unittest.TestCase):
         self.assertEqual(summary["queries"][0]["query_count"], 40)
         self.assertEqual(summary["queries"][0]["weighted_mean_milliseconds"], 3.5)
 
-    def test_legacy_query_log_remains_supported(self) -> None:
-        parsed = shared.parse_query_log(
-            "Run complete after 10 queries\nall queries:\n"
-            "min: 1ms, mean: 3.50ms, max: 4ms, count: 10\n"
+    def test_reused_load_does_not_require_a_log(self) -> None:
+        with tempfile.TemporaryDirectory() as temp:
+            summary = shared.build_summary(
+                Path(temp),
+                {
+                    "events": {
+                        "loads": [
+                            {
+                                "attempt": 1,
+                                "database": "benchmark",
+                                "database_mode": "reuse",
+                                "status": "reused",
+                            }
+                        ],
+                        "queries": [],
+                    }
+                },
+            )
+
+        self.assertEqual(summary["ingestion_runs"], [])
+        self.assertEqual(summary["failures"], [])
+
+    def test_legacy_result_uses_log_fallback(self) -> None:
+        with tempfile.TemporaryDirectory() as temp:
+            run_dir = Path(temp)
+            self.write_json(
+                run_dir,
+                "results/query.json",
+                {"ResultFormatVersion": "0.1", "Totals": {}},
+            )
+            log = run_dir / "logs/query.log"
+            log.parent.mkdir()
+            log.write_text(
+                "Run complete after 10 queries\nall queries:\n"
+                "min: 1ms, mean: 3.50ms, max: 4ms, count: 10\n",
+                encoding="utf-8",
+            )
+            summary = shared.build_summary(
+                run_dir,
+                {
+                    "events": {
+                        "loads": [],
+                        "queries": [
+                            {
+                                "query_type": "lastpoint",
+                                "attempt": 1,
+                                "database": "benchmark",
+                                "status": "completed",
+                                "log": "logs/query.log",
+                                "results": "results/query.json",
+                            }
+                        ],
+                    }
+                },
+            )
+
+        self.assertEqual(summary["failures"], [])
+        self.assertEqual(summary["queries"][0]["weighted_mean_milliseconds"], 3.5)
+
+    def test_invalid_current_result_is_reported_as_a_failure(self) -> None:
+        with tempfile.TemporaryDirectory() as temp:
+            run_dir = Path(temp)
+            self.write_json(
+                run_dir,
+                "results/query.json",
+                {"ResultFormatVersion": "0.2", "Totals": {"overallStats": {}}},
+            )
+            event = {
+                "query_type": "lastpoint",
+                "attempt": 1,
+                "database": "benchmark",
+                "status": "completed",
+                "log": "logs/query.log",
+                "results": "results/query.json",
+            }
+            incomplete = shared.build_summary(
+                run_dir, {"events": {"loads": [], "queries": [event]}}
+            )
+
+            (run_dir / "results/query.json").write_text(
+                "{not-json", encoding="utf-8"
+            )
+            malformed = shared.build_summary(
+                run_dir, {"events": {"loads": [], "queries": [event]}}
+            )
+
+        self.assertEqual(incomplete["queries"], [])
+        self.assertIn("all_queries", incomplete["failures"][0]["reason"])
+        self.assertIn("malformed result JSON", malformed["failures"][0]["reason"])
+
+    def test_load_parsers_preserve_optional_row_metrics(self) -> None:
+        structured = shared.parse_load_result(
+            {
+                "DurationMillis": 2000,
+                "Totals": {
+                    "metricCount": 200,
+                    "metricRate": 100.0,
+                    "rowCount": 0,
+                    "rowRate": 0.0,
+                },
+            }
+        )
+        legacy = shared.parse_load_log(
+            "loaded 200 metrics in 2.000sec (mean rate 100.00 metrics/sec)\n"
+            "loaded 40 rows in 2.000sec (mean rate 20.00 rows/sec)\n"
         )
 
-        self.assertEqual(parsed, {"mean_milliseconds": 3.5, "count": 10})
+        self.assertNotIn("rows", structured)
+        self.assertEqual(legacy["rows_per_second"], 20.0)
 
 
 if __name__ == "__main__":

--- a/.agents/tests/test_tsbs_benchmark.py
+++ b/.agents/tests/test_tsbs_benchmark.py
@@ -1,0 +1,158 @@
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+LIB = Path(__file__).resolve().parents[1] / "lib"
+sys.path.insert(0, str(LIB))
+
+import tsbs_benchmark as shared  # noqa: E402
+
+
+class ArtifactTests(unittest.TestCase):
+    def test_atomic_json_round_trip_and_checksum(self) -> None:
+        with tempfile.TemporaryDirectory() as temp:
+            path = Path(temp) / "nested" / "manifest.json"
+            shared.save_json(path, {"value": 1})
+
+            self.assertEqual(shared.read_json(path, RuntimeError), {"value": 1})
+            self.assertEqual(len(shared.sha256_file(path)), 64)
+            self.assertFalse(any(path.parent.glob("*.tmp-*")))
+
+    def test_new_run_dir_does_not_reuse_an_existing_run(self) -> None:
+        with tempfile.TemporaryDirectory() as temp:
+            root = Path(temp)
+            first = shared.new_run_dir(root)
+            first.mkdir()
+            second = shared.new_run_dir(root)
+
+            self.assertNotEqual(first, second)
+            self.assertEqual(second.parent, root)
+
+
+class WorkloadTests(unittest.TestCase):
+    def args(self, **overrides: object) -> argparse.Namespace:
+        values = {
+            "profile": "smoke",
+            "start": None,
+            "end": None,
+            "scale": None,
+            "seed": None,
+            "log_interval": None,
+            "load_workers": None,
+            "query_workers": None,
+            "batch_size": None,
+            "queries": None,
+            "query_type": None,
+        }
+        values.update(overrides)
+        return argparse.Namespace(**values)
+
+    def test_profile_is_copied_and_query_selection_is_canonical(self) -> None:
+        workload = shared.build_workload(
+            self.args(query_type=["lastpoint", "cpu-max-all-1"], queries=3)
+        )
+
+        self.assertEqual(
+            workload["query_counts"], {"cpu-max-all-1": 3, "lastpoint": 3}
+        )
+        workload["query_counts"]["lastpoint"] = 99
+        self.assertEqual(shared.PROFILES["smoke"]["query_counts"]["lastpoint"], 10)
+
+    def test_existing_workload_is_reused_when_profile_is_omitted(self) -> None:
+        base = json.loads(json.dumps(shared.PROFILES["manual"]))
+        workload = shared.build_workload(self.args(profile=None, scale=7), base)
+
+        self.assertEqual(workload["scale"], 7)
+        self.assertEqual(workload["start"], base["start"])
+
+
+class ResultTests(unittest.TestCase):
+    def write_json(self, root: Path, relative: str, value: dict) -> None:
+        path = root / relative
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps(value), encoding="utf-8")
+
+    def test_structured_results_are_aggregated_with_weighted_latency(self) -> None:
+        with tempfile.TemporaryDirectory() as temp:
+            run_dir = Path(temp)
+            self.write_json(
+                run_dir,
+                "results/load.json",
+                {
+                    "ResultFormatVersion": "0.2",
+                    "DurationMillis": 2000,
+                    "Totals": {
+                        "metricCount": 200,
+                        "metricRate": 100.0,
+                        "rowCount": 40,
+                        "rowRate": 20.0,
+                    },
+                },
+            )
+            for attempt, count, mean in ((1, 10, 2.0), (2, 30, 4.0)):
+                self.write_json(
+                    run_dir,
+                    f"results/query-{attempt}.json",
+                    {
+                        "ResultFormatVersion": "0.2",
+                        "DurationMillis": 1000,
+                        "Totals": {
+                            "overallStats": {
+                                "all_queries": {
+                                    "count": count,
+                                    "meanMilliseconds": mean,
+                                }
+                            }
+                        },
+                    },
+                )
+            manifest = {
+                "events": {
+                    "loads": [
+                        {
+                            "attempt": 1,
+                            "database": "benchmark",
+                            "database_mode": "create",
+                            "status": "completed",
+                            "log": "logs/load.log",
+                            "results": "results/load.json",
+                        }
+                    ],
+                    "queries": [
+                        {
+                            "query_type": "lastpoint",
+                            "attempt": attempt,
+                            "database": "benchmark",
+                            "status": "completed",
+                            "log": f"logs/query-{attempt}.log",
+                            "results": f"results/query-{attempt}.json",
+                        }
+                        for attempt in (1, 2)
+                    ],
+                }
+            }
+
+            summary = shared.build_summary(run_dir, manifest)
+
+        self.assertEqual(summary["failures"], [])
+        self.assertEqual(summary["ingestion_runs"][0]["metrics"], 200)
+        self.assertEqual(summary["queries"][0]["query_count"], 40)
+        self.assertEqual(summary["queries"][0]["weighted_mean_milliseconds"], 3.5)
+
+    def test_legacy_query_log_remains_supported(self) -> None:
+        parsed = shared.parse_query_log(
+            "Run complete after 10 queries\nall queries:\n"
+            "min: 1ms, mean: 3.50ms, max: 4ms, count: 10\n"
+        )
+
+        self.assertEqual(parsed, {"mean_milliseconds": 3.5, "count": 10})
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What changed

- extract database-neutral TSBS workload, artifact, locking, result-parsing, and summary-aggregation helpers into a shared internal module
- update the GreptimeDB and InfluxDB 3 benchmark skills to reuse those helpers
- keep each skill's CLI, target lifecycle, authentication, diagnostics, manifests, and query generation independent
- move shared parser and aggregation coverage out of both database suites while retaining target-specific integration tests

## Why

The two benchmark skills duplicated stable utility, result-processing, and test logic. Centralizing only the proven common pieces reduces maintenance drift without introducing an adapter framework that could constrain future database skills.

## Impact

User-facing benchmark commands, workspace paths, manifests, and database-specific behavior remain unchanged. Future database skills can import shared helpers selectively without implementing an interface.

## Validation

- 9 shared-module tests
- 10 GreptimeDB benchmark integration tests
- 17 InfluxDB 3 benchmark integration tests
- 11 dataset-generation tests
- 14 InfluxDB setup tests
- both benchmark skill validators
- CLI help and Python compilation checks
- `git diff --check`
