### PR TITLE
feat: add GreptimeDB setup skill

### DIFF
--- a/.agents/skills/benchmark-greptimedb/SKILL.md
+++ b/.agents/skills/benchmark-greptimedb/SKILL.md
@@ -8,13 +8,15 @@ description: Run repeatable GreptimeDB TSBS benchmarks with shared datasets, com
 Use `scripts/benchmark.py` for execution and structured result parsing. Read
 `references/workload.md` before selecting workload sizes, query types, database
 modes, or shared workspace identifiers. Use `$generate-tsbs-data` for standalone
-dataset generation, inspection, or non-Greptime serialization formats.
+dataset generation, inspection, or non-Greptime serialization formats. Use
+`$setup-greptimedb` to install and prepare a managed database workspace.
 
 ## Collect inputs
 
 1. Select a stage: `all`, `generate`, `load`, `query`, or `summarize`.
 2. For `all`, `load`, or `query`, select exactly one target:
-   - managed: an executable GreptimeDB binary plus a reusable `--database-id`;
+   - managed: a prepared reusable `--database-id`; legacy workspaces also need
+     an explicit GreptimeDB binary;
    - external: an HTTP endpoint.
 3. Select the SQL `--database`. For external loads, also select `create`,
    `reuse`, or explicitly confirmed `reset`. Never infer reset authorization.
@@ -26,8 +28,7 @@ Run from the repository root:
 
 ```bash
 python3 .agents/skills/benchmark-greptimedb/scripts/benchmark.py all \
-  --profile smoke --greptime-bin /absolute/path/to/greptime \
-  --database-id smoke-db
+  --profile smoke --database-id smoke-db
 
 python3 .agents/skills/benchmark-greptimedb/scripts/benchmark.py generate \
   --profile smoke --only queries \
@@ -56,6 +57,10 @@ size, and checksum validation.
 
 - Give every managed workspace a stable `--database-id`; `--database-root`
   defaults to `.benchmarks/greptimedb/databases`.
+- Prepare new managed workspaces with `$setup-greptimedb`; the benchmark runner
+  verifies and discovers their version-bound binary automatically.
+- Keep using `--greptime-bin` for legacy workspaces. Never silently adopt a
+  legacy workspace into a downloaded installation.
 - Keep one SQL database and one loaded dataset per managed workspace. Reuse a
   matching binding without loading duplicate data.
 - Rebind only with `--database-mode reset --confirm-reset DATABASE`, after the

--- a/.agents/skills/benchmark-greptimedb/references/workload.md
+++ b/.agents/skills/benchmark-greptimedb/references/workload.md
@@ -9,6 +9,7 @@
 │   ├── manifest.json
 │   └── queries/<query-type>.dat
 └── greptimedb/
+    ├── installations/<version>/<platform>/{manifest.json,greptime,...}
     ├── databases/<database-id>/{manifest.json,data/,logs/}
     └── runs/<run-id>/{manifest.json,logs/,results/,summary.json,summary.md}
 ```
@@ -58,7 +59,9 @@ The query generator receives the end timestamp plus one second.
 ## Database state
 
 Managed workspace manifests bind `database_id`, SQL database name, and one
-loaded dataset specification/checksum. A matching dataset is reused. A
+loaded dataset specification/checksum. Workspaces prepared by
+`$setup-greptimedb` additionally bind an exact installation version, platform,
+path, and binary checksum. A matching dataset is reused. A
 different dataset requires a successfully confirmed reset before the binding
 changes. External `create`, `reuse`, and `reset` map to the corresponding TSBS
 loader flags; external reuse may duplicate data.

--- a/.agents/skills/benchmark-greptimedb/scripts/benchmark.py
+++ b/.agents/skills/benchmark-greptimedb/scripts/benchmark.py
@@ -345,6 +345,16 @@ def validate_database_manifest(path: Path, expected_id: str | None = None) -> di
     binding_fields = {"dataset_id", "spec", "format", "bytes", "sha256"}
     if binding is not None and (not isinstance(binding, dict) or set(binding) != binding_fields or not isinstance(binding.get("spec"), dict)):
         raise BenchmarkError(f"malformed database binding: {path / 'manifest.json'}")
+    setup_fields = {"version", "version_source", "platform", "installation_path", "binary_sha256"}
+    present = setup_fields.intersection(manifest)
+    if present and present != setup_fields:
+        raise BenchmarkError(f"incomplete setup identity in database manifest: {path / 'manifest.json'}")
+    if present:
+        if not all(isinstance(manifest[field], str) and manifest[field] for field in setup_fields):
+            raise BenchmarkError(f"malformed setup identity in database manifest: {path / 'manifest.json'}")
+        binary = Path(manifest["installation_path"]) / "greptime"
+        if not binary.is_file() or not os.access(binary, os.X_OK) or sha256_file(binary) != manifest["binary_sha256"]:
+            raise BenchmarkError(f"prepared GreptimeDB binary checksum mismatch: {binary}")
     return manifest
 
 
@@ -355,10 +365,24 @@ def prepare_database_workspace(args: argparse.Namespace) -> tuple[Path, dict[str
         if manifest["database"] != args.database:
             raise BenchmarkError("managed workspace is bound to a different SQL database")
     else:
+        if not args.greptime_bin:
+            raise BenchmarkError(f"prepared managed workspace does not exist: {path}; create it with $setup-greptimedb")
         (path / "data").mkdir(parents=True, exist_ok=True); (path / "logs").mkdir(parents=True, exist_ok=True)
         manifest = {"schema_version": SCHEMA_VERSION, "kind": "greptimedb-database", "database_id": args.database_id, "created_at": utc_now(), "updated_at": utc_now(), "database": args.database, "binding": None}
         save_json(manifest_path, manifest)
     return path, manifest
+
+
+def managed_binary(args: argparse.Namespace, manifest: dict[str, Any]) -> Path:
+    prepared_path = manifest.get("installation_path")
+    if prepared_path:
+        prepared = Path(prepared_path) / "greptime"
+        if args.greptime_bin and args.greptime_bin.expanduser().resolve() != prepared.resolve():
+            raise BenchmarkError("--greptime-bin conflicts with the binary bound to the prepared database workspace")
+        return prepared.resolve()
+    if not args.greptime_bin:
+        raise BenchmarkError("legacy managed workspace requires --greptime-bin; prepare it with $setup-greptimedb for automatic binary discovery")
+    return args.greptime_bin.expanduser().resolve()
 
 
 @contextlib.contextmanager
@@ -426,12 +450,11 @@ def check_port_available(port: int) -> None:
 
 @contextlib.contextmanager
 def connection(args: argparse.Namespace, run_dir: Path) -> Iterator[tuple[str, bool, dict[str, Any] | None, Path | None]]:
-    if bool(args.greptime_bin) == bool(args.endpoint): raise BenchmarkError("provide exactly one of --greptime-bin or --endpoint")
     if args.endpoint:
         yield args.endpoint.rstrip("/"), False, None, None; return
     workspace, database_manifest = prepare_database_workspace(args)
     with lock_database(workspace):
-        binary = args.greptime_bin.resolve()
+        binary = managed_binary(args, database_manifest)
         if not binary.is_file() or not os.access(binary, os.X_OK): raise BenchmarkError(f"GreptimeDB binary is not executable: {binary}")
         check_port_available(args.http_port); endpoint = f"http://127.0.0.1:{args.http_port}"; process_log_path = run_dir / "logs" / "greptimedb-process.log"; process_log = process_log_path.open("a", encoding="utf-8")
         command = [str(binary), "standalone", "start", "--http-addr", f"127.0.0.1:{args.http_port}", "--influxdb-enable", "--data-home", str(workspace / "data"), "--log-dir", str(workspace / "logs")]
@@ -487,8 +510,8 @@ def validate_args(args: argparse.Namespace) -> None:
         value = getattr(args, name, None)
         if value and not ID_RE.fullmatch(value): raise BenchmarkError(f"--{name.replace('_', '-')} contains invalid characters")
     if args.command in ("load", "query", "all"):
-        if bool(args.greptime_bin) == bool(args.endpoint): raise BenchmarkError("provide exactly one of --greptime-bin or --endpoint")
-        if args.greptime_bin and not args.database_id: raise BenchmarkError("managed GreptimeDB requires --database-id")
+        if args.endpoint and (args.greptime_bin or args.database_id): raise BenchmarkError("external GreptimeDB cannot use --greptime-bin or --database-id")
+        if not args.endpoint and not args.database_id: raise BenchmarkError("provide --database-id for managed GreptimeDB or --endpoint for external GreptimeDB")
         if args.endpoint and args.database_id: raise BenchmarkError("--database-id is only valid with managed GreptimeDB")
         if args.endpoint:
             parsed = urllib.parse.urlparse(args.endpoint)
@@ -512,7 +535,7 @@ def main(argv: Sequence[str] | None = None) -> int:
             if args.only in ("all", "queries"): generate_queries(args, run_dir, manifest)
         elif args.command in ("load", "query", "all"):
             with connection(args, run_dir) as (endpoint, managed, database_manifest, database_path):
-                manifest["target"] = {"mode": "managed" if managed else "external", "endpoint": endpoint, "database": args.database, "database_id": args.database_id if managed else None}; save_manifest(run_dir, manifest)
+                manifest["target"] = {"mode": "managed" if managed else "external", "endpoint": endpoint, "database": args.database, "database_id": args.database_id if managed else None, "version": database_manifest.get("version") if database_manifest else None, "binary_sha256": database_manifest.get("binary_sha256") if database_manifest else None}; save_manifest(run_dir, manifest)
                 if args.command in ("load", "all"): load_data(args, run_dir, manifest, endpoint, managed, database_manifest, database_path)
                 if args.command in ("query", "all"): run_queries(args, run_dir, manifest, endpoint, database_manifest)
         summary = write_summary(run_dir, manifest); print(f"Run directory: {run_dir}"); print(f"Summary: {run_dir / 'summary.md'}"); return 1 if summary["failures"] else 0

--- a/.agents/skills/benchmark-greptimedb/scripts/summarize.py
+++ b/.agents/skills/benchmark-greptimedb/scripts/summarize.py
@@ -34,6 +34,10 @@ def render_markdown(summary: dict[str, Any]) -> str:
     if target:
         target_name = target.get("database_id") or target.get("endpoint")
         lines.append(f"- Benchmark target: `{target.get('mode')}:{target_name}`")
+        if target.get("version"):
+            lines.append(f"- GreptimeDB version: `{target.get('version')}`")
+        if target.get("binary_sha256"):
+            lines.append(f"- GreptimeDB binary SHA-256: `{target.get('binary_sha256')}`")
     dataset = summary.get("dataset")
     if dataset:
         lines.extend(

--- a/.agents/skills/benchmark-greptimedb/tests/test_benchmark.py
+++ b/.agents/skills/benchmark-greptimedb/tests/test_benchmark.py
@@ -25,7 +25,7 @@ class SummaryIntegrationTests(unittest.TestCase):
                     "run_id": "run",
                     "profile": "smoke",
                     "database": "benchmark",
-                    "target": {"mode": "managed", "database_id": "db-a"},
+                    "target": {"mode": "managed", "database_id": "db-a", "version": "1.1.4", "binary_sha256": "def"},
                     "dataset": {"dataset_id": "data-a"},
                     "query_set": {
                         "query_set_id": "set-a",
@@ -37,6 +37,8 @@ class SummaryIntegrationTests(unittest.TestCase):
 
         rendered = summarize.render_markdown(summary)
         self.assertIn("managed:db-a", rendered)
+        self.assertIn("GreptimeDB version: `1.1.4`", rendered)
+        self.assertIn("GreptimeDB binary SHA-256: `def`", rendered)
         self.assertIn("set-a", rendered)
 
 
@@ -212,6 +214,40 @@ class ManagedDatabaseTests(unittest.TestCase):
         benchmark.resolve_database(args)
         with self.assertRaisesRegex(benchmark.BenchmarkError, "database-id"):
             benchmark.validate_args(args)
+
+    def test_prepared_workspace_discovers_and_validates_binary(self) -> None:
+        with tempfile.TemporaryDirectory() as temp:
+            root = Path(temp); installation = root / "installations/1.1.4/linux_amd64"; installation.mkdir(parents=True)
+            binary = installation / "greptime"; binary.write_text("#!/bin/sh\n", encoding="utf-8"); binary.chmod(0o755)
+            database = root / "databases/db-a"; (database / "data").mkdir(parents=True); (database / "logs").mkdir()
+            benchmark.save_json(database / "manifest.json", {
+                "schema_version": 1, "kind": "greptimedb-database", "database_id": "db-a",
+                "created_at": benchmark.utc_now(), "database": "benchmark", "binding": None,
+                "version": "1.1.4", "version_source": "explicit", "platform": "linux_amd64",
+                "installation_path": str(installation), "binary_sha256": benchmark.sha256_file(binary),
+            })
+            args = benchmark.make_parser().parse_args(["query", "--database-id", "db-a", "--database-root", str(root / "databases"), "--database", "benchmark"])
+            manifest = benchmark.validate_database_manifest(database, "db-a")
+            self.assertEqual(benchmark.managed_binary(args, manifest), binary.resolve())
+            explicit = benchmark.make_parser().parse_args(["query", "--greptime-bin", "/bin/true", "--database-id", "db-a", "--database-root", str(root / "databases"), "--database", "benchmark"])
+            with self.assertRaisesRegex(benchmark.BenchmarkError, "conflicts"):
+                benchmark.managed_binary(explicit, manifest)
+            binary.write_text("corrupt", encoding="utf-8")
+            with self.assertRaisesRegex(benchmark.BenchmarkError, "checksum mismatch"):
+                benchmark.validate_database_manifest(database, "db-a")
+
+    def test_legacy_workspace_requires_explicit_binary(self) -> None:
+        manifest = {"database_id": "db-a", "database": "benchmark", "binding": None}
+        args = benchmark.make_parser().parse_args(["query", "--database-id", "db-a", "--database", "benchmark"])
+        with self.assertRaisesRegex(benchmark.BenchmarkError, "legacy managed workspace"):
+            benchmark.managed_binary(args, manifest)
+
+    def test_missing_prepared_workspace_does_not_create_legacy_state(self) -> None:
+        with tempfile.TemporaryDirectory() as temp:
+            root = Path(temp); args = benchmark.make_parser().parse_args(["query", "--database-id", "db-a", "--database-root", str(root), "--database", "benchmark"])
+            with self.assertRaisesRegex(benchmark.BenchmarkError, "does not exist"):
+                benchmark.prepare_database_workspace(args)
+            self.assertFalse((root / "db-a").exists())
 
 
 if __name__ == "__main__":

--- a/.agents/skills/setup-greptimedb/SKILL.md
+++ b/.agents/skills/setup-greptimedb/SKILL.md
@@ -1,0 +1,58 @@
+---
+name: setup-greptimedb
+description: Install checksum-verified latest-stable or version-pinned GreptimeDB native releases and prepare reusable local benchmark database workspaces. Use for local GreptimeDB installation, exact-version setup, installation verification, managed TSBS workspace preparation, or locating a managed GreptimeDB binary.
+---
+
+# Setup GreptimeDB
+
+Use `scripts/setup.py` for deterministic installation and database management.
+Read `references/setup.md` before choosing a version or platform. Use
+`$benchmark-greptimedb` after preparing a database workspace.
+
+## Install the latest stable or an exact version
+
+Run from the repository root:
+
+```bash
+python3 .agents/skills/setup-greptimedb/scripts/setup.py install
+
+python3 .agents/skills/setup-greptimedb/scripts/setup.py install \
+  --version 1.1.4
+
+python3 .agents/skills/setup-greptimedb/scripts/setup.py install \
+  --version v1.2.0-beta.1
+```
+
+Omitting `--version` resolves GitHub's latest stable, non-prerelease release.
+Pass an exact version, with or without `v`, to select a stable or prerelease
+version. The installer requires the adjacent vendor SHA-256, validates the
+complete extracted distribution, checks `greptime --version`, and publishes
+atomically. It never executes the official shell installer.
+
+## Prepare a database workspace
+
+```bash
+python3 .agents/skills/setup-greptimedb/scripts/setup.py prepare \
+  --database-id greptime-114 --version 1.1.4
+
+python3 .agents/skills/setup-greptimedb/scripts/setup.py prepare \
+  --database-id greptime-stable
+```
+
+Existing workspaces are immutable with respect to version, platform, binary
+checksum, and SQL database. Omitting `--version` resolves the stable version at
+command execution time and never upgrades an existing workspace automatically.
+Do not adopt or rewrite a legacy benchmark workspace; continue using it with an
+explicit binary or choose a new database ID.
+
+## Inspect and verify
+
+```bash
+python3 .agents/skills/setup-greptimedb/scripts/setup.py list
+python3 .agents/skills/setup-greptimedb/scripts/setup.py inspect --database-id greptime-114
+python3 .agents/skills/setup-greptimedb/scripts/setup.py verify --database-id greptime-114
+```
+
+Report the database ID, exact version, platform, binary path and checksum, and
+workspace path. Do not add the binary to `PATH` or alter system packages or
+services.

--- a/.agents/skills/setup-greptimedb/agents/openai.yaml
+++ b/.agents/skills/setup-greptimedb/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Setup GreptimeDB"
+  short_description: "Install and prepare local GreptimeDB"
+  default_prompt: "Use $setup-greptimedb to install and prepare a verified local GreptimeDB database workspace."

--- a/.agents/skills/setup-greptimedb/references/setup.md
+++ b/.agents/skills/setup-greptimedb/references/setup.md
@@ -1,0 +1,30 @@
+# GreptimeDB local setup reference
+
+## Workspace
+
+```text
+.benchmarks/greptimedb/
+├── installations/<version>/<platform>/{manifest.json,greptime,...}
+└── databases/<database-id>/{manifest.json,data/,logs/}
+```
+
+Installations and prepared database workspaces are reusable and checksum
+validated. Official assets use
+`greptime-<os>-<arch>-v<version>.tar.gz` and an adjacent `.sha256sum` file on
+GitHub Releases. The full extracted distribution is retained and hashed.
+
+When `--version` is omitted, resolve GitHub's latest stable release endpoint.
+The GreptimeDB download page and documentation quickstart are human-facing
+cross-checks and can feature a prerelease. Resolution failures do not fall back
+to the website, a cached version, or a guessed tag; pass an exact version for
+offline or reproducible operation. Set `GITHUB_TOKEN` to authenticate GitHub
+requests when anonymous API limits are insufficient. Never record the token.
+
+Supported native platforms are Linux AMD64, Linux ARM64, macOS AMD64, and
+macOS ARM64. Windows, Android, Docker, Kubernetes, package managers, and nightly
+builds are outside this managed benchmark workflow.
+
+Prepared manifests bind the database ID, SQL database name, release version,
+platform, installation path, and binary checksum. Dataset binding remains owned
+by the benchmark skill. Legacy benchmark manifests intentionally lack release
+identity and require an explicit `--greptime-bin`.

--- a/.agents/skills/setup-greptimedb/scripts/setup.py
+++ b/.agents/skills/setup-greptimedb/scripts/setup.py
@@ -113,7 +113,11 @@ def download_bytes(url: str, *, accept: str = "application/octet-stream,*/*") ->
 
 
 def download(url: str, destination: Path) -> None:
-    destination.write_bytes(download_bytes(url))
+    try:
+        with urllib.request.urlopen(request(url), timeout=60) as response, destination.open("wb") as output:
+            shutil.copyfileobj(response, output)
+    except (OSError, urllib.error.URLError) as exc:
+        raise SetupError(f"could not download {url}: {exc}") from exc
 
 
 def resolve_official_version() -> str:

--- a/.agents/skills/setup-greptimedb/scripts/setup.py
+++ b/.agents/skills/setup-greptimedb/scripts/setup.py
@@ -1,0 +1,399 @@
+#!/usr/bin/env python3
+"""Install GreptimeDB releases and prepare reusable benchmark workspaces."""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import hashlib
+import json
+import os
+import platform
+import re
+import shutil
+import subprocess
+import sys
+import tarfile
+import tempfile
+import urllib.error
+import urllib.request
+from pathlib import Path, PurePosixPath
+from typing import Any, Sequence
+
+
+SCRIPT_PATH = Path(__file__).resolve()
+REPO_ROOT = SCRIPT_PATH.parents[4]
+DEFAULT_ROOT = REPO_ROOT / ".benchmarks" / "greptimedb"
+DEFAULT_INSTALL_ROOT = DEFAULT_ROOT / "installations"
+DEFAULT_DATABASE_ROOT = DEFAULT_ROOT / "databases"
+GITHUB_API_LATEST = "https://api.github.com/repos/GreptimeTeam/greptimedb/releases/latest"
+RELEASE_BASE_URL = "https://github.com/GreptimeTeam/greptimedb/releases/download"
+USER_AGENT = "tsbs-greptimedb-setup/1.0"
+SCHEMA_VERSION = 1
+INSTALLATION_SCHEMA_VERSION = 1
+ID_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]*$")
+VERSION_RE = re.compile(r"^[0-9]+\.[0-9]+\.[0-9]+(?:[-+][A-Za-z0-9.-]+)?$")
+
+
+class SetupError(RuntimeError):
+    """Raised for an actionable setup failure."""
+
+
+def utc_now() -> str:
+    return dt.datetime.now(dt.timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def save_json(path: Path, value: Any) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temporary = path.with_name(f"{path.name}.tmp-{os.getpid()}")
+    temporary.write_text(json.dumps(value, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    os.replace(temporary, path)
+
+
+def read_json(path: Path) -> dict[str, Any]:
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except FileNotFoundError as exc:
+        raise SetupError(f"missing manifest: {path}") from exc
+    except json.JSONDecodeError as exc:
+        raise SetupError(f"invalid JSON manifest {path}: {exc}") from exc
+    if not isinstance(value, dict):
+        raise SetupError(f"manifest must be an object: {path}")
+    return value
+
+
+def sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as stream:
+        for chunk in iter(lambda: stream.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def normalize_version(value: str) -> str:
+    normalized = value[1:] if value.startswith("v") else value
+    if not VERSION_RE.fullmatch(normalized):
+        raise SetupError("--version must be an exact semantic version such as 1.1.4 or v1.2.0-beta.1")
+    return normalized
+
+
+def platform_tag(system: str | None = None, machine: str | None = None) -> str:
+    system = system or platform.system()
+    machine = (machine or platform.machine()).lower()
+    if system == "Linux" and machine in ("x86_64", "amd64"):
+        return "linux_amd64"
+    if system == "Linux" and machine in ("aarch64", "arm64"):
+        return "linux_arm64"
+    if system == "Darwin" and machine in ("x86_64", "amd64"):
+        return "darwin_amd64"
+    if system == "Darwin" and machine in ("arm64", "aarch64"):
+        return "darwin_arm64"
+    raise SetupError(f"unsupported native platform: {system} {machine}")
+
+
+def artifact_name(version: str, target: str) -> str:
+    system, architecture = target.split("_", 1)
+    return f"greptime-{system}-{architecture}-v{version}.tar.gz"
+
+
+def request(url: str, *, accept: str = "application/octet-stream,*/*") -> urllib.request.Request:
+    headers = {"User-Agent": USER_AGENT, "Accept": accept}
+    token = os.environ.get("GITHUB_TOKEN")
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+    return urllib.request.Request(url, headers=headers)
+
+
+def download_bytes(url: str, *, accept: str = "application/octet-stream,*/*") -> bytes:
+    try:
+        with urllib.request.urlopen(request(url, accept=accept), timeout=60) as response:
+            return response.read()
+    except (OSError, urllib.error.URLError) as exc:
+        raise SetupError(f"could not download {url}: {exc}") from exc
+
+
+def download(url: str, destination: Path) -> None:
+    destination.write_bytes(download_bytes(url))
+
+
+def resolve_official_version() -> str:
+    try:
+        release = json.loads(download_bytes(GITHUB_API_LATEST, accept="application/vnd.github+json"))
+    except (json.JSONDecodeError, UnicodeDecodeError) as exc:
+        raise SetupError("could not parse the latest stable GreptimeDB release; provide an exact --version") from exc
+    if not isinstance(release, dict) or release.get("draft") or release.get("prerelease"):
+        raise SetupError("GitHub did not return a stable GreptimeDB release; provide an exact --version")
+    tag = release.get("tag_name")
+    if not isinstance(tag, str):
+        raise SetupError("latest stable GreptimeDB release has no tag; provide an exact --version")
+    try:
+        return normalize_version(tag)
+    except SetupError as exc:
+        raise SetupError("latest stable GreptimeDB release has an invalid tag; provide an exact --version") from exc
+
+
+def resolve_args_version(args: argparse.Namespace) -> None:
+    if args.version is None:
+        args.version = resolve_official_version()
+        args.version_source = "github-latest-stable"
+    else:
+        args.version = normalize_version(args.version)
+        args.version_source = "explicit"
+
+
+def installation_path(args: argparse.Namespace, target: str | None = None) -> Path:
+    root = (args.install_root or DEFAULT_INSTALL_ROOT).expanduser().resolve()
+    return root / args.version / (target or platform_tag())
+
+
+def distribution_sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    entries = sorted(
+        (entry for entry in path.rglob("*") if entry.relative_to(path).as_posix() != "manifest.json"),
+        key=lambda entry: entry.relative_to(path).as_posix(),
+    )
+    for entry in entries:
+        relative = entry.relative_to(path).as_posix()
+        stat = entry.lstat()
+        mode = stat.st_mode & 0o7777
+        if entry.is_symlink():
+            kind, content = "symlink", os.readlink(entry).encode()
+        elif entry.is_file():
+            kind, content = "file", bytes.fromhex(sha256_file(entry))
+        elif entry.is_dir():
+            kind, content = "directory", b""
+        else:
+            raise SetupError(f"unsupported installation entry: {entry}")
+        digest.update(f"{kind}\0{relative}\0{mode:o}\0".encode())
+        digest.update(content)
+        digest.update(b"\0")
+    return digest.hexdigest()
+
+
+def verify_binary(binary: Path, version: str) -> None:
+    try:
+        result = subprocess.run(
+            [str(binary), "--version"], cwd=binary.parent, capture_output=True,
+            text=True, timeout=15, check=False,
+        )
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        raise SetupError(f"GreptimeDB installation is not runnable: {binary}; reinstall with --reinstall: {exc}") from exc
+    tokens = re.split(r"\s+", f"{result.stdout}\n{result.stderr}".strip())
+    matches = [token.lstrip("v") for token in tokens if token.lstrip("v") == version or token.lstrip("v").startswith(version + "-")]
+    if result.returncode != 0 or not matches:
+        raise SetupError(f"GreptimeDB installation failed version validation for {version}; reinstall with --reinstall")
+
+
+def validate_installation(path: Path, version: str | None = None) -> dict[str, Any]:
+    manifest = read_json(path / "manifest.json")
+    required = {
+        "schema_version", "kind", "version", "version_source", "platform", "binary",
+        "binary_sha256", "archive_sha256", "distribution_sha256",
+    }
+    if manifest.get("schema_version") != INSTALLATION_SCHEMA_VERSION or manifest.get("kind") != "greptimedb-installation" or not required.issubset(manifest):
+        raise SetupError(f"malformed installation manifest: {path / 'manifest.json'}")
+    if version and manifest["version"] != version:
+        raise SetupError("installation version mismatch")
+    binary = path / manifest["binary"]
+    if not binary.is_file() or not os.access(binary, os.X_OK) or sha256_file(binary) != manifest["binary_sha256"]:
+        raise SetupError(f"installation binary checksum mismatch: {binary}")
+    if distribution_sha256(path) != manifest["distribution_sha256"]:
+        raise SetupError(f"installation distribution checksum mismatch: {path}")
+    verify_binary(binary, manifest["version"])
+    return manifest
+
+
+def safe_extract_distribution(archive: Path, destination: Path, expected_root: str) -> Path:
+    with tarfile.open(archive, "r:gz") as bundle:
+        members = bundle.getmembers()
+        if not members:
+            raise SetupError("archive is empty")
+        validated: list[tuple[tarfile.TarInfo, PurePosixPath]] = []
+        for member in members:
+            source = PurePosixPath(member.name)
+            if source.is_absolute() or not source.parts or source.parts[0] != expected_root:
+                raise SetupError("archive must contain exactly the expected top-level directory")
+            relative = PurePosixPath(*source.parts[1:])
+            if any(part in ("", ".", "..") for part in relative.parts):
+                raise SetupError(f"unsafe archive path: {member.name}")
+            if member.islnk() or member.isdev() or member.isfifo() or not (member.isdir() or member.isfile() or member.issym()):
+                raise SetupError(f"unsupported archive member: {member.name}")
+            if member.issym():
+                link = PurePosixPath(member.linkname)
+                if link.is_absolute():
+                    raise SetupError(f"unsafe archive symlink: {member.name}")
+                resolved = list(relative.parent.parts)
+                for part in link.parts:
+                    if part in ("", "."):
+                        continue
+                    if part == "..":
+                        if not resolved:
+                            raise SetupError(f"archive symlink escapes distribution: {member.name}")
+                        resolved.pop()
+                    else:
+                        resolved.append(part)
+            validated.append((member, relative))
+        for member, relative in validated:
+            if relative.parts and member.isdir():
+                target = destination.joinpath(*relative.parts); target.mkdir(parents=True, exist_ok=True); target.chmod(member.mode & 0o7777)
+        for member, relative in validated:
+            if relative.parts and member.isfile():
+                target = destination.joinpath(*relative.parts); target.parent.mkdir(parents=True, exist_ok=True)
+                source = bundle.extractfile(member)
+                if source is None:
+                    raise SetupError(f"could not read archive member: {member.name}")
+                with source, target.open("wb") as output:
+                    shutil.copyfileobj(source, output)
+                target.chmod(member.mode & 0o7777)
+        for member, relative in validated:
+            if relative.parts and member.issym():
+                target = destination.joinpath(*relative.parts); target.parent.mkdir(parents=True, exist_ok=True)
+                os.symlink(member.linkname, target)
+    binary = destination / "greptime"
+    if not binary.is_file():
+        raise SetupError("archive does not contain the greptime binary")
+    return binary
+
+
+def install(args: argparse.Namespace) -> dict[str, Any]:
+    target = platform_tag(); destination = installation_path(args, target)
+    if destination.exists() and not args.reinstall:
+        manifest = validate_installation(destination, args.version)
+        return {**manifest, "installation_path": str(destination), "reused": True}
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    name = artifact_name(args.version, target); tag = f"v{args.version}"
+    temporary = Path(tempfile.mkdtemp(prefix=f".{tag}-", dir=destination.parent))
+    try:
+        archive = temporary / name; checksum_file = temporary / f"{name[:-7]}.sha256sum"
+        source_url = f"{RELEASE_BASE_URL}/{tag}/{name}"
+        download(source_url, archive); download(f"{RELEASE_BASE_URL}/{tag}/{checksum_file.name}", checksum_file)
+        checksum_match = re.search(r"\b([0-9a-fA-F]{64})\b", checksum_file.read_text(encoding="utf-8"))
+        if not checksum_match:
+            raise SetupError("vendor checksum file is malformed")
+        expected, actual = checksum_match.group(1).lower(), sha256_file(archive)
+        if actual != expected:
+            raise SetupError(f"archive checksum mismatch: expected {expected}, got {actual}")
+        expected_root = name[:-7]
+        binary = safe_extract_distribution(archive, temporary, expected_root)
+        archive.unlink(); checksum_file.unlink()
+        manifest = {
+            "schema_version": INSTALLATION_SCHEMA_VERSION, "kind": "greptimedb-installation",
+            "version": args.version, "version_source": args.version_source, "platform": target,
+            "created_at": utc_now(), "source_url": source_url, "archive_sha256": actual,
+            "binary": binary.relative_to(temporary).as_posix(), "binary_sha256": sha256_file(binary),
+            "distribution_sha256": distribution_sha256(temporary),
+        }
+        save_json(temporary / "manifest.json", manifest)
+        validate_installation(temporary, args.version)
+        if destination.exists():
+            backup = destination.with_name(f".{destination.name}.old-{os.getpid()}")
+            os.replace(destination, backup)
+            try:
+                os.replace(temporary, destination)
+            except Exception:
+                os.replace(backup, destination)
+                raise
+            shutil.rmtree(backup)
+        else:
+            os.replace(temporary, destination)
+        return {**manifest, "installation_path": str(destination), "reused": False}
+    finally:
+        if temporary.exists():
+            shutil.rmtree(temporary)
+
+
+def database_path(args: argparse.Namespace) -> Path:
+    return (args.database_root or DEFAULT_DATABASE_ROOT).expanduser().resolve() / args.database_id
+
+
+def validate_database(path: Path, expected_id: str | None = None) -> dict[str, Any]:
+    manifest = read_json(path / "manifest.json")
+    required = {
+        "schema_version", "kind", "database_id", "version", "version_source", "platform",
+        "installation_path", "binary_sha256", "created_at", "database", "binding",
+    }
+    if manifest.get("schema_version") != SCHEMA_VERSION or manifest.get("kind") != "greptimedb-database" or not required.issubset(manifest):
+        raise SetupError(f"malformed or legacy database manifest: {path / 'manifest.json'}")
+    if expected_id and manifest["database_id"] != expected_id:
+        raise SetupError("database identity mismatch")
+    installation = Path(manifest["installation_path"])
+    installed = validate_installation(installation, manifest["version"])
+    if installed["platform"] != manifest["platform"] or installed["binary_sha256"] != manifest["binary_sha256"]:
+        raise SetupError("database installation identity mismatch")
+    return manifest
+
+
+def prepare(args: argparse.Namespace) -> dict[str, Any]:
+    installation = installation_path(args); installed = validate_installation(installation, args.version)
+    path = database_path(args); manifest_path = path / "manifest.json"
+    if manifest_path.exists():
+        manifest = validate_database(path, args.database_id)
+        expected = (args.version, installed["platform"], installed["binary_sha256"], args.database)
+        actual = (manifest["version"], manifest["platform"], manifest["binary_sha256"], manifest["database"])
+        if actual != expected:
+            raise SetupError("database is already bound to another version, binary, platform, or SQL database")
+        return {**manifest, "database_path": str(path), "reused": True}
+    if path.exists() and any(path.iterdir()):
+        raise SetupError(f"database workspace exists without a setup-compatible manifest: {path}")
+    path.mkdir(parents=True, exist_ok=True); (path / "data").mkdir(); (path / "logs").mkdir()
+    manifest = {
+        "schema_version": SCHEMA_VERSION, "kind": "greptimedb-database", "database_id": args.database_id,
+        "version": args.version, "version_source": args.version_source, "platform": installed["platform"],
+        "installation_path": str(installation), "binary_sha256": installed["binary_sha256"],
+        "created_at": utc_now(), "updated_at": utc_now(), "database": args.database, "binding": None,
+    }
+    save_json(manifest_path, manifest)
+    return {**manifest, "database_path": str(path), "reused": False}
+
+
+def print_value(value: Any) -> None:
+    print(json.dumps(value, indent=2, sort_keys=True))
+
+
+def make_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__); sub = parser.add_subparsers(dest="command", required=True)
+    install_parser = sub.add_parser("install"); install_parser.add_argument("--version"); install_parser.add_argument("--install-root", type=Path); install_parser.add_argument("--reinstall", action="store_true")
+    prepare_parser = sub.add_parser("prepare"); prepare_parser.add_argument("--database-id", required=True); prepare_parser.add_argument("--version"); prepare_parser.add_argument("--database", default="benchmark"); prepare_parser.add_argument("--install-root", type=Path); prepare_parser.add_argument("--database-root", type=Path)
+    list_parser = sub.add_parser("list"); list_parser.add_argument("--database-root", type=Path)
+    inspect_parser = sub.add_parser("inspect"); inspect_parser.add_argument("--database-id", required=True); inspect_parser.add_argument("--database-root", type=Path)
+    verify_parser = sub.add_parser("verify"); verify_parser.add_argument("--database-id", required=True); verify_parser.add_argument("--database-root", type=Path)
+    return parser
+
+
+def validate_args(args: argparse.Namespace) -> None:
+    if hasattr(args, "version") and args.version is not None:
+        normalize_version(args.version)
+    if hasattr(args, "database_id") and not ID_RE.fullmatch(args.database_id):
+        raise SetupError("--database-id contains invalid characters")
+    if hasattr(args, "database") and (not args.database or "\x00" in args.database):
+        raise SetupError("--database must not be empty or contain NUL")
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = make_parser().parse_args(argv)
+    try:
+        validate_args(args)
+        if args.command in ("install", "prepare"):
+            resolve_args_version(args)
+        if args.command == "install":
+            value = install(args)
+        elif args.command == "prepare":
+            value = prepare(args)
+        elif args.command in ("inspect", "verify"):
+            path = database_path(args); value = {**validate_database(path, args.database_id), "database_path": str(path)}
+        else:
+            root = (args.database_root or DEFAULT_DATABASE_ROOT).expanduser().resolve(); value = []
+            if root.exists():
+                for path in sorted(root.iterdir()):
+                    if path.is_dir():
+                        try:
+                            value.append({**validate_database(path), "database_path": str(path)})
+                        except SetupError:
+                            continue
+        print_value(value); return 0
+    except (SetupError, OSError, tarfile.TarError, KeyError, TypeError) as exc:
+        print(f"error: {exc}", file=sys.stderr); return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.agents/skills/setup-greptimedb/tests/test_setup.py
+++ b/.agents/skills/setup-greptimedb/tests/test_setup.py
@@ -48,6 +48,21 @@ class VersionResolutionTests(unittest.TestCase):
         self.assertEqual(value.get_header("User-agent"), setup.USER_AGENT)
         self.assertEqual(value.get_header("Authorization"), "Bearer secret")
 
+    def test_download_streams_response_to_destination(self) -> None:
+        payload = b"release archive contents"
+
+        class StreamingResponse(io.BytesIO):
+            def read(self, size: int = -1) -> bytes:
+                if size < 0:
+                    raise AssertionError("download must not buffer the complete response")
+                return super().read(size)
+
+        with tempfile.TemporaryDirectory() as temp:
+            destination = Path(temp) / "artifact.tar.gz"
+            with mock.patch.object(setup.urllib.request, "urlopen", return_value=StreamingResponse(payload)):
+                setup.download("https://example.test/artifact.tar.gz", destination)
+            self.assertEqual(destination.read_bytes(), payload)
+
 
 class InstallationTests(unittest.TestCase):
     binary_content = b"#!/bin/sh\necho 'greptime 1.1.4'\n"

--- a/.agents/skills/setup-greptimedb/tests/test_setup.py
+++ b/.agents/skills/setup-greptimedb/tests/test_setup.py
@@ -1,0 +1,138 @@
+from __future__ import annotations
+
+import argparse
+import hashlib
+import io
+import json
+import os
+import sys
+import tarfile
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+
+SCRIPTS = Path(__file__).resolve().parents[1] / "scripts"
+sys.path.insert(0, str(SCRIPTS))
+
+import setup  # noqa: E402
+
+
+class PlatformTests(unittest.TestCase):
+    def test_supported_platforms_and_artifact_names(self) -> None:
+        self.assertEqual(setup.platform_tag("Linux", "x86_64"), "linux_amd64")
+        self.assertEqual(setup.platform_tag("Linux", "aarch64"), "linux_arm64")
+        self.assertEqual(setup.platform_tag("Darwin", "x86_64"), "darwin_amd64")
+        self.assertEqual(setup.platform_tag("Darwin", "arm64"), "darwin_arm64")
+        self.assertEqual(setup.artifact_name("1.1.4", "linux_amd64"), "greptime-linux-amd64-v1.1.4.tar.gz")
+        with self.assertRaises(setup.SetupError):
+            setup.platform_tag("Windows", "AMD64")
+
+
+class VersionResolutionTests(unittest.TestCase):
+    def test_normalizes_explicit_versions_and_latest_stable(self) -> None:
+        self.assertEqual(setup.normalize_version("v1.1.4"), "1.1.4")
+        self.assertEqual(setup.normalize_version("1.2.0-beta.1"), "1.2.0-beta.1")
+        payload = json.dumps({"tag_name": "v1.1.4", "draft": False, "prerelease": False}).encode()
+        with mock.patch.object(setup, "download_bytes", return_value=payload):
+            self.assertEqual(setup.resolve_official_version(), "1.1.4")
+        for release in ({"tag_name": "v1.2.0-beta.1", "prerelease": True}, {"tag_name": "bad"}):
+            with self.subTest(release=release), mock.patch.object(setup, "download_bytes", return_value=json.dumps(release).encode()):
+                with self.assertRaisesRegex(setup.SetupError, "exact --version"):
+                    setup.resolve_official_version()
+
+    def test_request_uses_optional_github_token(self) -> None:
+        with mock.patch.dict("os.environ", {"GITHUB_TOKEN": "secret"}):
+            value = setup.request("https://api.github.test", accept="application/vnd.github+json")
+        self.assertEqual(value.get_header("User-agent"), setup.USER_AGENT)
+        self.assertEqual(value.get_header("Authorization"), "Bearer secret")
+
+
+class InstallationTests(unittest.TestCase):
+    binary_content = b"#!/bin/sh\necho 'greptime 1.1.4'\n"
+
+    def archive(self, root: Path, *, unsafe: str | None = None) -> str:
+        distribution = root / "greptime-linux-amd64-v1.1.4"
+        distribution.mkdir()
+        binary = distribution / "greptime"; binary.write_bytes(self.binary_content); binary.chmod(0o755)
+        (distribution / "README.txt").write_text("release", encoding="utf-8")
+        archive = root / "artifact.tar.gz"
+        with tarfile.open(archive, "w:gz") as bundle:
+            bundle.add(distribution, arcname=distribution.name, recursive=True)
+            if unsafe:
+                member = tarfile.TarInfo(unsafe); member.size = 1; bundle.addfile(member, io.BytesIO(b"x"))
+        return hashlib.sha256(archive.read_bytes()).hexdigest()
+
+    def args(self, root: Path, reinstall: bool = False) -> argparse.Namespace:
+        return argparse.Namespace(version="1.1.4", version_source="explicit", install_root=root, reinstall=reinstall)
+
+    def test_install_verifies_reuses_and_detects_corruption(self) -> None:
+        with tempfile.TemporaryDirectory() as temp:
+            root = Path(temp); source = root / "source"; source.mkdir(); checksum = self.archive(source)
+            def download(_url: str, destination: Path) -> None:
+                if destination.name.endswith(".sha256sum"):
+                    destination.write_text(checksum + "  artifact.tar.gz\n", encoding="utf-8")
+                else:
+                    destination.write_bytes((source / "artifact.tar.gz").read_bytes())
+            with mock.patch.object(setup, "platform_tag", return_value="linux_amd64"), mock.patch.object(setup, "download", side_effect=download):
+                first = setup.install(self.args(root / "installations")); second = setup.install(self.args(root / "installations"))
+            self.assertFalse(first["reused"]); self.assertTrue(second["reused"])
+            installation = Path(first["installation_path"]); (installation / "README.txt").write_text("corrupt", encoding="utf-8")
+            with self.assertRaisesRegex(setup.SetupError, "distribution checksum mismatch"):
+                setup.validate_installation(installation)
+
+    def test_checksum_and_unsafe_archive_fail_atomically(self) -> None:
+        for unsafe, expected_checksum, message in ((None, "0" * 64, "checksum mismatch"), ("../escape", None, "top-level directory")):
+            with self.subTest(unsafe=unsafe), tempfile.TemporaryDirectory() as temp:
+                root = Path(temp); source = root / "source"; source.mkdir(); checksum = self.archive(source, unsafe=unsafe)
+                def download(_url: str, destination: Path) -> None:
+                    if destination.name.endswith(".sha256sum"):
+                        destination.write_text(expected_checksum or checksum, encoding="utf-8")
+                    else:
+                        destination.write_bytes((source / "artifact.tar.gz").read_bytes())
+                args = self.args(root / "installations")
+                with mock.patch.object(setup, "platform_tag", return_value="linux_amd64"), mock.patch.object(setup, "download", side_effect=download):
+                    with self.assertRaisesRegex(setup.SetupError, message):
+                        setup.install(args)
+                self.assertFalse(setup.installation_path(args, "linux_amd64").exists())
+
+
+class DatabaseTests(unittest.TestCase):
+    def make_installation(self, root: Path) -> Path:
+        path = root / "installations/1.1.4/linux_amd64"; path.mkdir(parents=True)
+        binary = path / "greptime"; binary.write_text("#!/bin/sh\necho 'greptime 1.1.4'\n", encoding="utf-8"); binary.chmod(0o755)
+        manifest = {
+            "schema_version": 1, "kind": "greptimedb-installation", "version": "1.1.4",
+            "version_source": "explicit", "platform": "linux_amd64", "binary": "greptime",
+            "binary_sha256": setup.sha256_file(binary), "archive_sha256": "a" * 64,
+            "distribution_sha256": setup.distribution_sha256(path),
+        }
+        setup.save_json(path / "manifest.json", manifest); return path
+
+    def args(self, root: Path, version: str = "1.1.4") -> argparse.Namespace:
+        return argparse.Namespace(database_id="db-a", version=version, version_source="explicit", database="benchmark", install_root=root / "installations", database_root=root / "databases")
+
+    def test_prepare_reuse_and_immutable_identity(self) -> None:
+        with tempfile.TemporaryDirectory() as temp:
+            root = Path(temp); self.make_installation(root); args = self.args(root)
+            with mock.patch.object(setup, "platform_tag", return_value="linux_amd64"):
+                value = setup.prepare(args); reused = setup.prepare(args)
+            self.assertFalse(value["reused"]); self.assertTrue(reused["reused"])
+            self.assertEqual(value["database"], "benchmark")
+            manifest = setup.validate_database(Path(value["database_path"]), "db-a")
+            self.assertEqual(manifest["version"], "1.1.4")
+            args.database = "other"
+            with mock.patch.object(setup, "platform_tag", return_value="linux_amd64"), self.assertRaisesRegex(setup.SetupError, "already bound"):
+                setup.prepare(args)
+
+    def test_legacy_workspace_is_not_adopted(self) -> None:
+        with tempfile.TemporaryDirectory() as temp:
+            root = Path(temp); self.make_installation(root); path = root / "databases/db-a"; path.mkdir(parents=True)
+            setup.save_json(path / "manifest.json", {"schema_version": 1, "kind": "greptimedb-database", "database_id": "db-a", "database": "benchmark", "binding": None})
+            with mock.patch.object(setup, "platform_tag", return_value="linux_amd64"), self.assertRaisesRegex(setup.SetupError, "legacy"):
+                setup.prepare(self.args(root))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What changed

- add a `setup-greptimedb` skill for checksum-verified latest-stable and version-pinned native releases
- prepare immutable, version-bound local database workspaces for TSBS
- let the GreptimeDB benchmark skill discover prepared binaries while preserving explicit-binary support for legacy workspaces
- include GreptimeDB version and binary checksum in benchmark summaries

## Why

Managed GreptimeDB benchmarks previously required callers to locate and pass a binary manually. This adds a reproducible setup path equivalent to the existing InfluxDB 3 workflow while preserving existing workspaces without migration.

## Validation

- `python3 -m unittest discover -s .agents/skills/setup-greptimedb/tests -q`
- `python3 -m unittest discover -s .agents/skills/benchmark-greptimedb/tests -q`
- `python3 /Users/evenyag/.codex/skills/.system/skill-creator/scripts/quick_validate.py .agents/skills/setup-greptimedb`
- `git diff --check`

The live latest-stable resolver returned GreptimeDB `1.1.4`; no release archive was downloaded during tests.