### PR TITLE
Add automatic TSBS Go environment setup

### DIFF
--- a/.agents/lib/tsbs_environment.py
+++ b/.agents/lib/tsbs_environment.py
@@ -1,0 +1,307 @@
+"""Resolve and manage the Go toolchain used by TSBS automation."""
+
+from __future__ import annotations
+
+import contextlib
+import datetime as dt
+import fcntl
+import hashlib
+import json
+import os
+import platform
+import re
+import shutil
+import subprocess
+import tarfile
+import tempfile
+import urllib.error
+import urllib.request
+from pathlib import Path, PurePosixPath
+from typing import Any, Iterator
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_INSTALL_ROOT = REPO_ROOT / ".benchmarks" / "environment" / "go"
+MINIMUM_GO_VERSION = (1, 21, 0)
+MANAGED_GO_VERSION = "1.21.13"
+DOWNLOADS_API = "https://go.dev/dl/?mode=json&include=all"
+DOWNLOAD_BASE_URL = "https://go.dev/dl"
+USER_AGENT = "tsbs-environment-setup/1"
+SCHEMA_VERSION = 1
+GO_VERSION_RE = re.compile(r"^go version go(\d+)\.(\d+)(?:\.(\d+))? (\S+)$")
+
+
+class TsbsEnvironmentError(RuntimeError):
+    """Raised when a suitable TSBS build environment cannot be prepared."""
+
+
+def utc_now() -> str:
+    return dt.datetime.now(dt.timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def save_json(path: Path, value: Any) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temporary = path.with_name(f"{path.name}.tmp-{os.getpid()}")
+    temporary.write_text(json.dumps(value, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    os.replace(temporary, path)
+
+
+def read_json(path: Path) -> dict[str, Any]:
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except FileNotFoundError as exc:
+        raise TsbsEnvironmentError(f"missing Go installation manifest: {path}") from exc
+    except json.JSONDecodeError as exc:
+        raise TsbsEnvironmentError(f"invalid Go installation manifest {path}: {exc}") from exc
+    if not isinstance(value, dict):
+        raise TsbsEnvironmentError(f"Go installation manifest must be an object: {path}")
+    return value
+
+
+def sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as stream:
+        for chunk in iter(lambda: stream.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def distribution_sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    entries = sorted(
+        (entry for entry in path.rglob("*") if entry.relative_to(path).as_posix() != "manifest.json"),
+        key=lambda entry: entry.relative_to(path).as_posix(),
+    )
+    for entry in entries:
+        relative = entry.relative_to(path).as_posix()
+        stat = entry.lstat()
+        mode = stat.st_mode & 0o7777
+        if entry.is_symlink():
+            kind, content = "symlink", os.readlink(entry).encode()
+        elif entry.is_file():
+            kind, content = "file", bytes.fromhex(sha256_file(entry))
+        elif entry.is_dir():
+            kind, content = "directory", b""
+        else:
+            raise TsbsEnvironmentError(f"unsupported Go installation entry: {entry}")
+        digest.update(f"{kind}\0{relative}\0{mode:o}\0".encode())
+        digest.update(content)
+        digest.update(b"\0")
+    return digest.hexdigest()
+
+
+def platform_tag(system: str | None = None, machine: str | None = None) -> str:
+    system = system or platform.system()
+    machine = (machine or platform.machine()).lower()
+    if system == "Linux" and machine in ("x86_64", "amd64"):
+        return "linux_amd64"
+    if system == "Linux" and machine in ("aarch64", "arm64"):
+        return "linux_arm64"
+    if system == "Darwin" and machine in ("x86_64", "amd64"):
+        return "darwin_amd64"
+    if system == "Darwin" and machine in ("arm64", "aarch64"):
+        return "darwin_arm64"
+    raise TsbsEnvironmentError(f"unsupported Go platform: {system} {machine}")
+
+
+def parse_go_version(output: str) -> tuple[tuple[int, int, int], str]:
+    match = GO_VERSION_RE.fullmatch(output.strip())
+    if not match:
+        raise TsbsEnvironmentError(f"could not parse stable Go version output: {output.strip() or '<empty>'}")
+    version = tuple(int(value or 0) for value in match.group(1, 2, 3))
+    return version, ".".join(str(value) for value in version)
+
+
+def probe_go(binary: Path, *, minimum: tuple[int, int, int] = MINIMUM_GO_VERSION) -> dict[str, Any]:
+    try:
+        result = subprocess.run(
+            [str(binary), "version"], capture_output=True, text=True, check=False, timeout=15
+        )
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        raise TsbsEnvironmentError(f"could not execute Go binary {binary}: {exc}") from exc
+    if result.returncode:
+        detail = (result.stderr or result.stdout).strip()
+        raise TsbsEnvironmentError(f"Go binary {binary} failed version verification: {detail}")
+    version, normalized = parse_go_version(result.stdout)
+    if version < minimum:
+        required = ".".join(str(value) for value in minimum[:2])
+        raise TsbsEnvironmentError(f"Go {normalized} is too old; TSBS requires Go {required} or newer")
+    resolved = binary.expanduser().resolve()
+    return {
+        "source": "system",
+        "version": normalized,
+        "platform": platform_tag(),
+        "binary": str(resolved),
+        "binary_sha256": sha256_file(resolved),
+    }
+
+
+def installation_path(install_root: Path | None = None) -> Path:
+    root = (install_root or DEFAULT_INSTALL_ROOT).expanduser().resolve()
+    return root / MANAGED_GO_VERSION / platform_tag()
+
+
+def request(url: str, *, accept: str = "application/octet-stream,*/*") -> urllib.request.Request:
+    return urllib.request.Request(url, headers={"User-Agent": USER_AGENT, "Accept": accept})
+
+
+def download_bytes(url: str) -> bytes:
+    try:
+        with urllib.request.urlopen(request(url, accept="application/json"), timeout=60) as response:
+            return response.read()
+    except (OSError, urllib.error.URLError) as exc:
+        raise TsbsEnvironmentError(f"could not download {url}: {exc}") from exc
+
+
+def download(url: str, destination: Path) -> None:
+    try:
+        with urllib.request.urlopen(request(url), timeout=60) as response, destination.open("wb") as output:
+            shutil.copyfileobj(response, output)
+    except (OSError, urllib.error.URLError) as exc:
+        raise TsbsEnvironmentError(f"could not download {url}: {exc}") from exc
+
+
+def release_metadata(target: str) -> dict[str, str]:
+    try:
+        releases = json.loads(download_bytes(DOWNLOADS_API))
+    except (json.JSONDecodeError, UnicodeDecodeError) as exc:
+        raise TsbsEnvironmentError("could not parse official Go download metadata") from exc
+    system, architecture = target.split("_", 1)
+    expected_version = f"go{MANAGED_GO_VERSION}"
+    if not isinstance(releases, list):
+        raise TsbsEnvironmentError("official Go download metadata is malformed")
+    for release in releases:
+        if not isinstance(release, dict) or release.get("version") != expected_version:
+            continue
+        for artifact in release.get("files", []):
+            if not isinstance(artifact, dict):
+                continue
+            if artifact.get("os") == system and artifact.get("arch") == architecture and artifact.get("kind") == "archive":
+                filename, checksum = artifact.get("filename"), artifact.get("sha256")
+                if isinstance(filename, str) and isinstance(checksum, str) and re.fullmatch(r"[0-9a-f]{64}", checksum):
+                    return {
+                        "filename": filename,
+                        "sha256": checksum,
+                        "source_url": f"{DOWNLOAD_BASE_URL}/{filename}",
+                    }
+    raise TsbsEnvironmentError(f"official Go metadata has no {expected_version} archive for {target}")
+
+
+def safe_extract_go(archive: Path, destination: Path) -> Path:
+    with tarfile.open(archive, "r:gz") as bundle:
+        members = bundle.getmembers()
+        for member in members:
+            relative = PurePosixPath(member.name)
+            if relative.is_absolute() or not relative.parts or relative.parts[0] != "go" or ".." in relative.parts:
+                raise TsbsEnvironmentError(f"unsafe path in Go archive: {member.name}")
+            if member.issym() or member.islnk() or not (member.isdir() or member.isfile()):
+                raise TsbsEnvironmentError(f"unsupported entry in Go archive: {member.name}")
+        bundle.extractall(destination, members=members)
+    extracted = destination / "go"
+    binary = extracted / "bin" / "go"
+    if not binary.is_file():
+        raise TsbsEnvironmentError("Go archive does not contain bin/go")
+    return extracted
+
+
+@contextlib.contextmanager
+def installation_lock(root: Path) -> Iterator[None]:
+    root.mkdir(parents=True, exist_ok=True)
+    lock_path = root / ".install.lock"
+    with lock_path.open("a", encoding="utf-8") as lock:
+        fcntl.flock(lock.fileno(), fcntl.LOCK_EX)
+        try:
+            yield
+        finally:
+            fcntl.flock(lock.fileno(), fcntl.LOCK_UN)
+
+
+def validate_installation(path: Path) -> dict[str, Any]:
+    manifest = read_json(path / "manifest.json")
+    required = {
+        "schema_version", "kind", "version", "platform", "source_url", "archive_sha256",
+        "binary", "binary_sha256", "distribution_sha256", "created_at",
+    }
+    if manifest.get("schema_version") != SCHEMA_VERSION or manifest.get("kind") != "tsbs-go-installation" or not required.issubset(manifest):
+        raise TsbsEnvironmentError(f"malformed Go installation manifest: {path / 'manifest.json'}")
+    if manifest["version"] != MANAGED_GO_VERSION or manifest["platform"] != platform_tag():
+        raise TsbsEnvironmentError(f"Go installation identity mismatch: {path}")
+    binary = path / str(manifest["binary"])
+    if not binary.is_file() or not os.access(binary, os.X_OK):
+        raise TsbsEnvironmentError(f"managed Go binary is missing or not executable: {binary}")
+    if sha256_file(binary) != manifest["binary_sha256"]:
+        raise TsbsEnvironmentError(f"managed Go binary checksum mismatch: {binary}")
+    if distribution_sha256(path) != manifest["distribution_sha256"]:
+        raise TsbsEnvironmentError(f"managed Go distribution checksum mismatch: {path}")
+    checked = probe_go(binary)
+    if checked["version"] != MANAGED_GO_VERSION:
+        raise TsbsEnvironmentError(f"managed Go reports {checked['version']}, expected {MANAGED_GO_VERSION}")
+    return {
+        **manifest,
+        "source": "managed",
+        "binary": str(binary.resolve()),
+        "installation_path": str(path.resolve()),
+    }
+
+
+def install_go(install_root: Path | None = None) -> dict[str, Any]:
+    root = (install_root or DEFAULT_INSTALL_ROOT).expanduser().resolve()
+    destination = installation_path(root)
+    with installation_lock(root):
+        if destination.exists():
+            return {**validate_installation(destination), "reused": True}
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        target = platform_tag()
+        metadata = release_metadata(target)
+        temporary = Path(tempfile.mkdtemp(prefix=f".go-{MANAGED_GO_VERSION}-", dir=destination.parent))
+        try:
+            archive = temporary / metadata["filename"]
+            download(metadata["source_url"], archive)
+            actual = sha256_file(archive)
+            if actual != metadata["sha256"]:
+                raise TsbsEnvironmentError(f"Go archive checksum mismatch: expected {metadata['sha256']}, got {actual}")
+            extracted = safe_extract_go(archive, temporary)
+            archive.unlink()
+            binary = extracted / "bin" / "go"
+            manifest = {
+                "schema_version": SCHEMA_VERSION,
+                "kind": "tsbs-go-installation",
+                "version": MANAGED_GO_VERSION,
+                "platform": target,
+                "created_at": utc_now(),
+                "source_url": metadata["source_url"],
+                "archive_sha256": actual,
+                "binary": "bin/go",
+                "binary_sha256": sha256_file(binary),
+                "distribution_sha256": distribution_sha256(extracted),
+            }
+            save_json(extracted / "manifest.json", manifest)
+            validate_installation(extracted)
+            os.replace(extracted, destination)
+            return {**validate_installation(destination), "reused": False}
+        finally:
+            if temporary.exists():
+                shutil.rmtree(temporary)
+
+
+def resolve_go(install_root: Path | None = None, system_go: str | Path | None = None) -> dict[str, Any]:
+    candidate = str(system_go) if system_go is not None else shutil.which("go")
+    if candidate:
+        try:
+            return {**probe_go(Path(candidate)), "reused": True}
+        except TsbsEnvironmentError:
+            pass
+    return install_go(install_root)
+
+
+def verify_go(install_root: Path | None = None, system_go: str | Path | None = None) -> dict[str, Any]:
+    candidate = str(system_go) if system_go is not None else shutil.which("go")
+    if candidate:
+        try:
+            return {**probe_go(Path(candidate)), "reused": True}
+        except TsbsEnvironmentError:
+            pass
+    path = installation_path(install_root)
+    if not path.exists():
+        raise TsbsEnvironmentError("no suitable Go 1.21+ toolchain is installed; run prepare")
+    return {**validate_installation(path), "reused": True}

--- a/.agents/skills/benchmark-greptimedb/SKILL.md
+++ b/.agents/skills/benchmark-greptimedb/SKILL.md
@@ -9,7 +9,9 @@ Use `scripts/benchmark.py` for execution and structured result parsing. Read
 `references/workload.md` before selecting workload sizes, query types, database
 modes, or shared workspace identifiers. Use `$generate-tsbs-data` for standalone
 dataset generation, inspection, or non-Greptime serialization formats. Use
-`$setup-greptimedb` to install and prepare a managed database workspace.
+`$setup-greptimedb` to install and prepare a managed database workspace. Builds
+automatically use `$setup-tsbs-environment` to reuse Go 1.21+ or prepare the
+verified repository-local fallback.
 
 ## Collect inputs
 

--- a/.agents/skills/benchmark-greptimedb/scripts/benchmark.py
+++ b/.agents/skills/benchmark-greptimedb/scripts/benchmark.py
@@ -42,6 +42,7 @@ from tsbs_benchmark import (  # noqa: E402
     sha256_file,
     utc_now,
 )
+from tsbs_environment import TsbsEnvironmentError, resolve_go  # noqa: E402
 from summarize import write_summary
 
 
@@ -58,6 +59,7 @@ ID_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]*$")
 DATA_WORKLOAD_OPTIONS = ("start", "end", "scale", "seed", "log_interval")
 BINARIES = {"queries": "tsbs_generate_queries", "load": "tsbs_load_greptime", "query": "tsbs_run_queries_influx"}
 BUILT_THIS_PROCESS: set[str] = set()
+GO_TOOLCHAIN: dict[str, Any] | None = None
 
 
 class BenchmarkError(RuntimeError):
@@ -167,15 +169,25 @@ def binary_needs_build(run_dir: Path, name: str, target: Path, rebuild: bool) ->
     return name not in BUILT_THIS_PROCESS and (rebuild or not (target.exists() and marker.exists()))
 
 
-def ensure_binaries(run_dir: Path, stages: Sequence[str], rebuild: bool) -> None:
+def ensure_binaries(run_dir: Path, stages: Sequence[str], rebuild: bool) -> dict[str, dict[str, Any]]:
+    global GO_TOOLCHAIN
+    built: dict[str, dict[str, Any]] = {}
     for stage in stages:
         name = BINARIES[stage]; target = REPO_ROOT / "bin" / name
         marker = run_dir / "results" / f"built-{name}"
         if not binary_needs_build(run_dir, name, target, rebuild):
             continue
+        if GO_TOOLCHAIN is None:
+            GO_TOOLCHAIN = resolve_go()
         target.parent.mkdir(parents=True, exist_ok=True)
-        run_tee(["go", "build", "-o", str(target), f"./cmd/{name}"], run_dir / "logs" / "build.log", append=True)
-        marker.write_text(utc_now() + "\n", encoding="utf-8"); BUILT_THIS_PROCESS.add(name)
+        build_log = run_dir / "logs" / "build.log"
+        build_log.parent.mkdir(parents=True, exist_ok=True)
+        with build_log.open("a", encoding="utf-8") as log:
+            log.write(f"# Go toolchain: {json.dumps(GO_TOOLCHAIN, sort_keys=True)}\n")
+        run_tee([GO_TOOLCHAIN["binary"], "build", "-o", str(target), f"./cmd/{name}"], build_log, append=True)
+        metadata = {"binary": f"bin/{name}", "binary_sha256": sha256_file(target), "built_at": utc_now(), "go_toolchain": GO_TOOLCHAIN}
+        save_json(marker, metadata); built[name] = metadata; BUILT_THIS_PROCESS.add(name)
+    return built
 
 
 def dataset_selection_args(args: argparse.Namespace, manifest: dict[str, Any]) -> list[str]:
@@ -285,7 +297,7 @@ def generate_queries(args: argparse.Namespace, run_dir: Path, manifest: dict[str
     if destination.exists():
         set_manifest = validate_query_set(destination, spec); reused = True
     else:
-        ensure_binaries(run_dir, ["queries"], args.rebuild)
+        build_metadata = ensure_binaries(run_dir, ["queries"], args.rebuild)
         destination.parent.mkdir(parents=True, exist_ok=True)
         temporary = Path(tempfile.mkdtemp(prefix=f".{set_id}-", dir=destination.parent))
         try:
@@ -296,7 +308,10 @@ def generate_queries(args: argparse.Namespace, run_dir: Path, manifest: dict[str
                 run_tee(command, run_dir / "logs" / f"generate-query-{query_type}.log", stdout_path=output)
                 files[query_type] = {"path": f"queries/{query_type}.dat", "bytes": output.stat().st_size, "sha256": sha256_file(output)}
             binary = REPO_ROOT / "bin" / BINARIES["queries"]
-            set_manifest = {"schema_version": SCHEMA_VERSION, "kind": "greptimedb-query-set", "query_set_id": set_id, "created_at": utc_now(), "spec": spec, "generator": {"binary": "bin/tsbs_generate_queries", "binary_sha256": sha256_file(binary), "git_revision": git_revision()}, "files": files}
+            generator = {"binary": "bin/tsbs_generate_queries", "binary_sha256": sha256_file(binary), "git_revision": git_revision()}
+            if BINARIES["queries"] in build_metadata:
+                generator["go_toolchain"] = build_metadata[BINARIES["queries"]]["go_toolchain"]
+            set_manifest = {"schema_version": SCHEMA_VERSION, "kind": "greptimedb-query-set", "query_set_id": set_id, "created_at": utc_now(), "spec": spec, "generator": generator, "files": files}
             save_json(temporary / "manifest.json", set_manifest)
             try:
                 os.replace(temporary, destination)
@@ -539,7 +554,7 @@ def main(argv: Sequence[str] | None = None) -> int:
                 if args.command in ("load", "all"): load_data(args, run_dir, manifest, endpoint, managed, database_manifest, database_path)
                 if args.command in ("query", "all"): run_queries(args, run_dir, manifest, endpoint, database_manifest)
         summary = write_summary(run_dir, manifest); print(f"Run directory: {run_dir}"); print(f"Summary: {run_dir / 'summary.md'}"); return 1 if summary["failures"] else 0
-    except (BenchmarkError, OSError, json.JSONDecodeError, KeyError, TypeError) as exc:
+    except (BenchmarkError, TsbsEnvironmentError, OSError, json.JSONDecodeError, KeyError, TypeError) as exc:
         if run_dir is not None and manifest is not None:
             try: write_summary(run_dir, manifest)
             except OSError: pass

--- a/.agents/skills/benchmark-greptimedb/tests/test_benchmark.py
+++ b/.agents/skills/benchmark-greptimedb/tests/test_benchmark.py
@@ -175,6 +175,27 @@ class QuerySetTests(unittest.TestCase):
             self.assertTrue(all(event["file_sha256"] for event in manifest["events"]["queries"]))
 
 
+class BuildEnvironmentTests(unittest.TestCase):
+    def test_build_uses_resolved_go_and_records_metadata(self) -> None:
+        with tempfile.TemporaryDirectory() as temp:
+            root = Path(temp); run_dir = root / "run"
+            (run_dir / "results").mkdir(parents=True); (run_dir / "logs").mkdir()
+            toolchain = {"source": "managed", "version": "1.21.13", "binary": "/managed/go", "binary_sha256": "a" * 64}
+
+            def build(command, _log_path, **_kwargs):
+                target = Path(command[3]); target.parent.mkdir(parents=True, exist_ok=True); target.write_text("binary", encoding="utf-8")
+
+            with mock.patch.object(benchmark, "REPO_ROOT", root), mock.patch.object(benchmark, "resolve_go", return_value=toolchain), mock.patch.object(
+                benchmark, "run_tee", side_effect=build
+            ) as runner, mock.patch.object(benchmark, "GO_TOOLCHAIN", None), mock.patch.object(benchmark, "BUILT_THIS_PROCESS", set()):
+                built = benchmark.ensure_binaries(run_dir, ["queries"], False)
+            self.assertEqual(runner.call_args.args[0][0], "/managed/go")
+            self.assertEqual(built[benchmark.BINARIES["queries"]]["go_toolchain"], toolchain)
+            marker = json.loads((run_dir / "results" / f"built-{benchmark.BINARIES['queries']}").read_text(encoding="utf-8"))
+            self.assertEqual(marker["go_toolchain"]["source"], "managed")
+            self.assertIn('"version": "1.21.13"', (run_dir / "logs" / "build.log").read_text(encoding="utf-8"))
+
+
 class ManagedDatabaseTests(unittest.TestCase):
     def args(self, root: Path, mode: str | None = None) -> argparse.Namespace:
         values = ["load", "--greptime-bin", "/bin/true", "--database-id", "db-a", "--database-root", str(root), "--database", "benchmark"]

--- a/.agents/skills/benchmark-influxdb3/SKILL.md
+++ b/.agents/skills/benchmark-influxdb3/SKILL.md
@@ -9,6 +9,8 @@ Use `scripts/benchmark.py` for execution and structured result parsing. Read
 `references/workload.md` before choosing workloads, editions, durability flags,
 or database modes. Use `$setup-influxdb3` to install and prepare a managed
 database workspace and `$generate-tsbs-data` for standalone dataset operations.
+Builds automatically use `$setup-tsbs-environment` to reuse Go 1.21+ or prepare
+the verified repository-local fallback.
 
 ## Collect inputs
 

--- a/.agents/skills/benchmark-influxdb3/scripts/benchmark.py
+++ b/.agents/skills/benchmark-influxdb3/scripts/benchmark.py
@@ -42,6 +42,7 @@ from tsbs_benchmark import (  # noqa: E402
     sha256_file,
     utc_now,
 )
+from tsbs_environment import TsbsEnvironmentError, resolve_go  # noqa: E402
 from summarize import write_summary
 
 
@@ -58,6 +59,7 @@ ID_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]*$")
 DATA_WORKLOAD_OPTIONS = ("start", "end", "scale", "seed", "log_interval")
 BINARIES = {"queries": "tsbs_generate_queries", "load": "tsbs_load_influx3", "query": "tsbs_run_queries_influx3"}
 BUILT_THIS_PROCESS: set[str] = set()
+GO_TOOLCHAIN: dict[str, Any] | None = None
 
 
 class BenchmarkError(RuntimeError):
@@ -172,15 +174,25 @@ def binary_needs_build(run_dir: Path, name: str, target: Path, rebuild: bool) ->
     return name not in BUILT_THIS_PROCESS and (rebuild or not (target.exists() and marker.exists()))
 
 
-def ensure_binaries(run_dir: Path, stages: Sequence[str], rebuild: bool) -> None:
+def ensure_binaries(run_dir: Path, stages: Sequence[str], rebuild: bool) -> dict[str, dict[str, Any]]:
+    global GO_TOOLCHAIN
+    built: dict[str, dict[str, Any]] = {}
     for stage in stages:
         name = BINARIES[stage]; target = REPO_ROOT / "bin" / name
         marker = run_dir / "results" / f"built-{name}"
         if not binary_needs_build(run_dir, name, target, rebuild):
             continue
+        if GO_TOOLCHAIN is None:
+            GO_TOOLCHAIN = resolve_go()
         target.parent.mkdir(parents=True, exist_ok=True)
-        run_tee(["go", "build", "-o", str(target), f"./cmd/{name}"], run_dir / "logs" / "build.log", append=True)
-        marker.write_text(utc_now() + "\n", encoding="utf-8"); BUILT_THIS_PROCESS.add(name)
+        build_log = run_dir / "logs" / "build.log"
+        build_log.parent.mkdir(parents=True, exist_ok=True)
+        with build_log.open("a", encoding="utf-8") as log:
+            log.write(f"# Go toolchain: {json.dumps(GO_TOOLCHAIN, sort_keys=True)}\n")
+        run_tee([GO_TOOLCHAIN["binary"], "build", "-o", str(target), f"./cmd/{name}"], build_log, append=True)
+        metadata = {"binary": f"bin/{name}", "binary_sha256": sha256_file(target), "built_at": utc_now(), "go_toolchain": GO_TOOLCHAIN}
+        save_json(marker, metadata); built[name] = metadata; BUILT_THIS_PROCESS.add(name)
+    return built
 
 
 def dataset_selection_args(args: argparse.Namespace, manifest: dict[str, Any]) -> list[str]:
@@ -290,7 +302,7 @@ def generate_queries(args: argparse.Namespace, run_dir: Path, manifest: dict[str
     if destination.exists():
         set_manifest = validate_query_set(destination, spec); reused = True
     else:
-        ensure_binaries(run_dir, ["queries"], args.rebuild)
+        build_metadata = ensure_binaries(run_dir, ["queries"], args.rebuild)
         destination.parent.mkdir(parents=True, exist_ok=True)
         temporary = Path(tempfile.mkdtemp(prefix=f".{set_id}-", dir=destination.parent))
         try:
@@ -301,7 +313,10 @@ def generate_queries(args: argparse.Namespace, run_dir: Path, manifest: dict[str
                 run_tee(command, run_dir / "logs" / f"generate-query-{query_type}.log", stdout_path=output)
                 files[query_type] = {"path": f"queries/{query_type}.dat", "bytes": output.stat().st_size, "sha256": sha256_file(output)}
             binary = REPO_ROOT / "bin" / BINARIES["queries"]
-            set_manifest = {"schema_version": SCHEMA_VERSION, "kind": "influxdb3-query-set", "query_set_id": set_id, "created_at": utc_now(), "spec": spec, "generator": {"binary": "bin/tsbs_generate_queries", "binary_sha256": sha256_file(binary), "git_revision": git_revision()}, "files": files}
+            generator = {"binary": "bin/tsbs_generate_queries", "binary_sha256": sha256_file(binary), "git_revision": git_revision()}
+            if BINARIES["queries"] in build_metadata:
+                generator["go_toolchain"] = build_metadata[BINARIES["queries"]]["go_toolchain"]
+            set_manifest = {"schema_version": SCHEMA_VERSION, "kind": "influxdb3-query-set", "query_set_id": set_id, "created_at": utc_now(), "spec": spec, "generator": generator, "files": files}
             save_json(temporary / "manifest.json", set_manifest)
             try:
                 os.replace(temporary, destination)
@@ -660,7 +675,7 @@ def main(argv: Sequence[str] | None = None) -> int:
                 if args.command in ("load", "all"): load_data(args, run_dir, manifest, endpoint, managed, database_manifest, database_path)
                 if args.command in ("query", "all"): run_queries(args, run_dir, manifest, endpoint, database_manifest)
         summary = write_summary(run_dir, manifest); print(f"Run directory: {run_dir}"); print(f"Summary: {run_dir / 'summary.md'}"); return 1 if summary["failures"] else 0
-    except (BenchmarkError, OSError, json.JSONDecodeError, KeyError, TypeError) as exc:
+    except (BenchmarkError, TsbsEnvironmentError, OSError, json.JSONDecodeError, KeyError, TypeError) as exc:
         if run_dir is not None and manifest is not None:
             try: write_summary(run_dir, manifest)
             except OSError: pass

--- a/.agents/skills/benchmark-influxdb3/tests/test_benchmark.py
+++ b/.agents/skills/benchmark-influxdb3/tests/test_benchmark.py
@@ -247,6 +247,27 @@ class QuerySetTests(unittest.TestCase):
             self.assertTrue(all(event["file_sha256"] for event in manifest["events"]["queries"]))
 
 
+class BuildEnvironmentTests(unittest.TestCase):
+    def test_build_uses_resolved_go_and_records_metadata(self) -> None:
+        with tempfile.TemporaryDirectory() as temp:
+            root = Path(temp); run_dir = root / "run"
+            (run_dir / "results").mkdir(parents=True); (run_dir / "logs").mkdir()
+            toolchain = {"source": "system", "version": "1.22.0", "binary": "/usr/bin/go", "binary_sha256": "a" * 64}
+
+            def build(command, _log_path, **_kwargs):
+                target = Path(command[3]); target.parent.mkdir(parents=True, exist_ok=True); target.write_text("binary", encoding="utf-8")
+
+            with mock.patch.object(benchmark, "REPO_ROOT", root), mock.patch.object(benchmark, "resolve_go", return_value=toolchain), mock.patch.object(
+                benchmark, "run_tee", side_effect=build
+            ) as runner, mock.patch.object(benchmark, "GO_TOOLCHAIN", None), mock.patch.object(benchmark, "BUILT_THIS_PROCESS", set()):
+                built = benchmark.ensure_binaries(run_dir, ["queries"], False)
+            self.assertEqual(runner.call_args.args[0][0], "/usr/bin/go")
+            self.assertEqual(built[benchmark.BINARIES["queries"]]["go_toolchain"], toolchain)
+            marker = json.loads((run_dir / "results" / f"built-{benchmark.BINARIES['queries']}").read_text(encoding="utf-8"))
+            self.assertEqual(marker["go_toolchain"]["source"], "system")
+            self.assertIn('"version": "1.22.0"', (run_dir / "logs" / "build.log").read_text(encoding="utf-8"))
+
+
 class ManagedDatabaseTests(unittest.TestCase):
     def args(self, root: Path, mode: str | None = None) -> argparse.Namespace:
         values = ["load", "--database-id", "db-a", "--database-root", str(root), "--database", "benchmark"]

--- a/.agents/skills/generate-tsbs-data/SKILL.md
+++ b/.agents/skills/generate-tsbs-data/SKILL.md
@@ -7,7 +7,9 @@ description: Prepare logical TSBS dataset metadata and generate, cache, inspect,
 
 Use `scripts/generate.py` for deterministic logical dataset identity,
 generation, and validation. Read `references/datasets.md` when choosing
-profiles, formats, or shared roots.
+profiles, formats, or shared roots. Binary builds automatically use
+`$setup-tsbs-environment` to reuse Go 1.21+ or prepare the verified
+repository-local fallback.
 
 ## Prepare metadata only
 

--- a/.agents/skills/generate-tsbs-data/scripts/generate.py
+++ b/.agents/skills/generate-tsbs-data/scripts/generate.py
@@ -17,8 +17,13 @@ from typing import Any, Sequence
 
 SCRIPT_PATH = Path(__file__).resolve()
 REPO_ROOT = SCRIPT_PATH.parents[4]
+sys.path.insert(0, str(REPO_ROOT / ".agents" / "lib"))
+
+from tsbs_environment import TsbsEnvironmentError, resolve_go  # noqa: E402
+
 DEFAULT_DATASET_ROOT = REPO_ROOT / ".benchmarks" / "datasets"
 GENERATOR = REPO_ROOT / "bin" / "tsbs_generate_data"
+GENERATOR_BUILD_METADATA = REPO_ROOT / "bin" / "tsbs_generate_data.build.json"
 SCHEMA_VERSION = 1
 FORMAT_RE = re.compile(r"^[a-z0-9][a-z0-9_-]*$")
 ID_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]*$")
@@ -161,13 +166,19 @@ def command_text(command: Sequence[str]) -> str:
     return " ".join(subprocess.list2cmdline([part]) for part in command)
 
 
-def run_build(log_path: Path, rebuild: bool) -> None:
+def run_build(log_path: Path, rebuild: bool) -> dict[str, Any] | None:
     if GENERATOR.is_file() and not rebuild:
-        return
+        if GENERATOR_BUILD_METADATA.is_file():
+            metadata = read_json(GENERATOR_BUILD_METADATA)
+            if metadata.get("binary_sha256") == sha256_file(GENERATOR) and isinstance(metadata.get("go_toolchain"), dict):
+                return metadata["go_toolchain"]
+        return None
     GENERATOR.parent.mkdir(parents=True, exist_ok=True)
-    command = ["go", "build", "-o", str(GENERATOR), "./cmd/tsbs_generate_data"]
+    toolchain = resolve_go()
+    command = [toolchain["binary"], "build", "-o", str(GENERATOR), "./cmd/tsbs_generate_data"]
     log_path.parent.mkdir(parents=True, exist_ok=True)
     with log_path.open("a", encoding="utf-8") as log:
+        log.write(f"# Go toolchain: {json.dumps(toolchain, sort_keys=True)}\n")
         header = f"$ {command_text(command)}\n"
         log.write(header)
         print(header, end="", file=sys.stderr)
@@ -186,6 +197,11 @@ def run_build(log_path: Path, rebuild: bool) -> None:
         process.stdout.close()
         if process.wait():
             raise DatasetError(f"failed to build tsbs_generate_data; see {log_path}")
+    save_json(
+        GENERATOR_BUILD_METADATA,
+        {"binary": "bin/tsbs_generate_data", "binary_sha256": sha256_file(GENERATOR), "built_at": utc_now(), "go_toolchain": toolchain},
+    )
+    return toolchain
 
 
 def git_revision() -> str | None:
@@ -223,7 +239,7 @@ def generate_variant(
             return result(dataset_dir, dataset_manifest, manifest, reused=True)
 
     variant_dir.mkdir(parents=True, exist_ok=True)
-    run_build(log_path, rebuild)
+    toolchain = run_build(log_path, rebuild)
     spec = dataset_manifest["spec"]
     command = [
         str(GENERATOR),
@@ -289,6 +305,7 @@ def generate_variant(
             "binary": "bin/tsbs_generate_data",
             "binary_sha256": sha256_file(GENERATOR),
             "git_revision": git_revision(),
+            **({"go_toolchain": toolchain} if toolchain else {}),
         },
     }
     save_json(manifest_path, manifest)
@@ -518,7 +535,7 @@ def main(argv: Sequence[str] | None = None) -> int:
             save_json(args.result_file.resolve(), output)
         print_output(output, args.json)
         return 0
-    except (DatasetError, OSError) as exc:
+    except (DatasetError, TsbsEnvironmentError, OSError) as exc:
         print(f"error: {exc}", file=sys.stderr)
         return 1
 

--- a/.agents/skills/generate-tsbs-data/tests/test_generate.py
+++ b/.agents/skills/generate-tsbs-data/tests/test_generate.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import io
 import json
 import stat
 import sys
@@ -200,6 +201,39 @@ class DatasetVariantTests(unittest.TestCase):
             result = json.loads(result_file.read_text(encoding="utf-8"))
             self.assertEqual(result["format"], "influx")
             self.assertTrue(Path(result["data_path"]).is_file())
+
+    def test_build_uses_resolved_absolute_go_binary(self) -> None:
+        with tempfile.TemporaryDirectory() as temp:
+            root = Path(temp)
+            generator = root / "bin" / "tsbs_generate_data"
+            build_metadata = root / "bin" / "tsbs_generate_data.build.json"
+            toolchain = {"source": "managed", "version": "1.21.13", "binary": "/managed/go", "binary_sha256": "a" * 64}
+
+            class Process:
+                stdout = io.StringIO("")
+
+                def wait(self):
+                    generator.parent.mkdir(parents=True, exist_ok=True)
+                    generator.write_text("binary", encoding="utf-8")
+                    return 0
+
+            with mock.patch.object(generate, "REPO_ROOT", root), mock.patch.object(generate, "GENERATOR", generator), mock.patch.object(
+                generate, "GENERATOR_BUILD_METADATA", build_metadata
+            ), mock.patch.object(
+                generate, "resolve_go", return_value=toolchain
+            ), mock.patch.object(generate.subprocess, "Popen", return_value=Process()) as popen:
+                selected = generate.run_build(root / "build.log", False)
+            self.assertEqual(selected, toolchain)
+            self.assertEqual(popen.call_args.args[0][0], "/managed/go")
+            self.assertEqual(json.loads(build_metadata.read_text(encoding="utf-8"))["go_toolchain"], toolchain)
+            self.assertIn('"source": "managed"', (root / "build.log").read_text(encoding="utf-8"))
+
+            with mock.patch.object(generate, "GENERATOR", generator), mock.patch.object(generate, "GENERATOR_BUILD_METADATA", build_metadata), mock.patch.object(
+                generate, "resolve_go"
+            ) as resolver:
+                reused = generate.run_build(root / "build.log", False)
+            self.assertEqual(reused, toolchain)
+            resolver.assert_not_called()
 
 
 if __name__ == "__main__":

--- a/.agents/skills/setup-tsbs-environment/SKILL.md
+++ b/.agents/skills/setup-tsbs-environment/SKILL.md
@@ -1,0 +1,36 @@
+---
+name: setup-tsbs-environment
+description: Select, install, verify, and report the Go toolchain used by repository TSBS automation. Use for TSBS prerequisite setup, missing or outdated Go, managed Go installation verification, or locating the exact Go binary selected by benchmark and dataset skills.
+---
+
+# Setup TSBS Environment
+
+Use `scripts/setup.py` to prepare the Go toolchain required to build TSBS
+binaries. Python 3 is assumed to be available.
+
+## Prepare the environment
+
+Run from the repository root:
+
+```bash
+python3 .agents/skills/setup-tsbs-environment/scripts/setup.py prepare
+```
+
+Reuse a stable system Go 1.21 or newer. If none is available, download the
+official Go 1.21.13 archive, verify its published SHA-256, and install it under
+`.benchmarks/environment/go`. Benchmark and dataset skills call this operation
+automatically immediately before they need to build a TSBS binary.
+
+Pass `--install-root` only to relocate the managed toolchain. Use `--json` or
+`--result-file` for structured output.
+
+## Verify without downloading
+
+```bash
+python3 .agents/skills/setup-tsbs-environment/scripts/setup.py verify
+```
+
+Verify a suitable system Go or the cached managed toolchain. Report its source,
+version, platform, binary path, and checksums. Do not alter `PATH`, `GOROOT`,
+`GOPATH`, shell profiles, package managers, system packages, services, or the
+user's existing Go installation.

--- a/.agents/skills/setup-tsbs-environment/agents/openai.yaml
+++ b/.agents/skills/setup-tsbs-environment/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Setup TSBS Environment"
+  short_description: "Install and verify the TSBS Go toolchain"
+  default_prompt: "Use $setup-tsbs-environment to prepare a verified Go toolchain for TSBS."

--- a/.agents/skills/setup-tsbs-environment/scripts/setup.py
+++ b/.agents/skills/setup-tsbs-environment/scripts/setup.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python3
+"""Prepare or verify the Go toolchain used by TSBS automation."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any, Sequence
+
+
+SCRIPT_PATH = Path(__file__).resolve()
+sys.path.insert(0, str(SCRIPT_PATH.parents[3] / "lib"))
+
+from tsbs_environment import (  # noqa: E402
+    TsbsEnvironmentError,
+    resolve_go,
+    verify_go,
+)
+
+
+def make_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    subparsers = parser.add_subparsers(dest="command", required=True)
+    for command in ("prepare", "verify"):
+        child = subparsers.add_parser(command)
+        child.add_argument("--install-root", type=Path)
+        child.add_argument("--json", action="store_true")
+        child.add_argument("--result-file", type=Path)
+    return parser
+
+
+def emit(result: dict[str, Any], args: argparse.Namespace) -> None:
+    serialized = json.dumps(result, indent=2, sort_keys=True) + "\n"
+    if args.result_file:
+        path = args.result_file.expanduser().resolve()
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(serialized, encoding="utf-8")
+    if args.json:
+        print(serialized, end="")
+    else:
+        print(f"Go source: {result['source']}")
+        print(f"Go version: {result['version']}")
+        print(f"Go platform: {result['platform']}")
+        print(f"Go binary: {result['binary']}")
+        print(f"Go binary SHA-256: {result['binary_sha256']}")
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = make_parser().parse_args(argv)
+    try:
+        result = resolve_go(args.install_root) if args.command == "prepare" else verify_go(args.install_root)
+        emit(result, args)
+        return 0
+    except (TsbsEnvironmentError, OSError) as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.agents/skills/setup-tsbs-environment/tests/test_setup.py
+++ b/.agents/skills/setup-tsbs-environment/tests/test_setup.py
@@ -1,0 +1,150 @@
+from __future__ import annotations
+
+import hashlib
+import io
+import json
+import stat
+import sys
+import tarfile
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+
+LIB = Path(__file__).resolve().parents[3] / "lib"
+SCRIPTS = Path(__file__).resolve().parents[1] / "scripts"
+sys.path.insert(0, str(LIB))
+sys.path.insert(0, str(SCRIPTS))
+
+import setup  # noqa: E402
+import tsbs_environment as environment  # noqa: E402
+
+
+class PlatformAndVersionTests(unittest.TestCase):
+    def test_supported_platforms(self) -> None:
+        self.assertEqual(environment.platform_tag("Linux", "x86_64"), "linux_amd64")
+        self.assertEqual(environment.platform_tag("Linux", "aarch64"), "linux_arm64")
+        self.assertEqual(environment.platform_tag("Darwin", "x86_64"), "darwin_amd64")
+        self.assertEqual(environment.platform_tag("Darwin", "arm64"), "darwin_arm64")
+        with self.assertRaises(environment.TsbsEnvironmentError):
+            environment.platform_tag("Windows", "AMD64")
+
+    def test_stable_version_parsing(self) -> None:
+        self.assertEqual(environment.parse_go_version("go version go1.21.0 linux/amd64")[0], (1, 21, 0))
+        self.assertEqual(environment.parse_go_version("go version go1.24 darwin/arm64")[0], (1, 24, 0))
+        for output in ("go version devel go1.25-abc linux/amd64", "go1.21.0"):
+            with self.subTest(output=output), self.assertRaises(environment.TsbsEnvironmentError):
+                environment.parse_go_version(output)
+
+    def test_probe_rejects_old_go(self) -> None:
+        completed = mock.Mock(returncode=0, stdout="go version go1.20.14 linux/amd64\n", stderr="")
+        with mock.patch.object(environment.subprocess, "run", return_value=completed):
+            with self.assertRaisesRegex(environment.TsbsEnvironmentError, "too old"):
+                environment.probe_go(Path("/tmp/go"))
+
+
+class ResolutionTests(unittest.TestCase):
+    def test_reuses_acceptable_system_go(self) -> None:
+        selected = {"source": "system", "version": "1.22.1", "binary": "/usr/bin/go"}
+        with mock.patch.object(environment.shutil, "which", return_value="/usr/bin/go"), mock.patch.object(
+            environment, "probe_go", return_value=selected
+        ), mock.patch.object(environment, "install_go") as install:
+            self.assertEqual(environment.resolve_go(), {**selected, "reused": True})
+        install.assert_not_called()
+
+    def test_missing_or_old_system_go_installs_fallback(self) -> None:
+        installed = {"source": "managed", "version": environment.MANAGED_GO_VERSION}
+        with mock.patch.object(environment.shutil, "which", return_value="/old/go"), mock.patch.object(
+            environment, "probe_go", side_effect=environment.TsbsEnvironmentError("old")
+        ), mock.patch.object(environment, "install_go", return_value=installed) as install:
+            self.assertEqual(environment.resolve_go(Path("/cache")), installed)
+        install.assert_called_once_with(Path("/cache"))
+
+    def test_verify_never_installs(self) -> None:
+        with tempfile.TemporaryDirectory() as temp, mock.patch.object(environment.shutil, "which", return_value=None), mock.patch.object(
+            environment, "platform_tag", return_value="linux_amd64"
+        ):
+            with self.assertRaisesRegex(environment.TsbsEnvironmentError, "run prepare"):
+                environment.verify_go(Path(temp))
+
+
+class InstallationTests(unittest.TestCase):
+    binary_content = b"#!/bin/sh\necho 'go version go1.21.13 linux/amd64'\n"
+
+    def archive(self, root: Path, unsafe: str | None = None) -> tuple[Path, str]:
+        source = root / "source" / "go" / "bin"
+        source.mkdir(parents=True)
+        binary = source / "go"
+        binary.write_bytes(self.binary_content)
+        binary.chmod(binary.stat().st_mode | stat.S_IXUSR)
+        archive = root / "go.tar.gz"
+        with tarfile.open(archive, "w:gz") as bundle:
+            bundle.add(root / "source" / "go", arcname="go")
+            if unsafe:
+                member = tarfile.TarInfo(unsafe)
+                member.size = 1
+                bundle.addfile(member, io.BytesIO(b"x"))
+        return archive, hashlib.sha256(archive.read_bytes()).hexdigest()
+
+    def test_install_verifies_and_reuses(self) -> None:
+        with tempfile.TemporaryDirectory() as temp:
+            root = Path(temp)
+            archive, checksum = self.archive(root)
+            metadata = {"filename": archive.name, "sha256": checksum, "source_url": "https://example.test/go.tar.gz"}
+
+            def copy_download(_url: str, destination: Path) -> None:
+                destination.write_bytes(archive.read_bytes())
+
+            completed = mock.Mock(returncode=0, stdout="go version go1.21.13 linux/amd64\n", stderr="")
+            patches = (
+                mock.patch.object(environment, "platform_tag", return_value="linux_amd64"),
+                mock.patch.object(environment, "release_metadata", return_value=metadata),
+                mock.patch.object(environment, "download", side_effect=copy_download),
+                mock.patch.object(environment.subprocess, "run", return_value=completed),
+            )
+            with patches[0], patches[1], patches[2], patches[3]:
+                first = environment.install_go(root / "installations")
+                second = environment.install_go(root / "installations")
+            self.assertFalse(first["reused"])
+            self.assertTrue(second["reused"])
+            self.assertEqual(first["source"], "managed")
+            self.assertTrue(Path(first["binary"]).is_file())
+
+    def test_checksum_and_unsafe_archive_fail_atomically(self) -> None:
+        for unsafe, expected, message in ((None, "0" * 64, "checksum mismatch"), ("../escape", None, "unsafe path")):
+            with self.subTest(unsafe=unsafe), tempfile.TemporaryDirectory() as temp:
+                root = Path(temp)
+                archive, checksum = self.archive(root, unsafe)
+                metadata = {"filename": archive.name, "sha256": expected or checksum, "source_url": "https://example.test/go.tar.gz"}
+                with mock.patch.object(environment, "platform_tag", return_value="linux_amd64"), mock.patch.object(
+                    environment, "release_metadata", return_value=metadata
+                ), mock.patch.object(environment, "download", side_effect=lambda _url, destination: destination.write_bytes(archive.read_bytes())):
+                    with self.assertRaisesRegex(environment.TsbsEnvironmentError, message):
+                        environment.install_go(root / "installations")
+                self.assertFalse((root / "installations" / environment.MANAGED_GO_VERSION / "linux_amd64").exists())
+
+    def test_release_metadata_selects_matching_archive(self) -> None:
+        payload = [{"version": "go1.21.13", "files": [{
+            "filename": "go1.21.13.linux-amd64.tar.gz", "os": "linux", "arch": "amd64",
+            "kind": "archive", "sha256": "a" * 64,
+        }]}]
+        with mock.patch.object(environment, "download_bytes", return_value=json.dumps(payload).encode()):
+            selected = environment.release_metadata("linux_amd64")
+        self.assertEqual(selected["sha256"], "a" * 64)
+
+
+class CliTests(unittest.TestCase):
+    def test_result_file_is_machine_readable(self) -> None:
+        result = {
+            "source": "system", "version": "1.22.0", "platform": "linux_amd64",
+            "binary": "/usr/bin/go", "binary_sha256": "a" * 64,
+        }
+        with tempfile.TemporaryDirectory() as temp, mock.patch.object(setup, "resolve_go", return_value=result):
+            path = Path(temp) / "result.json"
+            self.assertEqual(setup.main(["prepare", "--result-file", str(path)]), 0)
+            self.assertEqual(json.loads(path.read_text(encoding="utf-8"))["source"], "system")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What changed

- add a `setup-tsbs-environment` skill and shared Go toolchain resolver
- reuse stable system Go 1.21+ or install checksum-verified Go 1.21.13 locally
- integrate automatic Go selection into dataset, GreptimeDB, and InfluxDB 3 TSBS builds
- record toolchain identity and checksums in build logs and generated metadata
- add unit coverage for platform/version selection, safe installation, caching, CLI output, and build integration

## Why

The benchmark skills previously invoked `go build` directly and assumed a suitable Go installation was already present. That made otherwise automated TSBS workflows fail on machines with missing or outdated Go.

The new setup keeps the toolchain repository-local and does not modify `PATH`, `GOROOT`, `GOPATH`, shell profiles, package managers, or system services.

## Validation

- skill structure validation passed
- 85 Python unit and regression tests passed
- `git diff --check` passed
- installed and verified the official Go 1.21.13 macOS ARM64 archive on a host whose system Go is 1.20.5
- built all GreptimeDB and InfluxDB 3 TSBS binaries using the managed toolchain
- generated a smoke dataset using the managed toolchain