### PR TITLE
perf: Tune InfluxDB 3 ingestion defaults

### DIFF
--- a/.agents/lib/tsbs_benchmark.py
+++ b/.agents/lib/tsbs_benchmark.py
@@ -137,12 +137,16 @@ def add_one_second(timestamp: str) -> str:
 
 
 def build_workload(
-    args: argparse.Namespace, base: dict[str, Any] | None = None
+    args: argparse.Namespace,
+    base: dict[str, Any] | None = None,
+    defaults: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     if base is not None and not args.profile:
         workload = json.loads(json.dumps(base))
     else:
         workload = json.loads(json.dumps(PROFILES[args.profile or "manual"]))
+        if defaults:
+            workload.update(defaults)
     for attr in (
         "start",
         "end",

--- a/.agents/skills/benchmark-influxdb3/SKILL.md
+++ b/.agents/skills/benchmark-influxdb3/SKILL.md
@@ -23,6 +23,10 @@ the verified repository-local fallback.
    explicitly confirmed `reset`. Never infer reset authorization.
 4. Keep durable writes and atomic batch rejection unless the user explicitly
    requests `--no-sync` or `--accept-partial`.
+5. The manual profile defaults to 25,000-row batches and 16 load workers. For
+   the measured non-durable throughput recipe, pass `--batch-size 3000`,
+   `--load-workers 8`, and `--no-sync`; see
+   `docs/influx3-ingestion-benchmark.md`.
 
 ## Run benchmarks
 

--- a/.agents/skills/benchmark-influxdb3/references/workload.md
+++ b/.agents/skills/benchmark-influxdb3/references/workload.md
@@ -23,13 +23,19 @@ workers, batch sizes, and durability flags for comparisons.
 | Start | `2023-06-11T00:00:00Z` | `2023-06-11T00:00:00Z` |
 | End | `2023-06-14T00:00:00Z` | `2023-06-12T00:00:00Z` |
 | Hosts | 4000 | 10 |
-| Load workers | 6 | 2 |
+| Load workers | 16 | 2 |
 | Query workers | 1 | 1 |
-| Batch size | 3000 | 3000 |
+| Batch size | 25000 | 3000 |
 
 Both use seed `123`, interval `10s`, `cpu-only` data, `devops` queries,
 durable WAL acknowledgement, and rejection of partial batches. The query end
 timestamp is the dataset end plus one second.
+
+The manual load settings are InfluxDB-specific overrides selected by
+`docs/influx3-ingestion-benchmark.md`; shared TSBS and GreptimeDB profile
+defaults remain unchanged. Explicit `--load-workers` and `--batch-size` flags
+take precedence. Core 3.11.1 rejected a 100,000-row batch because its encoded
+request exceeded 10 MiB, so do not assume arbitrarily larger batches are valid.
 
 ## Database and target state
 

--- a/.agents/skills/benchmark-influxdb3/scripts/benchmark.py
+++ b/.agents/skills/benchmark-influxdb3/scripts/benchmark.py
@@ -54,6 +54,7 @@ DEFAULT_DATABASE_ROOT = BENCHMARK_ROOT / "influxdb3" / "databases"
 DEFAULT_DATASET_ROOT = BENCHMARK_ROOT / "datasets"
 DATASET_RUNNER = REPO_ROOT / ".agents" / "skills" / "generate-tsbs-data" / "scripts" / "generate.py"
 DEFAULT_DATABASE = "benchmark"
+MANUAL_LOAD_DEFAULTS = {"load_workers": 16, "batch_size": 25000}
 SCHEMA_VERSION = 1
 ID_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]*$")
 DATA_WORKLOAD_OPTIONS = ("start", "end", "scale", "seed", "log_interval")
@@ -115,7 +116,15 @@ def prepare_run(args: argparse.Namespace) -> tuple[Path, dict[str, Any]]:
         validate_run_manifest(manifest, manifest_path)
         workload_options = ("profile", "start", "end", "scale", "seed", "log_interval", "load_workers", "query_workers", "batch_size", "queries", "query_type")
         if any(getattr(args, name, None) is not None for name in workload_options):
-            requested = build_workload(args, manifest["workload"])
+            requested = build_workload(
+                args,
+                manifest["workload"],
+                defaults=(
+                    MANUAL_LOAD_DEFAULTS
+                    if (args.profile or manifest["profile"]) == "manual"
+                    else None
+                ),
+            )
             if requested != manifest["workload"]:
                 raise BenchmarkError("run workload is immutable; create a new run for different settings")
     else:
@@ -123,7 +132,11 @@ def prepare_run(args: argparse.Namespace) -> tuple[Path, dict[str, Any]]:
         manifest = {
             "schema_version": SCHEMA_VERSION, "kind": "influxdb3-run", "run_id": run_dir.name,
             "created_at": utc_now(), "profile": profile, "database": getattr(args, "database", DEFAULT_DATABASE),
-            "workload": build_workload(args), "events": {"loads": [], "queries": [], "servers": []},
+            "workload": build_workload(
+                args,
+                defaults=MANUAL_LOAD_DEFAULTS if profile == "manual" else None,
+            ),
+            "events": {"loads": [], "queries": [], "servers": []},
         }
     if hasattr(args, "database") and manifest.get("database") != args.database and manifest_path.exists():
         raise BenchmarkError("--database conflicts with the database pinned by this run")
@@ -585,7 +598,7 @@ def connection(args: argparse.Namespace, run_dir: Path, manifest: dict[str, Any]
                 event.update(shutdown_expected=True, shutdown_started_at=utc_now()); save_manifest(run_dir, manifest)
                 os.killpg(process.pid, signal.SIGTERM)
                 try:
-                    return_code = process.wait(timeout=15)
+                    return_code = process.wait(timeout=args.shutdown_timeout)
                 except subprocess.TimeoutExpired:
                     event["forced_shutdown"] = True
                     os.killpg(process.pid, signal.SIGKILL); return_code = process.wait(timeout=5)
@@ -609,7 +622,7 @@ def add_run_options(parser: argparse.ArgumentParser) -> None:
 
 
 def add_connection_options(parser: argparse.ArgumentParser) -> None:
-    parser.add_argument("--database-id"); parser.add_argument("--database-root", type=Path); parser.add_argument("--url", action="append"); parser.add_argument("--edition", choices=("core", "enterprise")); parser.add_argument("--http-port", type=int, default=8181); parser.add_argument("--startup-timeout", type=int, default=60); parser.add_argument("--database", help=f"SQL database name (default: {DEFAULT_DATABASE})"); parser.add_argument("--auth-token-env", default="INFLUXDB3_AUTH_TOKEN"); parser.add_argument("--admin-token-env", default="INFLUXDB3_ADMIN_TOKEN")
+    parser.add_argument("--database-id"); parser.add_argument("--database-root", type=Path); parser.add_argument("--url", action="append"); parser.add_argument("--edition", choices=("core", "enterprise")); parser.add_argument("--http-port", type=int, default=8181); parser.add_argument("--startup-timeout", type=int, default=60); parser.add_argument("--shutdown-timeout", type=int, default=60, help="seconds to wait for a managed server to flush and stop"); parser.add_argument("--database", help=f"SQL database name (default: {DEFAULT_DATABASE})"); parser.add_argument("--auth-token-env", default="INFLUXDB3_AUTH_TOKEN"); parser.add_argument("--admin-token-env", default="INFLUXDB3_ADMIN_TOKEN")
 
 
 def add_load_options(parser: argparse.ArgumentParser) -> None:
@@ -635,6 +648,8 @@ def validate_args(args: argparse.Namespace) -> None:
         value = getattr(args, name, None)
         if value and not ID_RE.fullmatch(value): raise BenchmarkError(f"--{name.replace('_', '-')} contains invalid characters")
     if args.command in ("load", "query", "all"):
+        if args.startup_timeout <= 0: raise BenchmarkError("--startup-timeout must be positive")
+        if args.shutdown_timeout <= 0: raise BenchmarkError("--shutdown-timeout must be positive")
         if bool(args.database_id) == bool(args.url): raise BenchmarkError("provide exactly one of --database-id or --url")
         if args.database_id and args.edition: raise BenchmarkError("managed database edition comes from its manifest; omit --edition")
         if args.url and not args.edition: raise BenchmarkError("external targets require --edition=core|enterprise")

--- a/.agents/skills/benchmark-influxdb3/tests/test_benchmark.py
+++ b/.agents/skills/benchmark-influxdb3/tests/test_benchmark.py
@@ -127,6 +127,38 @@ class QuerySetIdentityTests(unittest.TestCase):
 
 
 class WorkspaceTests(unittest.TestCase):
+    def test_manual_load_defaults_are_influxdb_specific_and_overridable(self) -> None:
+        parser = benchmark.make_parser()
+        manual = parser.parse_args(["generate", "--only", "data"])
+        smoke = parser.parse_args(["generate", "--only", "data", "--profile", "smoke"])
+        overridden = parser.parse_args([
+            "generate", "--only", "data", "--batch-size", "7000", "--load-workers", "3",
+        ])
+
+        with tempfile.TemporaryDirectory() as temp:
+            root = Path(temp)
+            manual.run_root = root / "manual"
+            smoke.run_root = root / "smoke"
+            overridden.run_root = root / "overridden"
+            manual_dir, manual_manifest = benchmark.prepare_run(manual)
+            _, smoke_manifest = benchmark.prepare_run(smoke)
+            _, overridden_manifest = benchmark.prepare_run(overridden)
+            reopened = parser.parse_args([
+                "generate", "--run-dir", str(manual_dir), "--only", "data",
+                "--profile", "manual",
+            ])
+            _, reopened_manifest = benchmark.prepare_run(reopened)
+
+        self.assertEqual(manual_manifest["workload"]["batch_size"], 25000)
+        self.assertEqual(manual_manifest["workload"]["load_workers"], 16)
+        self.assertEqual(reopened_manifest["workload"], manual_manifest["workload"])
+        self.assertEqual(benchmark.build_workload(manual)["batch_size"], 3000)
+        self.assertEqual(benchmark.build_workload(manual)["load_workers"], 6)
+        self.assertEqual(smoke_manifest["workload"]["batch_size"], 3000)
+        self.assertEqual(smoke_manifest["workload"]["load_workers"], 2)
+        self.assertEqual(overridden_manifest["workload"]["batch_size"], 7000)
+        self.assertEqual(overridden_manifest["workload"]["load_workers"], 3)
+
     def test_port_probe_enables_address_reuse_and_retries(self) -> None:
         sock = mock.MagicMock(); sock.__enter__.return_value = sock
         with mock.patch.object(benchmark.socket, "socket", return_value=sock):
@@ -339,6 +371,25 @@ class ManagedDatabaseTests(unittest.TestCase):
 
 
 class TargetTests(unittest.TestCase):
+    def test_sync_is_default_and_no_sync_is_opt_in(self) -> None:
+        parser = benchmark.make_parser()
+        durable = parser.parse_args(["load", "--database-id", "db-a"])
+        non_durable = parser.parse_args([
+            "load", "--database-id", "db-a", "--no-sync",
+        ])
+        self.assertFalse(durable.no_sync)
+        self.assertEqual(durable.shutdown_timeout, 60)
+        self.assertTrue(non_durable.no_sync)
+
+    def test_managed_server_timeouts_must_be_positive(self) -> None:
+        for option in ("--startup-timeout", "--shutdown-timeout"):
+            args = benchmark.make_parser().parse_args([
+                "load", "--database-id", "db-a", option, "0",
+            ])
+            benchmark.resolve_database(args)
+            with self.assertRaisesRegex(benchmark.BenchmarkError, "must be positive"):
+                benchmark.validate_args(args)
+
     def test_external_target_validation_and_token_redaction(self) -> None:
         args = benchmark.make_parser().parse_args([
             "all", "--url", "http://node-a:8181", "--url", "http://node-b:8181",

--- a/docs/influx3-ingestion-benchmark.md
+++ b/docs/influx3-ingestion-benchmark.md
@@ -51,6 +51,17 @@ The durable default is therefore 25,000 rows and 16 workers. This is about 53
 times the 6,029 rows/s measured for the previous 3,000-row, two-worker default
 on the same dataset.
 
+To remove the small dataset's request-count limitation, 25,000 and 30,000 rows
+were also compared at 16 workers on the 8.64-million-row dataset:
+
+| Batch rows | Workers | Run 1 | Run 2 | Run 3 | Median rows/s |
+| ---: | ---: | ---: | ---: | ---: | ---: |
+| 25,000 | 16 | 371,399 | 349,529 | 363,538 | 363,538 |
+| 30,000 | 16 | 297,017 | 327,809 | 335,675 | 327,809 |
+
+The larger dataset confirms 25,000 rows: its median was 10.9% higher than
+30,000 rows, with every run accepting all 8.64 million rows.
+
 ## No-sync results
 
 At two workers, batch size had little effect: 3,000, 10,000, 20,000, 25,000,

--- a/docs/influx3-ingestion-benchmark.md
+++ b/docs/influx3-ingestion-benchmark.md
@@ -1,0 +1,85 @@
+# InfluxDB 3 ingestion tuning
+
+This benchmark selected the default ingestion settings for InfluxDB 3 Core.
+It was run on Core 3.11.1 for macOS ARM64 (binary SHA-256
+`c69df9525adf916ebfafd4d9713fdff3ddf8999adfeeb7d938679708e238f801`).
+Each result used a fresh managed database workspace. Rates below are accepted
+line-protocol rows per second; every row contains ten field metrics.
+
+## Datasets
+
+| Mode | Dataset | Rows | Metrics | Bytes | SHA-256 |
+| --- | --- | ---: | ---: | ---: | --- |
+| Sync | `cpu-only-s100-003a91156529` | 864,000 | 8,640,000 | 297,699,448 | `d287426a327c38a84ba495b533d8a7512a6a84bd271d5b6d85df6b8ad0f0d732` |
+| No-sync | `cpu-only-s1000-45c02116670b` | 8,640,000 | 86,400,000 | 2,989,015,165 | `33f08ef6aedf56b39a64598142f12c39779e7ececcc0df6e0471879c947448cd` |
+
+Both datasets cover one day at a 10-second interval with seed 123. The larger
+no-sync dataset provides enough requests to keep up to 16 workers active.
+Because the modes use different dataset sizes, their rates are not a controlled
+durability overhead comparison.
+
+## Durable sync results
+
+The batch-size screen used two workers:
+
+| Batch rows | Rows/s |
+| ---: | ---: |
+| 3,000 | 6,029 |
+| 10,000 | 19,819 |
+| 20,000 | 39,736 |
+| 25,000 | 49,019 |
+| 30,000 | 59,735 |
+| 100,000 | Rejected: HTTP 413, 10 MiB request limit |
+
+Worker screening showed near-linear acknowledgement scaling at smaller batches:
+
+| Batch rows | 1 worker | 2 workers | 4 workers | 8 workers | 16 workers |
+| ---: | ---: | ---: | ---: | ---: | ---: |
+| 3,000 | 3,000 | 6,029 | 12,035 | 24,343 | 49,092 |
+| 10,000 | 9,997 | 19,819 | 39,697 | 80,013 | 152,808 |
+
+Adaptive trials reached 193,422 rows/s at 25,000 rows and 8 workers, and
+192,018 rows/s at 30,000 rows and 8 workers. The finalists were repeated three
+times:
+
+| Batch rows | Workers | Run 1 | Run 2 | Run 3 | Median rows/s |
+| ---: | ---: | ---: | ---: | ---: | ---: |
+| 25,000 | 16 | 287,157 | 321,880 | 323,468 | 321,880 |
+| 20,000 | 16 | 250,594 | 300,870 | 298,074 | 298,074 |
+
+The durable default is therefore 25,000 rows and 16 workers. This is about 53
+times the 6,029 rows/s measured for the previous 3,000-row, two-worker default
+on the same dataset.
+
+## No-sync results
+
+At two workers, batch size had little effect: 3,000, 10,000, 20,000, 25,000,
+and 30,000 rows produced 490,346, 510,710, 497,183, 494,492, and 501,308
+rows/s respectively. The concurrency screen was:
+
+| Batch rows | 1 worker | 2 workers | 4 workers | 8 workers | 16 workers |
+| ---: | ---: | ---: | ---: | ---: | ---: |
+| 3,000 | 305,670 | 490,346 | 744,140 | 1,193,492 | 1,193,433 |
+| 10,000 | 311,153 | 510,710 | 837,991 | 1,093,859 | 1,199,947 |
+| 30,000 | 303,832 | 501,308 | 767,768 | 991,002 | 1,005,975 |
+
+The finalists were repeated three times:
+
+| Batch rows | Workers | Run 1 | Run 2 | Run 3 | Median rows/s |
+| ---: | ---: | ---: | ---: | ---: | ---: |
+| 10,000 | 16 | 1,199,947 | 1,148,305 | 1,202,085 | 1,199,947 |
+| 3,000 | 8 | 1,193,492 | 1,187,417 | 1,034,609 | 1,187,417 |
+
+The medians differ by about 1.1%, so the selection rule prefers the lower-cost
+3,000-row, eight-worker configuration. No-sync remains opt-in because it does
+not wait for durable WAL acknowledgement:
+
+```bash
+python3 .agents/skills/benchmark-influxdb3/scripts/benchmark.py load \
+  --database-id core-311 --batch-size 3000 --load-workers 8 --no-sync
+```
+
+InfluxDB Core limits write request bodies to 10 MiB for this setup. The
+100,000-row request exceeded that limit, so 200,000- and 300,000-row requests
+were not attempted. The managed runner waits up to 60 seconds for shutdown so
+accepted no-sync writes can flush before the server is stopped.

--- a/docs/influx3.md
+++ b/docs/influx3.md
@@ -32,8 +32,8 @@ gunzip -c /tmp/influx3-data.gz | tsbs_load_influx3 \
   --db-name=benchmark \
   --auth-token="$INFLUXDB3_AUTH_TOKEN" \
   --admin-token="$INFLUXDB3_ADMIN_TOKEN" \
-  --workers=4 \
-  --batch-size=10000
+  --workers=16 \
+  --batch-size=25000
 ```
 
 The loader sends line protocol to `/api/v3/write_lp` with nanosecond
@@ -41,6 +41,10 @@ precision. Gzip is enabled, invalid batches are rejected atomically, and
 durable WAL acknowledgement is used by default. Use `--no-sync` only for a
 separately labelled durability/performance experiment, and use
 `--accept-partial` only if partial batch acceptance is intentional.
+These recommended durable settings were selected by the
+[InfluxDB 3 ingestion tuning benchmark](influx3-ingestion-benchmark.md). For
+non-durable throughput experiments, that benchmark recommends eight workers,
+a 3,000-row batch, and explicit `--no-sync`.
 
 By default the loader creates the benchmark database, replacing one with the
 same name. Set `--do-abort-on-exist` to stop instead of replacing it.


### PR DESCRIPTION
## What changed

- tune the InfluxDB 3 manual benchmark profile from 3,000-row batches and 6 workers to 25,000-row batches and 16 workers
- keep sync acknowledgement as the default and preserve explicit batch/worker overrides, smoke settings, and GreptimeDB defaults
- add a 60-second configurable managed-server shutdown timeout so large no-sync loads can flush cleanly
- document the complete Core 3.11.1 ingestion study, including the recommended opt-in no-sync recipe

## Why

The previous small sync batches were acknowledgement-bound. On the same 864,000-row dataset, the old benchmark setting of 3,000 rows and 2 workers reached 6,029 rows/s, while the selected 25,000-row and 16-worker finalist had a median of 321,880 rows/s.

The experiment also found that Core rejects a 100,000-row batch when its encoded body exceeds the 10 MiB request limit, so larger batches are not valid for this workload. For explicit `--no-sync` testing on an 8.64-million-row dataset, 3,000 rows and 8 workers was selected over 10,000 rows and 16 workers because their medians were within 1.1% and the former uses half the workers.

## Benchmark evidence

- Core 3.11.1 binary SHA-256: `c69df9525adf916ebfafd4d9713fdff3ddf8999adfeeb7d938679708e238f801`
- sync dataset: `cpu-only-s100-003a91156529`, SHA-256 `d287426a327c38a84ba495b533d8a7512a6a84bd271d5b6d85df6b8ad0f0d732`
- no-sync dataset: `cpu-only-s1000-45c02116670b`, SHA-256 `33f08ef6aedf56b39a64598142f12c39779e7ececcc0df6e0471879c947448cd`
- sync 25K × 16 runs: `20260813T113913Z`, `20260813T114929Z`, `20260813T115039Z` (median 321,880 rows/s)
- sync 20K × 16 runs: `20260813T113930Z`, `20260813T115004Z`, `20260813T115113Z` (median 298,074 rows/s)
- large sync 25K × 16 runs: `20260813T120319Z`, `20260813T120347Z`, `20260813T120518Z` (median 363,538 rows/s)
- large sync 30K × 16 runs: `20260813T120242Z`, `20260813T120416Z`, `20260813T120447Z` (median 327,809 rows/s)
- no-sync 10K × 16 runs: `20260813T114711Z`, `20260813T115010Z`, `20260813T115045Z` (median 1,199,947 rows/s)
- no-sync 3K × 8 runs: `20260813T114802Z`, `20260813T114935Z`, `20260813T115119Z` (median 1,187,417 rows/s)

The ignored run artifacts are retained locally under `.benchmarks/influxdb3/runs/`.

The larger sync comparison used the 8.64-million-row dataset for both configurations. It confirms 25K over 30K at 16 workers by 10.9% at the median, with exact row and metric counts and no benchmark failures.

## Validation

- `python3 -m unittest discover -s .agents/skills/benchmark-influxdb3/tests -p 'test_*.py'` (21 tests)
- `python3 -m unittest discover -s .agents/skills/benchmark-greptimedb/tests -p 'test_*.py'` (14 tests)
- `.benchmarks/environment/go/1.21.13/darwin_arm64/bin/go test ./cmd/tsbs_load_influx3`
- Python bytecode compilation and `git diff --check`
