### PR TITLE
fix: flush benchmark logs promptly

### DIFF
--- a/.agents/lib/tsbs_benchmark.py
+++ b/.agents/lib/tsbs_benchmark.py
@@ -12,7 +12,7 @@ import math
 import os
 import re
 from pathlib import Path
-from typing import Any, Callable, Iterator, Sequence, TypeVar
+from typing import Any, Callable, Iterable, Iterator, Sequence, TextIO, TypeVar
 
 
 RESULT_FORMAT_VERSION = "0.2"
@@ -85,6 +85,19 @@ ErrorType = TypeVar("ErrorType", bound=Exception)
 
 def utc_now() -> str:
     return dt.datetime.now(dt.timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def write_streams(text: str, *destinations: TextIO) -> None:
+    """Write text to every destination and make it immediately observable."""
+    for destination in destinations:
+        destination.write(text)
+        destination.flush()
+
+
+def tee_stream(source: Iterable[str], *destinations: TextIO) -> None:
+    """Copy a text stream and flush every complete line to each destination."""
+    for line in source:
+        write_streams(line, *destinations)
 
 
 def canonical_json(value: Any) -> str:

--- a/.agents/skills/benchmark-greptimedb/scripts/benchmark.py
+++ b/.agents/skills/benchmark-greptimedb/scripts/benchmark.py
@@ -40,7 +40,9 @@ from tsbs_benchmark import (  # noqa: E402
     relative,
     save_json,
     sha256_file,
+    tee_stream,
     utc_now,
+    write_streams,
 )
 from tsbs_environment import TsbsEnvironmentError, resolve_go  # noqa: E402
 from summarize import write_summary
@@ -140,12 +142,11 @@ def run_tee(command: Sequence[str], log_path: Path, *, stdout_path: Path | None 
     log_path.parent.mkdir(parents=True, exist_ok=True)
     with log_path.open(mode, encoding="utf-8") as log:
         header = f"$ {display_command(command)}\n"
-        log.write(header); log.flush(); print(header, end="")
+        write_streams(header, sys.stdout, log)
         if stdout_path is None:
             process = subprocess.Popen(command, cwd=REPO_ROOT, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True, bufsize=1)
             assert process.stdout is not None
-            for line in process.stdout:
-                sys.stdout.write(line); log.write(line)
+            tee_stream(process.stdout, sys.stdout, log)
             process.stdout.close(); return_code = process.wait()
         else:
             stdout_path.parent.mkdir(parents=True, exist_ok=True)
@@ -153,8 +154,7 @@ def run_tee(command: Sequence[str], log_path: Path, *, stdout_path: Path | None 
             with temporary_output.open("wb") as output:
                 process = subprocess.Popen(command, cwd=REPO_ROOT, stdout=output, stderr=subprocess.PIPE, text=True, bufsize=1)
                 assert process.stderr is not None
-                for line in process.stderr:
-                    sys.stdout.write(line); log.write(line)
+                tee_stream(process.stderr, sys.stdout, log)
                 process.stderr.close(); return_code = process.wait()
         if return_code:
             if stdout_path is not None:

--- a/.agents/skills/benchmark-influxdb3/scripts/benchmark.py
+++ b/.agents/skills/benchmark-influxdb3/scripts/benchmark.py
@@ -40,7 +40,9 @@ from tsbs_benchmark import (  # noqa: E402
     relative,
     save_json,
     sha256_file,
+    tee_stream,
     utc_now,
+    write_streams,
 )
 from tsbs_environment import TsbsEnvironmentError, resolve_go  # noqa: E402
 from summarize import write_summary
@@ -158,12 +160,11 @@ def run_tee(command: Sequence[str], log_path: Path, *, stdout_path: Path | None 
     log_path.parent.mkdir(parents=True, exist_ok=True)
     with log_path.open(mode, encoding="utf-8") as log:
         header = f"$ {display_command(command)}\n"
-        log.write(header); log.flush(); print(header, end="")
+        write_streams(header, sys.stdout, log)
         if stdout_path is None:
             process = subprocess.Popen(command, cwd=REPO_ROOT, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True, bufsize=1)
             assert process.stdout is not None
-            for line in process.stdout:
-                sys.stdout.write(line); log.write(line)
+            tee_stream(process.stdout, sys.stdout, log)
             process.stdout.close(); return_code = process.wait()
         else:
             stdout_path.parent.mkdir(parents=True, exist_ok=True)
@@ -171,8 +172,7 @@ def run_tee(command: Sequence[str], log_path: Path, *, stdout_path: Path | None 
             with temporary_output.open("wb") as output:
                 process = subprocess.Popen(command, cwd=REPO_ROOT, stdout=output, stderr=subprocess.PIPE, text=True, bufsize=1)
                 assert process.stderr is not None
-                for line in process.stderr:
-                    sys.stdout.write(line); log.write(line)
+                tee_stream(process.stderr, sys.stdout, log)
                 process.stderr.close(); return_code = process.wait()
         if return_code:
             if stdout_path is not None:


### PR DESCRIPTION
## What changed

- add shared helpers that write and flush streamed subprocess output
- use the helpers in the GreptimeDB and InfluxDB 3 benchmark runners
- preserve the existing 10-second loader reporting interval

## Why

Benchmark load progress was copied with buffered writes. When the runner's stdout was captured or non-interactive, progress could remain invisible until the buffer filled or the process exited.

This change flushes each emitted line to both the console stream and the run log, making progress observable at the loader's existing reporting cadence.

## Validation

- `python3 .agents/tests/test_tsbs_benchmark.py`
- `python3 .agents/skills/benchmark-greptimedb/tests/test_benchmark.py`
- `python3 .agents/skills/benchmark-influxdb3/tests/test_benchmark.py`
- `python3 -m py_compile .agents/lib/tsbs_benchmark.py .agents/skills/benchmark-greptimedb/scripts/benchmark.py .agents/skills/benchmark-influxdb3/scripts/benchmark.py`
- `git diff --check`