### PR TITLE
fix(influxdb3): increase startup timeout

### DIFF
--- a/.agents/skills/benchmark-influxdb3/SKILL.md
+++ b/.agents/skills/benchmark-influxdb3/SKILL.md
@@ -52,6 +52,9 @@ Repeat `--query-type` to define membership; omit it for every supported type.
 Each immutable query file executes once per run. Query-only commands prepare
 logical dataset metadata without generating data. Shared query sets are reused
 only after exact manifest, membership, size, and checksum validation.
+Managed servers may take several minutes to initialize, so the runner waits up
+to 10 minutes by default. Override this with `--startup-timeout SECONDS` when a
+different allowance is required.
 
 ## Authenticate external targets
 

--- a/.agents/skills/benchmark-influxdb3/scripts/benchmark.py
+++ b/.agents/skills/benchmark-influxdb3/scripts/benchmark.py
@@ -622,7 +622,7 @@ def add_run_options(parser: argparse.ArgumentParser) -> None:
 
 
 def add_connection_options(parser: argparse.ArgumentParser) -> None:
-    parser.add_argument("--database-id"); parser.add_argument("--database-root", type=Path); parser.add_argument("--url", action="append"); parser.add_argument("--edition", choices=("core", "enterprise")); parser.add_argument("--http-port", type=int, default=8181); parser.add_argument("--startup-timeout", type=int, default=60); parser.add_argument("--shutdown-timeout", type=int, default=60, help="seconds to wait for a managed server to flush and stop"); parser.add_argument("--database", help=f"SQL database name (default: {DEFAULT_DATABASE})"); parser.add_argument("--auth-token-env", default="INFLUXDB3_AUTH_TOKEN"); parser.add_argument("--admin-token-env", default="INFLUXDB3_ADMIN_TOKEN")
+    parser.add_argument("--database-id"); parser.add_argument("--database-root", type=Path); parser.add_argument("--url", action="append"); parser.add_argument("--edition", choices=("core", "enterprise")); parser.add_argument("--http-port", type=int, default=8181); parser.add_argument("--startup-timeout", type=int, default=600, help="seconds to wait for a managed server to become ready"); parser.add_argument("--shutdown-timeout", type=int, default=60, help="seconds to wait for a managed server to flush and stop"); parser.add_argument("--database", help=f"SQL database name (default: {DEFAULT_DATABASE})"); parser.add_argument("--auth-token-env", default="INFLUXDB3_AUTH_TOKEN"); parser.add_argument("--admin-token-env", default="INFLUXDB3_ADMIN_TOKEN")
 
 
 def add_load_options(parser: argparse.ArgumentParser) -> None:

--- a/.agents/skills/benchmark-influxdb3/tests/test_benchmark.py
+++ b/.agents/skills/benchmark-influxdb3/tests/test_benchmark.py
@@ -378,6 +378,7 @@ class TargetTests(unittest.TestCase):
             "load", "--database-id", "db-a", "--no-sync",
         ])
         self.assertFalse(durable.no_sync)
+        self.assertEqual(durable.startup_timeout, 600)
         self.assertEqual(durable.shutdown_timeout, 60)
         self.assertTrue(non_durable.no_sync)
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,5 @@
+# Repository Instructions
+
+## Git commits
+
+- Use Conventional Commits for commit messages.


### PR DESCRIPTION
## Summary

- increase the managed InfluxDB 3 startup timeout default from 60 seconds to 10 minutes
- document the longer allowance and retain the CLI override
- record the Conventional Commits convention in `AGENTS.md`
- add regression coverage for the new default

## Why

InfluxDB 3 Core startup can take several minutes, causing managed benchmark
runs to fail before the server becomes ready.

## Impact

Managed Core and Enterprise benchmark runs now wait up to 10 minutes by
default. Users can still set a different allowance with `--startup-timeout`;
the shutdown timeout remains 60 seconds.

## Validation

- `python3 -m unittest discover -s .agents/skills/benchmark-influxdb3/tests -v` (21 tests passed)
- `git diff --check`
