### PR TITLE
feat: support per-query-type counts

### DIFF
--- a/.agents/lib/tsbs_benchmark.py
+++ b/.agents/lib/tsbs_benchmark.py
@@ -149,6 +149,38 @@ def add_one_second(timestamp: str) -> str:
     return (parsed + dt.timedelta(seconds=1)).isoformat().replace("+00:00", "Z")
 
 
+def parse_query_count(value: str) -> tuple[str, int]:
+    query_type, separator, raw_count = value.partition("=")
+    if not separator or not query_type or not raw_count:
+        raise argparse.ArgumentTypeError(
+            "query count must use QUERY_TYPE=COUNT syntax"
+        )
+    if query_type not in QUERY_TYPES:
+        raise argparse.ArgumentTypeError(f"unsupported query type: {query_type}")
+    try:
+        count = int(raw_count)
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError(
+            f"query count for {query_type} must be an integer"
+        ) from exc
+    if count <= 0:
+        raise argparse.ArgumentTypeError(
+            f"query count for {query_type} must be positive"
+        )
+    return query_type, count
+
+
+def query_count_overrides(
+    values: Sequence[tuple[str, int]] | None,
+) -> dict[str, int]:
+    overrides: dict[str, int] = {}
+    for query_type, count in values or ():
+        if query_type in overrides:
+            raise ValueError(f"duplicate --query-count for {query_type}")
+        overrides[query_type] = count
+    return overrides
+
+
 def build_workload(
     args: argparse.Namespace,
     base: dict[str, Any] | None = None,
@@ -173,10 +205,24 @@ def build_workload(
         value = getattr(args, attr, None)
         if value is not None:
             workload[attr] = value
-    selected = sorted(set(args.query_type or workload["query_counts"]))
+    overrides = query_count_overrides(getattr(args, "query_count", None))
+    if args.query_type:
+        selected = sorted(set(args.query_type))
+        unselected = sorted(set(overrides) - set(selected))
+        if unselected:
+            raise ValueError(
+                "--query-count targets query types not selected by --query-type: "
+                + ", ".join(unselected)
+            )
+    elif overrides:
+        selected = sorted(overrides)
+    else:
+        selected = sorted(workload["query_counts"])
     count_override = getattr(args, "queries", None)
     workload["query_counts"] = {
-        query_type: count_override
+        query_type: overrides[query_type]
+        if query_type in overrides
+        else count_override
         if count_override is not None
         else workload["query_counts"][query_type]
         for query_type in selected

--- a/.agents/skills/benchmark-greptimedb/SKILL.md
+++ b/.agents/skills/benchmark-greptimedb/SKILL.md
@@ -39,16 +39,19 @@ python3 .agents/skills/benchmark-greptimedb/scripts/benchmark.py generate \
 
 python3 .agents/skills/benchmark-greptimedb/scripts/benchmark.py query \
   --profile smoke --endpoint http://127.0.0.1:4000 --database benchmark \
-  --query-type cpu-max-all-1 --query-type lastpoint
+  --query-count cpu-max-all-1=100 --query-count lastpoint=10
 
 python3 .agents/skills/benchmark-greptimedb/scripts/benchmark.py summarize \
   --run-dir .benchmarks/greptimedb/runs/RUN_ID
 ```
 
 Repeat `--query-type` to define query-set membership; omit it for every
-supported type. `--queries=N` assigns that count to every selected type and
-therefore selects a different immutable query set. Each selected query file is
-executed once. Start another run to make another measurement.
+supported type. `--queries=N` assigns a default count to every selected type.
+Repeat `--query-count TYPE=N` to override individual counts; without
+`--query-type`, those entries also define membership. With both flags, every
+per-type override must name a selected type. Resolved counts are part of the
+immutable query-set identity. Each selected query file is executed once. Start
+another run to make another measurement.
 
 Query-only commands prepare logical dataset metadata without generating data.
 Use `--dataset-id` or `--dataset-path` to pin a dataset. Shared query sets live

--- a/.agents/skills/benchmark-greptimedb/references/workload.md
+++ b/.agents/skills/benchmark-greptimedb/references/workload.md
@@ -38,6 +38,13 @@ The query generator receives the end timestamp plus one second.
 
 ## Query counts
 
+Profile counts are defaults. `--queries=N` replaces the default for every
+selected type, and repeatable `--query-count TYPE=N` entries take final
+precedence for individual types. If `--query-count` is used without
+`--query-type`, only the named types belong to the query set. If
+`--query-type` is present, it defines membership and every per-type override
+must target one of those types.
+
 | Query type | Manual | Smoke |
 | --- | ---: | ---: |
 | `cpu-max-all-1` | 100 | 10 |

--- a/.agents/skills/benchmark-greptimedb/scripts/benchmark.py
+++ b/.agents/skills/benchmark-greptimedb/scripts/benchmark.py
@@ -35,6 +35,8 @@ from tsbs_benchmark import (  # noqa: E402
     lock_directory,
     new_run_dir as shared_new_run_dir,
     next_attempt,
+    parse_query_count,
+    query_count_overrides,
     query_file_path,
     read_json as shared_read_json,
     relative,
@@ -115,7 +117,7 @@ def prepare_run(args: argparse.Namespace) -> tuple[Path, dict[str, Any]]:
     if manifest_path.exists():
         manifest = read_json(manifest_path)
         validate_run_manifest(manifest, manifest_path)
-        workload_options = ("profile", "start", "end", "scale", "seed", "log_interval", "load_workers", "query_workers", "batch_size", "queries", "query_type")
+        workload_options = ("profile", "start", "end", "scale", "seed", "log_interval", "load_workers", "query_workers", "batch_size", "queries", "query_type", "query_count")
         if any(getattr(args, name, None) is not None for name in workload_options):
             requested = build_workload(args, manifest["workload"])
             if requested != manifest["workload"]:
@@ -493,7 +495,8 @@ def connection(args: argparse.Namespace, run_dir: Path) -> Iterator[tuple[str, b
 def add_run_options(parser: argparse.ArgumentParser) -> None:
     parser.add_argument("--run-dir", type=Path); parser.add_argument("--run-root", type=Path)
     parser.add_argument("--profile", choices=sorted(PROFILES)); parser.add_argument("--start"); parser.add_argument("--end"); parser.add_argument("--scale", type=int); parser.add_argument("--seed", type=int); parser.add_argument("--log-interval")
-    parser.add_argument("--load-workers", type=int); parser.add_argument("--query-workers", type=int); parser.add_argument("--batch-size", type=int); parser.add_argument("--queries", type=int, help="count for every selected query type")
+    parser.add_argument("--load-workers", type=int); parser.add_argument("--query-workers", type=int); parser.add_argument("--batch-size", type=int); parser.add_argument("--queries", type=int, help="default count for every selected query type")
+    parser.add_argument("--query-count", action="append", type=parse_query_count, metavar="QUERY_TYPE=COUNT", help="count for one query type; repeat for different counts")
     parser.add_argument("--query-type", action="append", choices=QUERY_TYPES); parser.add_argument("--query-root", type=Path); parser.add_argument("--regenerate", action="store_true"); parser.add_argument("--rebuild", action="store_true"); parser.add_argument("--dataset-root", type=Path)
     dataset = parser.add_mutually_exclusive_group(); dataset.add_argument("--dataset-id"); dataset.add_argument("--dataset-path", type=Path)
 
@@ -521,6 +524,13 @@ def validate_args(args: argparse.Namespace) -> None:
     for name in ("scale", "load_workers", "query_workers", "batch_size", "queries"):
         value = getattr(args, name, None)
         if value is not None and value <= 0: raise BenchmarkError(f"--{name.replace('_', '-')} must be positive")
+    try:
+        overrides = query_count_overrides(getattr(args, "query_count", None))
+    except ValueError as exc:
+        raise BenchmarkError(str(exc)) from exc
+    if getattr(args, "query_type", None):
+        unselected = sorted(set(overrides) - set(args.query_type))
+        if unselected: raise BenchmarkError("--query-count targets query types not selected by --query-type: " + ", ".join(unselected))
     for name in ("dataset_id", "database_id"):
         value = getattr(args, name, None)
         if value and not ID_RE.fullmatch(value): raise BenchmarkError(f"--{name.replace('_', '-')} contains invalid characters")

--- a/.agents/skills/benchmark-greptimedb/tests/test_benchmark.py
+++ b/.agents/skills/benchmark-greptimedb/tests/test_benchmark.py
@@ -82,6 +82,23 @@ class WorkspaceTests(unittest.TestCase):
             with self.assertRaisesRegex(benchmark.BenchmarkError, "unsupported"):
                 benchmark.prepare_run(args)
 
+    def test_per_type_count_change_is_rejected_for_an_existing_run(self) -> None:
+        with tempfile.TemporaryDirectory() as temp:
+            root = Path(temp)
+            parser = benchmark.make_parser()
+            initial = parser.parse_args([
+                "generate", "--run-root", str(root), "--only", "queries",
+                "--query-count", "lastpoint=7",
+            ])
+            run_dir, _ = benchmark.prepare_run(initial)
+            changed = parser.parse_args([
+                "generate", "--run-dir", str(run_dir), "--only", "queries",
+                "--query-count", "lastpoint=8",
+            ])
+
+            with self.assertRaisesRegex(benchmark.BenchmarkError, "immutable"):
+                benchmark.prepare_run(changed)
+
 
 class QuerySetTests(unittest.TestCase):
     def make_args(self, run_dir: Path, query_root: Path, *types: str) -> argparse.Namespace:
@@ -131,6 +148,34 @@ class QuerySetTests(unittest.TestCase):
                 else: runner.assert_not_called()
             self.assertEqual(paths[0], paths[1])
             self.assertEqual(json.loads((root / "run-b/manifest.json").read_text())["query_set"]["reused"], True)
+
+    def test_generator_receives_each_per_type_count(self) -> None:
+        with tempfile.TemporaryDirectory() as temp:
+            root = Path(temp); run_dir = root / "run"; query_root = root / "queries"
+            args = benchmark.make_parser().parse_args([
+                "generate", "--run-dir", str(run_dir), "--query-root", str(query_root),
+                "--profile", "smoke", "--only", "queries",
+                "--query-count", "lastpoint=7",
+                "--query-count", "cpu-max-all-1=23",
+            ])
+            manifest = self.make_manifest(run_dir, args)
+            real_sha = benchmark.sha256_file
+
+            def hashes(path):
+                return "b" * 64 if path.name == benchmark.BINARIES["queries"] else real_sha(path)
+
+            with mock.patch.object(benchmark, "ensure_binaries"), mock.patch.object(
+                benchmark, "run_tee", side_effect=self.generator
+            ) as runner, mock.patch.object(benchmark, "sha256_file", side_effect=hashes):
+                benchmark.generate_queries(args, run_dir, manifest)
+
+            commands = [call.args[0] for call in runner.call_args_list]
+            counts_by_type = {
+                next(part.removeprefix("--query-type=") for part in command if part.startswith("--query-type=")):
+                next(part.removeprefix("--queries=") for part in command if part.startswith("--queries="))
+                for command in commands
+            }
+            self.assertEqual(counts_by_type, {"cpu-max-all-1": "23", "lastpoint": "7"})
 
     def test_failure_is_atomic_and_diagnostics_stay_in_run(self) -> None:
         with tempfile.TemporaryDirectory() as temp:

--- a/.agents/skills/benchmark-influxdb3/SKILL.md
+++ b/.agents/skills/benchmark-influxdb3/SKILL.md
@@ -42,16 +42,20 @@ python3 .agents/skills/benchmark-influxdb3/scripts/benchmark.py all \
 
 python3 .agents/skills/benchmark-influxdb3/scripts/benchmark.py query \
   --profile smoke --url http://127.0.0.1:8181 --edition core \
-  --query-type cpu-max-all-1 --query-type lastpoint
+  --query-count cpu-max-all-1=100 --query-count lastpoint=10
 
 python3 .agents/skills/benchmark-influxdb3/scripts/benchmark.py summarize \
   --run-dir .benchmarks/influxdb3/runs/RUN_ID
 ```
 
 Repeat `--query-type` to define membership; omit it for every supported type.
-Each immutable query file executes once per run. Query-only commands prepare
-logical dataset metadata without generating data. Shared query sets are reused
-only after exact manifest, membership, size, and checksum validation.
+`--queries=N` supplies a default count for selected types, while repeatable
+`--query-count TYPE=N` entries override individual counts. Without
+`--query-type`, per-type entries define membership; with it, overrides must
+name selected types. Each immutable query file executes once per run.
+Query-only commands prepare logical dataset metadata without generating data.
+Shared query sets are reused only after exact manifest, membership, size, and
+checksum validation.
 Managed servers may take several minutes to initialize, so the runner waits up
 to 10 minutes by default. Override this with `--startup-timeout SECONDS` when a
 different allowance is required.

--- a/.agents/skills/benchmark-influxdb3/references/workload.md
+++ b/.agents/skills/benchmark-influxdb3/references/workload.md
@@ -31,6 +31,12 @@ Both use seed `123`, interval `10s`, `cpu-only` data, `devops` queries,
 durable WAL acknowledgement, and rejection of partial batches. The query end
 timestamp is the dataset end plus one second.
 
+Profile query counts are defaults. `--queries=N` replaces the default for
+every selected type, and repeatable `--query-count TYPE=N` entries override
+individual counts. Without `--query-type`, per-type entries define query-set
+membership; with `--query-type`, every override must target a selected type.
+The resolved type-to-count mapping is part of the immutable query-set identity.
+
 The manual load settings are InfluxDB-specific overrides selected by
 `docs/influx3-ingestion-benchmark.md`; shared TSBS and GreptimeDB profile
 defaults remain unchanged. Explicit `--load-workers` and `--batch-size` flags

--- a/.agents/skills/benchmark-influxdb3/scripts/benchmark.py
+++ b/.agents/skills/benchmark-influxdb3/scripts/benchmark.py
@@ -35,6 +35,8 @@ from tsbs_benchmark import (  # noqa: E402
     lock_directory,
     new_run_dir as shared_new_run_dir,
     next_attempt,
+    parse_query_count,
+    query_count_overrides,
     query_file_path,
     read_json as shared_read_json,
     relative,
@@ -116,7 +118,7 @@ def prepare_run(args: argparse.Namespace) -> tuple[Path, dict[str, Any]]:
     if manifest_path.exists():
         manifest = read_json(manifest_path)
         validate_run_manifest(manifest, manifest_path)
-        workload_options = ("profile", "start", "end", "scale", "seed", "log_interval", "load_workers", "query_workers", "batch_size", "queries", "query_type")
+        workload_options = ("profile", "start", "end", "scale", "seed", "log_interval", "load_workers", "query_workers", "batch_size", "queries", "query_type", "query_count")
         if any(getattr(args, name, None) is not None for name in workload_options):
             requested = build_workload(
                 args,
@@ -616,7 +618,8 @@ def connection(args: argparse.Namespace, run_dir: Path, manifest: dict[str, Any]
 def add_run_options(parser: argparse.ArgumentParser) -> None:
     parser.add_argument("--run-dir", type=Path); parser.add_argument("--run-root", type=Path)
     parser.add_argument("--profile", choices=sorted(PROFILES)); parser.add_argument("--start"); parser.add_argument("--end"); parser.add_argument("--scale", type=int); parser.add_argument("--seed", type=int); parser.add_argument("--log-interval")
-    parser.add_argument("--load-workers", type=int); parser.add_argument("--query-workers", type=int); parser.add_argument("--batch-size", type=int); parser.add_argument("--queries", type=int, help="count for every selected query type")
+    parser.add_argument("--load-workers", type=int); parser.add_argument("--query-workers", type=int); parser.add_argument("--batch-size", type=int); parser.add_argument("--queries", type=int, help="default count for every selected query type")
+    parser.add_argument("--query-count", action="append", type=parse_query_count, metavar="QUERY_TYPE=COUNT", help="count for one query type; repeat for different counts")
     parser.add_argument("--query-type", action="append", choices=QUERY_TYPES); parser.add_argument("--query-root", type=Path); parser.add_argument("--regenerate", action="store_true"); parser.add_argument("--rebuild", action="store_true"); parser.add_argument("--dataset-root", type=Path)
     dataset = parser.add_mutually_exclusive_group(); dataset.add_argument("--dataset-id"); dataset.add_argument("--dataset-path", type=Path)
 
@@ -644,6 +647,13 @@ def validate_args(args: argparse.Namespace) -> None:
     for name in ("scale", "load_workers", "query_workers", "batch_size", "queries"):
         value = getattr(args, name, None)
         if value is not None and value <= 0: raise BenchmarkError(f"--{name.replace('_', '-')} must be positive")
+    try:
+        overrides = query_count_overrides(getattr(args, "query_count", None))
+    except ValueError as exc:
+        raise BenchmarkError(str(exc)) from exc
+    if getattr(args, "query_type", None):
+        unselected = sorted(set(overrides) - set(args.query_type))
+        if unselected: raise BenchmarkError("--query-count targets query types not selected by --query-type: " + ", ".join(unselected))
     for name in ("dataset_id", "database_id"):
         value = getattr(args, name, None)
         if value and not ID_RE.fullmatch(value): raise BenchmarkError(f"--{name.replace('_', '-')} contains invalid characters")

--- a/.agents/skills/benchmark-influxdb3/tests/test_benchmark.py
+++ b/.agents/skills/benchmark-influxdb3/tests/test_benchmark.py
@@ -178,6 +178,21 @@ class WorkspaceTests(unittest.TestCase):
             self.assertFalse((run_dir / "data").exists())
             self.assertFalse((run_dir / "influxdb3").exists())
 
+    def test_per_type_counts_define_the_influxdb3_query_set(self) -> None:
+        with tempfile.TemporaryDirectory() as temp:
+            args = benchmark.make_parser().parse_args([
+                "generate", "--run-root", temp, "--only", "queries",
+                "--query-count", "lastpoint=7",
+                "--query-count", "cpu-max-all-1=23",
+            ])
+
+            _, manifest = benchmark.prepare_run(args)
+
+        self.assertEqual(
+            manifest["workload"]["query_counts"],
+            {"cpu-max-all-1": 23, "lastpoint": 7},
+        )
+
     def test_old_or_malformed_run_manifest_is_rejected(self) -> None:
         with tempfile.TemporaryDirectory() as temp:
             run_dir = Path(temp)

--- a/.agents/tests/test_tsbs_benchmark.py
+++ b/.agents/tests/test_tsbs_benchmark.py
@@ -49,6 +49,7 @@ class WorkloadTests(unittest.TestCase):
             "batch_size": None,
             "queries": None,
             "query_type": None,
+            "query_count": None,
         }
         values.update(overrides)
         return argparse.Namespace(**values)
@@ -70,6 +71,67 @@ class WorkloadTests(unittest.TestCase):
 
         self.assertEqual(workload["scale"], 7)
         self.assertEqual(workload["start"], base["start"])
+
+    def test_per_type_counts_define_a_subset(self) -> None:
+        workload = shared.build_workload(
+            self.args(
+                query_count=[("lastpoint", 7), ("cpu-max-all-1", 23)]
+            )
+        )
+
+        self.assertEqual(
+            workload["query_counts"], {"cpu-max-all-1": 23, "lastpoint": 7}
+        )
+
+    def test_per_type_counts_override_global_and_profile_counts(self) -> None:
+        workload = shared.build_workload(
+            self.args(
+                query_type=[
+                    "lastpoint",
+                    "cpu-max-all-1",
+                    "double-groupby-1",
+                ],
+                queries=20,
+                query_count=[("lastpoint", 7), ("cpu-max-all-1", 23)],
+            )
+        )
+
+        self.assertEqual(
+            workload["query_counts"],
+            {
+                "cpu-max-all-1": 23,
+                "double-groupby-1": 20,
+                "lastpoint": 7,
+            },
+        )
+
+    def test_per_type_count_must_match_explicit_membership(self) -> None:
+        with self.assertRaisesRegex(ValueError, "not selected"):
+            shared.build_workload(
+                self.args(
+                    query_type=["lastpoint"],
+                    query_count=[("cpu-max-all-1", 23)],
+                )
+            )
+
+    def test_duplicate_per_type_count_is_rejected(self) -> None:
+        with self.assertRaisesRegex(ValueError, "duplicate --query-count"):
+            shared.build_workload(
+                self.args(query_count=[("lastpoint", 7), ("lastpoint", 8)])
+            )
+
+    def test_query_count_parser_rejects_invalid_values(self) -> None:
+        invalid = (
+            "lastpoint",
+            "unknown=10",
+            "lastpoint=abc",
+            "lastpoint=0",
+            "lastpoint=-1",
+        )
+        for value in invalid:
+            with self.subTest(value=value):
+                with self.assertRaises(argparse.ArgumentTypeError):
+                    shared.parse_query_count(value)
 
 
 class ResultTests(unittest.TestCase):


### PR DESCRIPTION
## What changed

- add repeatable `--query-count QUERY_TYPE=COUNT` overrides to the GreptimeDB and InfluxDB 3 benchmark skills
- preserve `--queries` as the selected-type baseline and `--query-type` as explicit membership
- make per-type-only arguments define a concise query-set subset
- validate malformed, unsupported, duplicate, non-positive, and out-of-membership overrides
- document the precedence and immutable query-set behavior

## Why

The benchmark wrappers previously exposed only a single `--queries` override, so callers could not construct an ad hoc query set with different case counts per query type even though manifests already stored a type-to-count mapping. This exposes that existing capability without changing the manifest schema or underlying Go query generator.

## Impact

Existing commands and pinned manifests remain compatible. Resolved per-type counts continue to participate in query-set identity, so different mappings produce distinct immutable query sets.

## Validation

- all 7 repository agent test suites pass
- 66 relevant shared and benchmark tests pass
- Python compilation passes for the changed modules
- `git diff --check` passes