### PR TITLE
perf: skip dataset checksum on cache reuse

### DIFF
--- a/.agents/skills/generate-tsbs-data/SKILL.md
+++ b/.agents/skills/generate-tsbs-data/SKILL.md
@@ -37,7 +37,9 @@ The default root is `.benchmarks/datasets`. Set `TSBS_DATASET_ROOT` or pass
 `--dataset-root` to share datasets. Use `--dataset-id` or `--dataset-path`, but
 not both. Existing logical datasets inherit stored settings unless explicit
 overrides conflict. Pass `--regenerate` only to intentionally replace a format
-variant and `--rebuild` only to rebuild the generator.
+variant and `--rebuild` only to rebuild the generator. Reuse validates the
+manifest, completion status, artifact presence, and byte size without rereading
+the complete artifact to recompute its checksum.
 
 ## Inspect and verify
 
@@ -50,5 +52,7 @@ python3 .agents/skills/generate-tsbs-data/scripts/generate.py verify \
 
 Use `--json` or `--result-file` for machine-readable output. Report the
 dataset ID and specification; for materialized variants also report format,
-data path, byte size, and SHA-256. Database-specific query generation belongs
-to the corresponding benchmark skill.
+data path, byte size, and recorded SHA-256. The `verify` command explicitly
+recomputes the artifact checksum and should be used when full cache integrity
+validation is required. Database-specific query generation belongs to the
+corresponding benchmark skill.

--- a/.agents/skills/generate-tsbs-data/references/datasets.md
+++ b/.agents/skills/generate-tsbs-data/references/datasets.md
@@ -38,7 +38,9 @@ The generator validates format names. GreptimeDB and InfluxDB 3 consume the
 `influx` variant; other loaders should request their native TSBS format under
 the same logical dataset ID.
 
-- Validate the logical manifest and artifact size/checksum before reuse.
+- Validate the logical manifest, completion status, artifact presence, and byte
+  size before ordinary reuse. Run `generate.py verify` to recompute and validate
+  the artifact checksum explicitly.
 - Publish a replacement payload only after successful generation.
 - Preserve the completed artifact when regeneration fails.
 - Keep cached data outside Git; `.benchmarks/` is ignored.

--- a/.agents/skills/generate-tsbs-data/scripts/generate.py
+++ b/.agents/skills/generate-tsbs-data/scripts/generate.py
@@ -145,7 +145,12 @@ def validate_dataset_manifest(dataset_dir: Path, expected_spec: dict[str, Any] |
     return manifest
 
 
-def validate_variant(dataset_dir: Path, format_name: str) -> dict[str, Any]:
+def validate_variant(
+    dataset_dir: Path,
+    format_name: str,
+    *,
+    verify_checksum: bool = True,
+) -> dict[str, Any]:
     variant_dir = dataset_dir / "formats" / format_name
     manifest = read_json(variant_dir / "manifest.json")
     if manifest.get("status") != "completed":
@@ -155,9 +160,20 @@ def validate_variant(dataset_dir: Path, format_name: str) -> dict[str, Any]:
     artifact = variant_dir / str(manifest.get("artifact", "data"))
     if not artifact.is_file():
         raise DatasetError(f"missing dataset artifact: {artifact}")
+    recorded_size = manifest.get("bytes")
+    recorded_checksum = manifest.get("sha256")
+    if (
+        isinstance(recorded_size, bool)
+        or not isinstance(recorded_size, int)
+        or recorded_size < 0
+        or not isinstance(recorded_checksum, str)
+        or re.fullmatch(r"[0-9a-f]{64}", recorded_checksum) is None
+    ):
+        raise DatasetError(f"malformed dataset format manifest: {variant_dir}")
     actual_size = artifact.stat().st_size
-    actual_checksum = sha256_file(artifact)
-    if actual_size != manifest.get("bytes") or actual_checksum != manifest.get("sha256"):
+    if actual_size != recorded_size:
+        raise DatasetError(f"dataset artifact size mismatch: {artifact}")
+    if verify_checksum and sha256_file(artifact) != recorded_checksum:
         raise DatasetError(f"dataset artifact checksum mismatch: {artifact}")
     return manifest
 
@@ -235,7 +251,9 @@ def generate_variant(
         if existing.get("status") == "completed":
             if rebuild:
                 run_build(log_path, True)
-            manifest = validate_variant(dataset_dir, format_name)
+            manifest = validate_variant(
+                dataset_dir, format_name, verify_checksum=False
+            )
             return result(dataset_dir, dataset_manifest, manifest, reused=True)
 
     variant_dir.mkdir(parents=True, exist_ok=True)
@@ -418,7 +436,7 @@ def verify_dataset(args: argparse.Namespace) -> dict[str, Any]:
     variants = []
     for format_name in formats:
         validate_format(format_name)
-        variant = validate_variant(path, format_name)
+        variant = validate_variant(path, format_name, verify_checksum=True)
         variants.append(result(path, manifest, variant, reused=True))
     return {"dataset_id": manifest["dataset_id"], "dataset_path": str(path), "variants": variants}
 

--- a/.agents/skills/generate-tsbs-data/tests/test_generate.py
+++ b/.agents/skills/generate-tsbs-data/tests/test_generate.py
@@ -110,16 +110,61 @@ class DatasetVariantTests(unittest.TestCase):
             self.assertTrue(reused["reused"])
             self.assertNotEqual(influx["sha256"], timescale["sha256"])
 
-    def test_corrupt_artifact_is_rejected(self) -> None:
+    def test_reuse_skips_checksum_verification(self) -> None:
+        with tempfile.TemporaryDirectory() as temp:
+            root = Path(temp)
+            fake = self.make_generator(root, "print('valid')\n")
+            dataset_dir, manifest = self.prepare(root)
+            with mock.patch.object(generate, "GENERATOR", fake):
+                generate.generate_variant(
+                    dataset_dir, manifest, "influx", regenerate=False, rebuild=False
+                )
+                with mock.patch.object(
+                    generate,
+                    "sha256_file",
+                    side_effect=AssertionError("reuse must not hash the artifact"),
+                ):
+                    reused = generate.generate_variant(
+                        dataset_dir,
+                        manifest,
+                        "influx",
+                        regenerate=False,
+                        rebuild=False,
+                    )
+            self.assertTrue(reused["reused"])
+
+    def test_reuse_rejects_artifact_size_mismatch(self) -> None:
+        with tempfile.TemporaryDirectory() as temp:
+            root = Path(temp)
+            fake = self.make_generator(root, "print('valid')\n")
+            dataset_dir, manifest = self.prepare(root)
+            with mock.patch.object(generate, "GENERATOR", fake):
+                result = generate.generate_variant(
+                    dataset_dir, manifest, "influx", regenerate=False, rebuild=False
+                )
+                Path(result["data_path"]).write_text("longer payload\n", encoding="utf-8")
+                with self.assertRaisesRegex(generate.DatasetError, "size mismatch"):
+                    generate.generate_variant(
+                        dataset_dir,
+                        manifest,
+                        "influx",
+                        regenerate=False,
+                        rebuild=False,
+                    )
+
+    def test_explicit_verify_rejects_same_size_corruption(self) -> None:
         with tempfile.TemporaryDirectory() as temp:
             root = Path(temp)
             fake = self.make_generator(root, "print('valid')\n")
             dataset_dir, manifest = self.prepare(root)
             with mock.patch.object(generate, "GENERATOR", fake):
                 result = generate.generate_variant(dataset_dir, manifest, "influx", regenerate=False, rebuild=False)
-            Path(result["data_path"]).write_text("corrupt\n", encoding="utf-8")
+            Path(result["data_path"]).write_text("bad!!\n", encoding="utf-8")
+            verify_args = generate.make_parser().parse_args(
+                ["verify", "--dataset-path", str(dataset_dir), "--format", "influx"]
+            )
             with self.assertRaisesRegex(generate.DatasetError, "checksum mismatch"):
-                generate.validate_variant(dataset_dir, "influx")
+                generate.verify_dataset(verify_args)
 
     def test_failed_regeneration_preserves_completed_artifact(self) -> None:
         with tempfile.TemporaryDirectory() as temp:


### PR DESCRIPTION
## What changed

- use fast structural and byte-size validation when reusing completed cached datasets
- retain full SHA-256 verification in the explicit `generate.py verify` command
- keep checksum generation for new datasets and leave binary/query checksum checks unchanged
- document the reuse and verification behavior

## Why

The benchmark's dataset preparation path recomputed SHA-256 over the entire cached dataset before loading, including before a managed database could determine that the same dataset was already loaded. This made cache reuse unnecessarily slow.

For the existing 2.99 GB dataset, ordinary reuse improved from about 10.1 seconds to about 0.05 seconds.

## Impact

Normal benchmark reuse still validates the manifest, completion status, artifact presence, checksum metadata, and exact byte size. Users who require end-to-end content verification can run `generate.py verify`; same-size corruption remains detectable there.

## Validation

- 14 dataset generator tests
- 16 GreptimeDB benchmark tests
- 22 InfluxDB 3 benchmark tests
- `git diff --check`
- Python bytecode compilation