### PR TITLE
feat: compare GreptimeDB versions on loaded data

### DIFF
--- a/.agents/skills/benchmark-greptimedb/SKILL.md
+++ b/.agents/skills/benchmark-greptimedb/SKILL.md
@@ -15,7 +15,8 @@ verified repository-local fallback.
 
 ## Collect inputs
 
-1. Select a stage: `all`, `generate`, `load`, `query`, or `summarize`.
+1. Select a stage: `all`, `generate`, `load`, `query`, `summarize`, or
+   `compare`.
 2. For `all`, `load`, or `query`, select exactly one target:
    - managed: a prepared reusable `--database-id`; legacy workspaces also need
      an explicit GreptimeDB binary;
@@ -41,6 +42,14 @@ python3 .agents/skills/benchmark-greptimedb/scripts/benchmark.py query \
   --profile smoke --endpoint http://127.0.0.1:4000 --database benchmark \
   --query-count cpu-max-all-1=100 --query-count lastpoint=10
 
+python3 .agents/skills/benchmark-greptimedb/scripts/benchmark.py query \
+  --database-id loaded-db --greptime-version 1.1.4 \
+  --confirm-version-override loaded-db --dataset-id DATASET_ID
+
+python3 .agents/skills/benchmark-greptimedb/scripts/benchmark.py compare \
+  --baseline-run .benchmarks/greptimedb/runs/BASELINE_RUN \
+  --candidate-run .benchmarks/greptimedb/runs/CANDIDATE_RUN
+
 python3 .agents/skills/benchmark-greptimedb/scripts/benchmark.py summarize \
   --run-dir .benchmarks/greptimedb/runs/RUN_ID
 ```
@@ -53,6 +62,26 @@ per-type override must name a selected type. Resolved counts are part of the
 immutable query-set identity. Each selected query file is executed once. Start
 another run to make another measurement.
 
+For a cross-version query on the exact existing data directory, first install
+the alternate release with `$setup-greptimedb`, then pass its exact
+`--greptime-version` and repeat the database ID with
+`--confirm-version-override`. This override is supported only by `query`, uses
+the existing workspace lock, and does not rewrite the workspace's bound
+installation identity. Use `--install-root` for a non-default managed install
+root. Startup can still mutate persistent metadata, so treat confirmation as
+authorization for that compatibility risk.
+
+For an independent copy, use `$setup-greptimedb` to copy the loaded workspace
+to a new database ID bound to the alternate release, then run a normal query
+against the copy. The copy uses independent bytes and additional disk space.
+
+Keep every version measurement in a separate run. Use `compare` with one
+baseline and one or more repeated `--candidate-run` paths. Comparison requires
+managed targets, complete successful query results, and identical SQL database,
+dataset identity/checksum, query-set identity/checksum, membership, query
+counts, and repetitions. Database IDs may differ. A valid comparison is
+report-only and succeeds even when candidates regress.
+
 Query-only commands prepare logical dataset metadata without generating data.
 Use `--dataset-id` or `--dataset-path` to pin a dataset. Shared query sets live
 under `--query-root` and are reused only after exact manifest, membership,
@@ -64,6 +93,8 @@ size, and checksum validation.
   defaults to `.benchmarks/greptimedb/databases`.
 - Prepare new managed workspaces with `$setup-greptimedb`; the benchmark runner
   verifies and discovers their version-bound binary automatically.
+- Query-only version overrides resolve another checksum-validated managed
+  installation and record both runtime and workspace-bound identities.
 - Keep using `--greptime-bin` for legacy workspaces. Never silently adopt a
   legacy workspace into a downloaded installation.
 - Keep one SQL database and one loaded dataset per managed workspace. Reuse a
@@ -80,3 +111,6 @@ Read `summary.json` and report the dataset ID and checksum, query-set ID and
 manifest checksum, database ID or external target, metrics/second and
 rows/second for ingestion, weighted mean latency per query type, failures and
 their log paths, and the run directory. Preserve failed-run diagnostics.
+For comparisons, report the comparison directory, baseline and candidate run
+IDs and versions, improved/unchanged/regressed counts, the largest regression,
+and per-query latency delta, percentage, and candidate/baseline ratio.

--- a/.agents/skills/benchmark-greptimedb/references/workload.md
+++ b/.agents/skills/benchmark-greptimedb/references/workload.md
@@ -11,7 +11,8 @@
 └── greptimedb/
     ├── installations/<version>/<platform>/{manifest.json,greptime,...}
     ├── databases/<database-id>/{manifest.json,data/,logs/}
-    └── runs/<run-id>/{manifest.json,logs/,results/,summary.json,summary.md}
+    ├── runs/<run-id>/{manifest.json,logs/,results/,summary.json,summary.md}
+    └── comparisons/<comparison-id>/{manifest.json,summary.json,summary.md}
 ```
 
 A query-set identity includes the logical dataset identity and specification,
@@ -72,3 +73,24 @@ path, and binary checksum. A matching dataset is reused. A
 different dataset requires a successfully confirmed reset before the binding
 changes. External `create`, `reuse`, and `reset` map to the corresponding TSBS
 loader flags; external reuse may duplicate data.
+
+The database manifest's installation identity describes the version bound when
+the workspace was prepared or copied. A confirmed query-only override does not
+change it. The run target records the actual runtime version and checksum plus
+the workspace-bound identity, making separate runs safe to compare without
+rebinding metadata.
+
+Copied workspaces retain the source dataset binding and record their origin,
+source manifest checksum, full-copy method, and copied file and byte counts.
+They use independent storage and empty log directories.
+
+## Version comparisons
+
+Comparison artifacts use one explicit baseline and one or more candidates.
+They accept different managed database IDs so a source and copied workspace can
+be compared, but reject different SQL database names, datasets, query sets,
+query counts, repetitions, incomplete results, or failures. Per-query results
+contain baseline and candidate weighted means, millisecond and percentage
+deltas, candidate/baseline latency ratios, classifications, and source log
+paths. A zero baseline produces no ratio or percentage unless both values are
+zero. Comparisons report regressions but do not enforce thresholds.

--- a/.agents/skills/benchmark-greptimedb/scripts/benchmark.py
+++ b/.agents/skills/benchmark-greptimedb/scripts/benchmark.py
@@ -47,12 +47,15 @@ from tsbs_benchmark import (  # noqa: E402
     write_streams,
 )
 from tsbs_environment import TsbsEnvironmentError, resolve_go  # noqa: E402
+from compare import ComparisonError, create_comparison  # noqa: E402
 from summarize import write_summary
 
 
 REPO_ROOT = SCRIPT_PATH.parents[4]
 BENCHMARK_ROOT = REPO_ROOT / ".benchmarks"
 DEFAULT_RUN_ROOT = BENCHMARK_ROOT / "greptimedb" / "runs"
+DEFAULT_COMPARISON_ROOT = BENCHMARK_ROOT / "greptimedb" / "comparisons"
+DEFAULT_INSTALL_ROOT = BENCHMARK_ROOT / "greptimedb" / "installations"
 DEFAULT_QUERY_ROOT = BENCHMARK_ROOT / "queries"
 DEFAULT_DATABASE_ROOT = BENCHMARK_ROOT / "greptimedb" / "databases"
 DEFAULT_DATASET_ROOT = BENCHMARK_ROOT / "datasets"
@@ -60,6 +63,7 @@ DATASET_RUNNER = REPO_ROOT / ".agents" / "skills" / "generate-tsbs-data" / "scri
 DEFAULT_DATABASE = "benchmark"
 SCHEMA_VERSION = 1
 ID_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]*$")
+VERSION_RE = re.compile(r"^[0-9]+\.[0-9]+\.[0-9]+(?:[-+][A-Za-z0-9.-]+)?$")
 DATA_WORKLOAD_OPTIONS = ("start", "end", "scale", "seed", "log_interval")
 BINARIES = {"queries": "tsbs_generate_queries", "load": "tsbs_load_greptime", "query": "tsbs_run_queries_influx"}
 BUILT_THIS_PROCESS: set[str] = set()
@@ -393,6 +397,38 @@ def prepare_database_workspace(args: argparse.Namespace) -> tuple[Path, dict[str
 def managed_binary(args: argparse.Namespace, manifest: dict[str, Any]) -> Path:
     prepared_path = manifest.get("installation_path")
     if prepared_path:
+        requested_version = getattr(args, "greptime_version", None)
+        if requested_version:
+            normalized = requested_version[1:] if requested_version.startswith("v") else requested_version
+            if not VERSION_RE.fullmatch(normalized):
+                raise BenchmarkError("--greptime-version must be an exact semantic version")
+            if normalized != manifest["version"] and getattr(args, "confirm_version_override", None) != manifest["database_id"]:
+                raise BenchmarkError("version override requires --confirm-version-override to exactly match --database-id")
+            install_root = (getattr(args, "install_root", None) or DEFAULT_INSTALL_ROOT).expanduser().resolve()
+            installation = install_root / normalized / manifest["platform"]
+            installation_manifest = read_json(installation / "manifest.json")
+            required = {"schema_version", "kind", "version", "platform", "binary", "binary_sha256"}
+            if (
+                installation_manifest.get("schema_version") != 1
+                or installation_manifest.get("kind") != "greptimedb-installation"
+                or not required.issubset(installation_manifest)
+                or installation_manifest["version"] != normalized
+                or installation_manifest["platform"] != manifest["platform"]
+            ):
+                raise BenchmarkError(f"alternate GreptimeDB installation identity mismatch: {installation}")
+            binary = (installation / installation_manifest["binary"]).resolve()
+            if installation.resolve() not in binary.parents:
+                raise BenchmarkError(f"alternate GreptimeDB binary escapes installation: {binary}")
+            if not binary.is_file() or not os.access(binary, os.X_OK) or sha256_file(binary) != installation_manifest["binary_sha256"]:
+                raise BenchmarkError(f"alternate GreptimeDB binary checksum mismatch: {binary}")
+            try:
+                result = subprocess.run([str(binary), "--version"], cwd=installation, capture_output=True, text=True, timeout=15, check=False)
+            except (OSError, subprocess.TimeoutExpired) as exc:
+                raise BenchmarkError(f"alternate GreptimeDB installation is not runnable: {binary}") from exc
+            tokens = re.split(r"\s+", f"{result.stdout}\n{result.stderr}".strip())
+            if result.returncode or not any(token.lstrip("v") == normalized or token.lstrip("v").startswith(normalized + "-") for token in tokens):
+                raise BenchmarkError(f"alternate GreptimeDB binary failed version validation for {normalized}: {binary}")
+            return binary.resolve()
         prepared = Path(prepared_path) / "greptime"
         if args.greptime_bin and args.greptime_bin.expanduser().resolve() != prepared.resolve():
             raise BenchmarkError("--greptime-bin conflicts with the binary bound to the prepared database workspace")
@@ -400,6 +436,35 @@ def managed_binary(args: argparse.Namespace, manifest: dict[str, Any]) -> Path:
     if not args.greptime_bin:
         raise BenchmarkError("legacy managed workspace requires --greptime-bin; prepare it with $setup-greptimedb for automatic binary discovery")
     return args.greptime_bin.expanduser().resolve()
+
+
+def managed_target(args: argparse.Namespace, manifest: dict[str, Any], binary: Path) -> dict[str, Any]:
+    runtime_version = getattr(args, "greptime_version", None)
+    if runtime_version:
+        runtime_version = runtime_version.lstrip("v")
+    else:
+        runtime_version = manifest.get("version")
+    workspace_version = manifest.get("version")
+    workspace_checksum = manifest.get("binary_sha256")
+    runtime_checksum = sha256_file(binary)
+    return {
+        "mode": "managed",
+        "endpoint": f"http://127.0.0.1:{args.http_port}",
+        "database": args.database,
+        "database_id": args.database_id,
+        "version": runtime_version,
+        "binary_sha256": runtime_checksum,
+        "workspace_version": workspace_version,
+        "workspace_binary_sha256": workspace_checksum,
+        "version_override": bool(runtime_version and workspace_version and runtime_version != workspace_version),
+    }
+
+
+def target_matches(existing: dict[str, Any], requested: dict[str, Any]) -> bool:
+    if existing == requested:
+        return True
+    legacy_fields = {"mode", "endpoint", "database", "database_id", "version", "binary_sha256"}
+    return not existing.keys() - legacy_fields and existing == {key: requested.get(key) for key in existing}
 
 
 @contextlib.contextmanager
@@ -439,6 +504,8 @@ def run_queries(args: argparse.Namespace, run_dir: Path, manifest: dict[str, Any
         binding = database_manifest.get("binding")
         if binding is None or binding["dataset_id"] != manifest["dataset"]["dataset_id"] or binding["spec"] != manifest["dataset"]["spec"]:
             raise BenchmarkError("managed database is not loaded with the query set's dataset")
+        manifest["dataset"].update({key: binding[key] for key in ("format", "bytes", "sha256")})
+        save_manifest(run_dir, manifest)
     ensure_binaries(run_dir, ["query"], args.rebuild); workload = manifest["workload"]
     for query_type in set_manifest["spec"]["query_counts"]:
         attempt = next_attempt(manifest["events"]["queries"], query_type); log_path = run_dir / "logs" / f"query-{query_type}-run-{attempt:03d}.log"; result_path = run_dir / "results" / f"query-{query_type}-run-{attempt:03d}.json"
@@ -466,12 +533,19 @@ def check_port_available(port: int) -> None:
 
 
 @contextlib.contextmanager
-def connection(args: argparse.Namespace, run_dir: Path) -> Iterator[tuple[str, bool, dict[str, Any] | None, Path | None]]:
+def connection(args: argparse.Namespace, run_dir: Path, existing_target: dict[str, Any] | None = None) -> Iterator[tuple[str, bool, dict[str, Any] | None, Path | None, dict[str, Any]]]:
     if args.endpoint:
-        yield args.endpoint.rstrip("/"), False, None, None; return
+        endpoint = args.endpoint.rstrip("/")
+        target = {"mode": "external", "endpoint": endpoint, "database": args.database, "database_id": None, "version": None, "binary_sha256": None}
+        if existing_target and not target_matches(existing_target, target):
+            raise BenchmarkError("run target is immutable; create a new run for another GreptimeDB version or target")
+        yield endpoint, False, None, None, target; return
     workspace, database_manifest = prepare_database_workspace(args)
     with lock_database(workspace):
         binary = managed_binary(args, database_manifest)
+        target = managed_target(args, database_manifest, binary)
+        if existing_target and not target_matches(existing_target, target):
+            raise BenchmarkError("run target is immutable; create a new run for another GreptimeDB version or target")
         if not binary.is_file() or not os.access(binary, os.X_OK): raise BenchmarkError(f"GreptimeDB binary is not executable: {binary}")
         check_port_available(args.http_port); endpoint = f"http://127.0.0.1:{args.http_port}"; process_log_path = run_dir / "logs" / "greptimedb-process.log"; process_log = process_log_path.open("a", encoding="utf-8")
         command = [str(binary), "standalone", "start", "--http-addr", f"127.0.0.1:{args.http_port}", "--influxdb-enable", "--data-home", str(workspace / "data"), "--log-dir", str(workspace / "logs")]
@@ -483,7 +557,7 @@ def connection(args: argparse.Namespace, run_dir: Path) -> Iterator[tuple[str, b
                 if endpoint_ready(endpoint): break
                 time.sleep(0.5)
             else: raise BenchmarkError(f"GreptimeDB was not ready within {args.startup_timeout}s; see {process_log_path}")
-            yield endpoint, True, database_manifest, workspace
+            yield endpoint, True, database_manifest, workspace, target
         finally:
             if process.poll() is None:
                 os.killpg(process.pid, signal.SIGTERM)
@@ -505,6 +579,12 @@ def add_connection_options(parser: argparse.ArgumentParser) -> None:
     parser.add_argument("--greptime-bin", type=Path); parser.add_argument("--endpoint"); parser.add_argument("--http-port", type=int, default=4000); parser.add_argument("--startup-timeout", type=int, default=60); parser.add_argument("--database", help=f"SQL database name (default: {DEFAULT_DATABASE})"); parser.add_argument("--database-id"); parser.add_argument("--database-root", type=Path)
 
 
+def add_version_override_options(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument("--greptime-version")
+    parser.add_argument("--install-root", type=Path)
+    parser.add_argument("--confirm-version-override")
+
+
 def add_load_options(parser: argparse.ArgumentParser) -> None:
     parser.add_argument("--database-mode", choices=("create", "reuse", "reset")); parser.add_argument("--confirm-reset")
 
@@ -514,9 +594,10 @@ def make_parser() -> argparse.ArgumentParser:
     build = subparsers.add_parser("build"); build.add_argument("--run-dir", type=Path); build.add_argument("--run-root", type=Path); build.add_argument("--rebuild", action="store_true")
     generate = subparsers.add_parser("generate"); add_run_options(generate); generate.add_argument("--only", choices=("all", "data", "queries"), default="all")
     load = subparsers.add_parser("load"); add_run_options(load); add_connection_options(load); add_load_options(load)
-    query = subparsers.add_parser("query"); add_run_options(query); add_connection_options(query)
+    query = subparsers.add_parser("query"); add_run_options(query); add_connection_options(query); add_version_override_options(query)
     all_command = subparsers.add_parser("all"); add_run_options(all_command); add_connection_options(all_command); add_load_options(all_command)
     summarize = subparsers.add_parser("summarize"); summarize.add_argument("--run-dir", required=True, type=Path)
+    compare = subparsers.add_parser("compare"); compare.add_argument("--baseline-run", required=True, type=Path); compare.add_argument("--candidate-run", required=True, action="append", type=Path); compare.add_argument("--comparison-root", type=Path)
     return parser
 
 
@@ -535,9 +616,13 @@ def validate_args(args: argparse.Namespace) -> None:
         value = getattr(args, name, None)
         if value and not ID_RE.fullmatch(value): raise BenchmarkError(f"--{name.replace('_', '-')} contains invalid characters")
     if args.command in ("load", "query", "all"):
-        if args.endpoint and (args.greptime_bin or args.database_id): raise BenchmarkError("external GreptimeDB cannot use --greptime-bin or --database-id")
+        greptime_version = getattr(args, "greptime_version", None)
+        if args.endpoint and (args.greptime_bin or args.database_id or greptime_version): raise BenchmarkError("external GreptimeDB cannot use managed binary or database options")
         if not args.endpoint and not args.database_id: raise BenchmarkError("provide --database-id for managed GreptimeDB or --endpoint for external GreptimeDB")
         if args.endpoint and args.database_id: raise BenchmarkError("--database-id is only valid with managed GreptimeDB")
+        if greptime_version and args.greptime_bin: raise BenchmarkError("--greptime-version cannot be combined with --greptime-bin")
+        if getattr(args, "install_root", None) and not greptime_version: raise BenchmarkError("--install-root requires --greptime-version")
+        if getattr(args, "confirm_version_override", None) and not greptime_version: raise BenchmarkError("--confirm-version-override requires --greptime-version")
         if args.endpoint:
             parsed = urllib.parse.urlparse(args.endpoint)
             if parsed.scheme not in ("http", "https") or not parsed.netloc: raise BenchmarkError("--endpoint must be an absolute HTTP or HTTPS URL")
@@ -552,6 +637,9 @@ def main(argv: Sequence[str] | None = None) -> int:
         resolve_database(args); validate_args(args)
         if args.command == "summarize":
             run_dir = args.run_dir.resolve(); manifest = read_json(run_dir / "manifest.json"); validate_run_manifest(manifest, run_dir / "manifest.json"); summary = write_summary(run_dir, manifest); print(run_dir / "summary.md"); return 1 if summary["failures"] else 0
+        if args.command == "compare":
+            comparison_dir = create_comparison(args.baseline_run, args.candidate_run, args.comparison_root or DEFAULT_COMPARISON_ROOT)
+            print(f"Comparison directory: {comparison_dir}"); print(f"Summary: {comparison_dir / 'summary.md'}"); return 0
         if args.command == "build":
             run_dir = args.run_dir.resolve() if args.run_dir else new_run_dir((args.run_root or DEFAULT_RUN_ROOT).resolve()); (run_dir / "logs").mkdir(parents=True, exist_ok=True); (run_dir / "results").mkdir(parents=True, exist_ok=True); ensure_binaries(run_dir, list(BINARIES), args.rebuild); print(run_dir); return 0
         run_dir, manifest = prepare_run(args)
@@ -559,12 +647,12 @@ def main(argv: Sequence[str] | None = None) -> int:
             if args.only in ("all", "data"): generate_data(args, run_dir, manifest)
             if args.only in ("all", "queries"): generate_queries(args, run_dir, manifest)
         elif args.command in ("load", "query", "all"):
-            with connection(args, run_dir) as (endpoint, managed, database_manifest, database_path):
-                manifest["target"] = {"mode": "managed" if managed else "external", "endpoint": endpoint, "database": args.database, "database_id": args.database_id if managed else None, "version": database_manifest.get("version") if database_manifest else None, "binary_sha256": database_manifest.get("binary_sha256") if database_manifest else None}; save_manifest(run_dir, manifest)
+            with connection(args, run_dir, manifest.get("target")) as (endpoint, managed, database_manifest, database_path, target):
+                manifest["target"] = target; save_manifest(run_dir, manifest)
                 if args.command in ("load", "all"): load_data(args, run_dir, manifest, endpoint, managed, database_manifest, database_path)
                 if args.command in ("query", "all"): run_queries(args, run_dir, manifest, endpoint, database_manifest)
         summary = write_summary(run_dir, manifest); print(f"Run directory: {run_dir}"); print(f"Summary: {run_dir / 'summary.md'}"); return 1 if summary["failures"] else 0
-    except (BenchmarkError, TsbsEnvironmentError, OSError, json.JSONDecodeError, KeyError, TypeError) as exc:
+    except (BenchmarkError, ComparisonError, TsbsEnvironmentError, OSError, json.JSONDecodeError, KeyError, TypeError) as exc:
         if run_dir is not None and manifest is not None:
             try: write_summary(run_dir, manifest)
             except OSError: pass

--- a/.agents/skills/benchmark-greptimedb/scripts/compare.py
+++ b/.agents/skills/benchmark-greptimedb/scripts/compare.py
@@ -1,0 +1,205 @@
+#!/usr/bin/env python3
+"""Compare compatible GreptimeDB TSBS query benchmark runs."""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import sys
+import tempfile
+from pathlib import Path
+from typing import Any, Sequence
+
+
+SCRIPT_PATH = Path(__file__).resolve()
+sys.path.insert(0, str(SCRIPT_PATH.parents[3] / "lib"))
+
+from tsbs_benchmark import build_summary, new_run_dir, sha256_file, utc_now  # noqa: E402
+
+
+SCHEMA_VERSION = 1
+
+
+class ComparisonError(RuntimeError):
+    """Raised when benchmark runs cannot be compared safely."""
+
+
+def read_manifest(run_dir: Path) -> dict[str, Any]:
+    path = run_dir / "manifest.json"
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except FileNotFoundError as exc:
+        raise ComparisonError(f"missing run manifest: {path}") from exc
+    except json.JSONDecodeError as exc:
+        raise ComparisonError(f"invalid run manifest {path}: {exc}") from exc
+    if not isinstance(value, dict) or value.get("schema_version") != 1 or value.get("kind") != "greptimedb-run":
+        raise ComparisonError(f"unsupported GreptimeDB run manifest: {path}")
+    return value
+
+
+def comparable_identity(manifest: dict[str, Any]) -> dict[str, Any]:
+    dataset = manifest.get("dataset") or {}
+    query_set = manifest.get("query_set") or {}
+    return {
+        "database": manifest.get("database"),
+        "dataset": {key: dataset.get(key) for key in ("dataset_id", "spec", "format", "bytes", "sha256")},
+        "query_set": {key: query_set.get(key) for key in ("query_set_id", "manifest_sha256", "spec")},
+    }
+
+
+def run_for_comparison(run_dir: Path) -> dict[str, Any]:
+    run_dir = run_dir.expanduser().resolve()
+    manifest = read_manifest(run_dir)
+    target = manifest.get("target") or {}
+    if target.get("mode") != "managed" or not target.get("version") or not target.get("binary_sha256"):
+        raise ComparisonError(f"comparison requires a managed run with recorded GreptimeDB version identity: {run_dir}")
+    summary = build_summary(run_dir, manifest)
+    if summary["failures"]:
+        raise ComparisonError(f"comparison run has failures: {run_dir}")
+    expected_counts = ((manifest.get("query_set") or {}).get("spec") or {}).get("query_counts")
+    if not isinstance(expected_counts, dict) or not expected_counts:
+        raise ComparisonError(f"comparison run has no complete query-set identity: {run_dir}")
+    queries = {query["query_type"]: query for query in summary["queries"]}
+    if set(queries) != set(expected_counts):
+        raise ComparisonError(f"comparison run does not have completed results for every query type: {run_dir}")
+    for query_type, expected_count in expected_counts.items():
+        query = queries[query_type]
+        if query["query_count"] != expected_count * query["repetitions"]:
+            raise ComparisonError(f"comparison run has an incomplete result count for {query_type}: {run_dir}")
+    identity = comparable_identity(manifest)
+    dataset = identity["dataset"]
+    query_set = identity["query_set"]
+    if (
+        not isinstance(identity["database"], str)
+        or not identity["database"]
+        or not isinstance(dataset.get("dataset_id"), str)
+        or not isinstance(dataset.get("spec"), dict)
+        or not isinstance(dataset.get("sha256"), str)
+        or dataset.get("bytes") is None
+        or not isinstance(query_set.get("query_set_id"), str)
+        or not isinstance(query_set.get("manifest_sha256"), str)
+        or not isinstance(query_set.get("spec"), dict)
+    ):
+        raise ComparisonError(f"comparison run has incomplete dataset or query-set identity: {run_dir}")
+    return {
+        "path": str(run_dir),
+        "run_id": summary["run_id"],
+        "database_id": target.get("database_id"),
+        "version": target["version"],
+        "binary_sha256": target["binary_sha256"],
+        "manifest_sha256": sha256_file(run_dir / "manifest.json"),
+        "identity": identity,
+        "queries": queries,
+    }
+
+
+def run_identity(run: dict[str, Any]) -> dict[str, Any]:
+    return {key: run[key] for key in ("path", "run_id", "database_id", "version", "binary_sha256", "manifest_sha256")}
+
+
+def compare_candidate(baseline: dict[str, Any], candidate: dict[str, Any]) -> dict[str, Any]:
+    if candidate["identity"] != baseline["identity"]:
+        raise ComparisonError(
+            f"candidate run workload does not match baseline: {candidate['path']}"
+        )
+    comparisons: list[dict[str, Any]] = []
+    for query_type in sorted(baseline["queries"]):
+        base = baseline["queries"][query_type]
+        other = candidate["queries"][query_type]
+        if (base["repetitions"], base["query_count"]) != (other["repetitions"], other["query_count"]):
+            raise ComparisonError(f"candidate query repetitions or count differ for {query_type}: {candidate['path']}")
+        baseline_ms = base["weighted_mean_milliseconds"]
+        candidate_ms = other["weighted_mean_milliseconds"]
+        delta_ms = candidate_ms - baseline_ms
+        if baseline_ms == 0:
+            ratio = 1.0 if candidate_ms == 0 else None
+            delta_percent = 0.0 if candidate_ms == 0 else None
+        else:
+            ratio = candidate_ms / baseline_ms
+            delta_percent = (ratio - 1.0) * 100.0
+        classification = "regressed" if delta_ms > 0 else "improved" if delta_ms < 0 else "unchanged"
+        comparisons.append({
+            "query_type": query_type,
+            "repetitions": base["repetitions"],
+            "query_count": base["query_count"],
+            "baseline_milliseconds": baseline_ms,
+            "candidate_milliseconds": candidate_ms,
+            "delta_milliseconds": delta_ms,
+            "delta_percent": delta_percent,
+            "latency_ratio": ratio,
+            "classification": classification,
+            "baseline_logs": [str(Path(baseline["path"]) / run["log"]) for run in base["runs"]],
+            "candidate_logs": [str(Path(candidate["path"]) / run["log"]) for run in other["runs"]],
+        })
+    counts = {name: sum(item["classification"] == name for item in comparisons) for name in ("improved", "unchanged", "regressed")}
+    regressions = [item for item in comparisons if item["classification"] == "regressed"]
+    largest = max(regressions, key=lambda item: item["delta_percent"] if item["delta_percent"] is not None else float("inf"), default=None)
+    return {
+        **run_identity(candidate),
+        "counts": counts,
+        "largest_regression": None if largest is None else {
+            key: largest[key] for key in ("query_type", "delta_milliseconds", "delta_percent", "latency_ratio")
+        },
+        "queries": comparisons,
+    }
+
+
+def render_markdown(summary: dict[str, Any]) -> str:
+    baseline = summary["baseline"]
+    lines = [
+        f"# GreptimeDB version comparison: {summary['comparison_id']}", "",
+        f"- Baseline: `{baseline['version']}` (`{baseline['run_id']}`)",
+        f"- Baseline run: `{baseline['path']}`", "",
+    ]
+    for candidate in summary["candidates"]:
+        lines.extend([
+            f"## Candidate `{candidate['version']}` (`{candidate['run_id']}`)", "",
+            f"- Candidate run: `{candidate['path']}`",
+            f"- Improved: {candidate['counts']['improved']}; unchanged: {candidate['counts']['unchanged']}; regressed: {candidate['counts']['regressed']}", "",
+            "| Query type | Baseline (ms) | Candidate (ms) | Delta (ms) | Delta (%) | Latency ratio | Result |",
+            "| --- | ---: | ---: | ---: | ---: | ---: | --- |",
+        ])
+        for query in candidate["queries"]:
+            percent = "-" if query["delta_percent"] is None else f"{query['delta_percent']:.2f}%"
+            ratio = "-" if query["latency_ratio"] is None else f"{query['latency_ratio']:.3f}x"
+            lines.append(
+                f"| `{query['query_type']}` | {query['baseline_milliseconds']:.3f} | "
+                f"{query['candidate_milliseconds']:.3f} | {query['delta_milliseconds']:.3f} | "
+                f"{percent} | {ratio} | {query['classification']} |"
+            )
+        if candidate["largest_regression"]:
+            largest = candidate["largest_regression"]
+            percent = "undefined" if largest["delta_percent"] is None else f"{largest['delta_percent']:.2f}%"
+            lines.extend(["", f"Largest regression: `{largest['query_type']}` ({percent})."])
+        lines.append("")
+    return "\n".join(lines)
+
+
+def create_comparison(baseline_path: Path, candidate_paths: Sequence[Path], comparison_root: Path) -> Path:
+    if not candidate_paths:
+        raise ComparisonError("provide at least one --candidate-run")
+    baseline = run_for_comparison(baseline_path)
+    candidates = [compare_candidate(baseline, run_for_comparison(path)) for path in candidate_paths]
+    destination = new_run_dir(comparison_root.expanduser().resolve())
+    temporary = Path(tempfile.mkdtemp(prefix=f".{destination.name}-", dir=destination.parent))
+    try:
+        summary = {
+            "schema_version": SCHEMA_VERSION,
+            "kind": "greptimedb-comparison",
+            "comparison_id": destination.name,
+            "created_at": utc_now(),
+            "database": baseline["identity"]["database"],
+            "dataset": baseline["identity"]["dataset"],
+            "query_set": baseline["identity"]["query_set"],
+            "baseline": run_identity(baseline),
+            "candidates": candidates,
+        }
+        (temporary / "manifest.json").write_text(json.dumps({key: value for key, value in summary.items() if key != "candidates"} | {"candidate_runs": [run_identity(candidate) for candidate in candidates]}, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+        (temporary / "summary.json").write_text(json.dumps(summary, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+        (temporary / "summary.md").write_text(render_markdown(summary), encoding="utf-8")
+        os.replace(temporary, destination)
+        return destination
+    finally:
+        if temporary.exists():
+            shutil.rmtree(temporary)

--- a/.agents/skills/benchmark-greptimedb/scripts/summarize.py
+++ b/.agents/skills/benchmark-greptimedb/scripts/summarize.py
@@ -35,9 +35,14 @@ def render_markdown(summary: dict[str, Any]) -> str:
         target_name = target.get("database_id") or target.get("endpoint")
         lines.append(f"- Benchmark target: `{target.get('mode')}:{target_name}`")
         if target.get("version"):
-            lines.append(f"- GreptimeDB version: `{target.get('version')}`")
+            label = "Runtime GreptimeDB version" if target.get("version_override") else "GreptimeDB version"
+            lines.append(f"- {label}: `{target.get('version')}`")
         if target.get("binary_sha256"):
-            lines.append(f"- GreptimeDB binary SHA-256: `{target.get('binary_sha256')}`")
+            label = "Runtime GreptimeDB binary SHA-256" if target.get("version_override") else "GreptimeDB binary SHA-256"
+            lines.append(f"- {label}: `{target.get('binary_sha256')}`")
+        if target.get("version_override"):
+            lines.append(f"- Workspace-bound GreptimeDB version: `{target.get('workspace_version')}`")
+            lines.append(f"- Workspace-bound binary SHA-256: `{target.get('workspace_binary_sha256')}`")
     dataset = summary.get("dataset")
     if dataset:
         lines.extend(

--- a/.agents/skills/benchmark-greptimedb/tests/test_benchmark.py
+++ b/.agents/skills/benchmark-greptimedb/tests/test_benchmark.py
@@ -13,6 +13,7 @@ SCRIPTS = Path(__file__).resolve().parents[1] / "scripts"
 sys.path.insert(0, str(SCRIPTS))
 
 import benchmark  # noqa: E402
+import compare as version_compare  # noqa: E402
 import summarize  # noqa: E402
 
 
@@ -41,6 +42,20 @@ class SummaryIntegrationTests(unittest.TestCase):
         self.assertIn("GreptimeDB binary SHA-256: `def`", rendered)
         self.assertIn("set-a", rendered)
 
+    def test_version_override_identity_is_rendered(self) -> None:
+        summary = {
+            "run_id": "run", "profile": "smoke", "database": "benchmark",
+            "target": {
+                "mode": "managed", "database_id": "db-a", "version": "1.0.0",
+                "binary_sha256": "old", "workspace_version": "1.1.4",
+                "workspace_binary_sha256": "new", "version_override": True,
+            },
+            "ingestion_runs": [], "queries": [], "failures": [],
+        }
+        rendered = summarize.render_markdown(summary)
+        self.assertIn("Runtime GreptimeDB version: `1.0.0`", rendered)
+        self.assertIn("Workspace-bound GreptimeDB version: `1.1.4`", rendered)
+
 
 class QuerySetIdentityTests(unittest.TestCase):
     def dataset(self) -> dict:
@@ -60,6 +75,74 @@ class QuerySetIdentityTests(unittest.TestCase):
         subset = benchmark.query_set_spec(self.dataset(), self.workload({"lastpoint": 3}))
         self.assertNotEqual(benchmark.query_set_id(first), benchmark.query_set_id(changed_count))
         self.assertNotEqual(benchmark.query_set_id(first), benchmark.query_set_id(subset))
+
+
+class VersionComparisonTests(unittest.TestCase):
+    def make_run(self, root: Path, name: str, version: str, means: dict[str, float], *, dataset_id: str = "data-a") -> Path:
+        run_dir = root / name; (run_dir / "results").mkdir(parents=True); (run_dir / "logs").mkdir()
+        query_counts = {query_type: 10 for query_type in means}
+        events = []
+        for query_type, mean in means.items():
+            result = run_dir / "results" / f"{query_type}.json"
+            result.write_text(json.dumps({"ResultFormatVersion": "0.2", "Totals": {"overallStats": {"all_queries": {"meanMilliseconds": mean, "count": 10}}}}), encoding="utf-8")
+            log = run_dir / "logs" / f"{query_type}.log"; log.write_text("completed\n", encoding="utf-8")
+            events.append({
+                "query_type": query_type, "attempt": 1, "database": "benchmark",
+                "log": f"logs/{query_type}.log", "results": f"results/{query_type}.json",
+                "status": "completed",
+            })
+        manifest = {
+            "schema_version": 1, "kind": "greptimedb-run", "run_id": name,
+            "created_at": benchmark.utc_now(), "profile": "manual", "database": "benchmark",
+            "workload": {"query_counts": query_counts},
+            "target": {"mode": "managed", "database_id": f"db-{version}", "version": version, "binary_sha256": version * 4},
+            "dataset": {"dataset_id": dataset_id, "spec": {"scale": 10}, "format": "influx", "bytes": 100, "sha256": "d" * 64},
+            "query_set": {"query_set_id": "set-a", "manifest_sha256": "q" * 64, "spec": {"query_counts": query_counts}},
+            "events": {"loads": [], "queries": events},
+        }
+        benchmark.save_json(run_dir / "manifest.json", manifest)
+        return run_dir
+
+    def test_compares_saved_runs_and_writes_immutable_report(self) -> None:
+        with tempfile.TemporaryDirectory() as temp:
+            root = Path(temp)
+            baseline = self.make_run(root, "baseline", "1.1.4", {"lastpoint": 10.0, "high-cpu-1": 20.0})
+            candidate = self.make_run(root, "candidate", "1.0.0", {"lastpoint": 12.0, "high-cpu-1": 10.0})
+            output = version_compare.create_comparison(baseline, [candidate], root / "comparisons")
+            summary = json.loads((output / "summary.json").read_text())
+            by_type = {item["query_type"]: item for item in summary["candidates"][0]["queries"]}
+            self.assertAlmostEqual(by_type["lastpoint"]["delta_percent"], 20.0)
+            self.assertEqual(by_type["lastpoint"]["classification"], "regressed")
+            self.assertEqual(by_type["high-cpu-1"]["classification"], "improved")
+            self.assertEqual(summary["candidates"][0]["counts"], {"improved": 1, "unchanged": 0, "regressed": 1})
+            self.assertTrue((output / "manifest.json").is_file())
+            self.assertIn("Latency ratio", (output / "summary.md").read_text())
+            second = version_compare.create_comparison(baseline, [candidate], root / "comparisons")
+            self.assertNotEqual(output, second)
+
+    def test_rejects_mismatched_or_incomplete_runs(self) -> None:
+        with tempfile.TemporaryDirectory() as temp:
+            root = Path(temp)
+            baseline = self.make_run(root, "baseline", "1.1.4", {"lastpoint": 10.0})
+            mismatch = self.make_run(root, "mismatch", "1.0.0", {"lastpoint": 12.0}, dataset_id="data-b")
+            with self.assertRaisesRegex(version_compare.ComparisonError, "does not match"):
+                version_compare.create_comparison(baseline, [mismatch], root / "comparisons")
+            incomplete = self.make_run(root, "incomplete", "1.0.0", {"lastpoint": 12.0})
+            manifest = json.loads((incomplete / "manifest.json").read_text())
+            manifest["events"]["queries"][0]["status"] = "failed"
+            benchmark.save_json(incomplete / "manifest.json", manifest)
+            with self.assertRaisesRegex(version_compare.ComparisonError, "failures"):
+                version_compare.create_comparison(baseline, [incomplete], root / "comparisons")
+
+    def test_zero_baseline_latency_has_no_infinite_ratio(self) -> None:
+        with tempfile.TemporaryDirectory() as temp:
+            root = Path(temp)
+            baseline = self.make_run(root, "baseline", "1.1.4", {"lastpoint": 0.0})
+            candidate = self.make_run(root, "candidate", "1.0.0", {"lastpoint": 1.0})
+            output = version_compare.create_comparison(baseline, [candidate], root / "comparisons")
+            query = json.loads((output / "summary.json").read_text())["candidates"][0]["queries"][0]
+            self.assertIsNone(query["delta_percent"])
+            self.assertIsNone(query["latency_ratio"])
 
 
 class WorkspaceTests(unittest.TestCase):
@@ -213,11 +296,16 @@ class QuerySetTests(unittest.TestCase):
                 benchmark.generate_queries(args, run_dir, manifest)
             def execute(_command, log_path, **_kwargs):
                 log_path.write_text("Run complete after 1 queries\nall queries:\nmin: 1ms, mean: 1ms, max: 1ms, count: 1\n", encoding="utf-8")
+            binding = {
+                "dataset_id": manifest["dataset"]["dataset_id"], "spec": manifest["dataset"]["spec"],
+                "format": "influx", "bytes": 123, "sha256": "d" * 64,
+            }
             with mock.patch.object(benchmark, "generate_queries", return_value=Path(manifest["query_set"]["query_set_path"])), mock.patch.object(benchmark, "ensure_binaries"), mock.patch.object(benchmark, "run_tee", side_effect=execute) as runner:
-                benchmark.run_queries(args, run_dir, manifest, "http://localhost:4000")
+                benchmark.run_queries(args, run_dir, manifest, "http://localhost:4000", {"binding": binding})
             self.assertEqual(runner.call_count, 2)
             self.assertEqual(len(manifest["events"]["queries"]), 2)
             self.assertTrue(all(event["file_sha256"] for event in manifest["events"]["queries"]))
+            self.assertEqual(manifest["dataset"]["sha256"], "d" * 64)
 
 
 class BuildEnvironmentTests(unittest.TestCase):
@@ -314,6 +402,53 @@ class ManagedDatabaseTests(unittest.TestCase):
             with self.assertRaisesRegex(benchmark.BenchmarkError, "does not exist"):
                 benchmark.prepare_database_workspace(args)
             self.assertFalse((root / "db-a").exists())
+
+    def test_query_can_use_confirmed_installed_version_without_rebinding_workspace(self) -> None:
+        with tempfile.TemporaryDirectory() as temp:
+            root = Path(temp)
+            bound_installation = root / "installations/1.1.4/linux_amd64"; bound_installation.mkdir(parents=True)
+            bound_binary = bound_installation / "greptime"; bound_binary.write_text("#!/bin/sh\necho 'greptime 1.1.4'\n", encoding="utf-8"); bound_binary.chmod(0o755)
+            alternate = root / "installations/1.0.0/linux_amd64"; alternate.mkdir(parents=True)
+            alternate_binary = alternate / "greptime"; alternate_binary.write_text("#!/bin/sh\necho 'greptime 1.0.0'\n", encoding="utf-8"); alternate_binary.chmod(0o755)
+            benchmark.save_json(alternate / "manifest.json", {
+                "schema_version": 1, "kind": "greptimedb-installation", "version": "1.0.0",
+                "platform": "linux_amd64", "binary": "greptime",
+                "binary_sha256": benchmark.sha256_file(alternate_binary),
+            })
+            database = root / "databases/db-a"; (database / "data").mkdir(parents=True); (database / "logs").mkdir()
+            original = {
+                "schema_version": 1, "kind": "greptimedb-database", "database_id": "db-a",
+                "created_at": benchmark.utc_now(), "database": "benchmark", "binding": None,
+                "version": "1.1.4", "version_source": "explicit", "platform": "linux_amd64",
+                "installation_path": str(bound_installation), "binary_sha256": benchmark.sha256_file(bound_binary),
+            }
+            benchmark.save_json(database / "manifest.json", original)
+            args = benchmark.make_parser().parse_args([
+                "query", "--database-id", "db-a", "--database-root", str(root / "databases"),
+                "--database", "benchmark", "--greptime-version", "1.0.0",
+                "--install-root", str(root / "installations"), "--confirm-version-override", "db-a",
+            ])
+            manifest = benchmark.validate_database_manifest(database, "db-a")
+            binary = benchmark.managed_binary(args, manifest)
+            target = benchmark.managed_target(args, manifest, binary)
+            self.assertEqual(binary, alternate_binary.resolve())
+            self.assertEqual(target["version"], "1.0.0")
+            self.assertEqual(target["workspace_version"], "1.1.4")
+            self.assertTrue(target["version_override"])
+            self.assertEqual(json.loads((database / "manifest.json").read_text()), original)
+
+            args.confirm_version_override = "wrong"
+            with self.assertRaisesRegex(benchmark.BenchmarkError, "exactly match"):
+                benchmark.managed_binary(args, manifest)
+
+    def test_version_override_is_query_only_and_managed_only(self) -> None:
+        parser = benchmark.make_parser()
+        with self.assertRaises(SystemExit):
+            parser.parse_args(["load", "--database-id", "db-a", "--greptime-version", "1.0.0"])
+        args = parser.parse_args(["query", "--endpoint", "http://localhost:4000", "--greptime-version", "1.0.0"])
+        benchmark.resolve_database(args)
+        with self.assertRaisesRegex(benchmark.BenchmarkError, "external GreptimeDB"):
+            benchmark.validate_args(args)
 
 
 if __name__ == "__main__":

--- a/.agents/skills/setup-greptimedb/SKILL.md
+++ b/.agents/skills/setup-greptimedb/SKILL.md
@@ -45,6 +45,32 @@ command execution time and never upgrades an existing workspace automatically.
 Do not adopt or rewrite a legacy benchmark workspace; continue using it with an
 explicit binary or choose a new database ID.
 
+## Copy a loaded workspace for another version
+
+Install the target version first, then create a fully independent database
+copy:
+
+```bash
+python3 .agents/skills/setup-greptimedb/scripts/setup.py install \
+  --version 1.1.4
+
+python3 .agents/skills/setup-greptimedb/scripts/setup.py copy \
+  --source-database-id loaded-current \
+  --database-id loaded-114 \
+  --version 1.1.4
+```
+
+The source must be a loaded setup-managed workspace and the destination must
+not exist. The command locks the source, fully copies `data/` without reflinks
+or hard links, creates empty logs, preserves the SQL database and dataset
+binding, records copy provenance, and publishes atomically. It never overwrites
+or resumes a destination. Manually started GreptimeDB processes do not
+participate in the cooperative workspace lock.
+
+Use `$benchmark-greptimedb` to query the copied database ID. For an exact-path
+comparison without a copy, use that skill's confirmed query-only runtime
+version override instead.
+
 ## Inspect and verify
 
 ```bash

--- a/.agents/skills/setup-greptimedb/references/setup.md
+++ b/.agents/skills/setup-greptimedb/references/setup.md
@@ -28,3 +28,18 @@ Prepared manifests bind the database ID, SQL database name, release version,
 platform, installation path, and binary checksum. Dataset binding remains owned
 by the benchmark skill. Legacy benchmark manifests intentionally lack release
 identity and require an explicit `--greptime-bin`.
+
+A copied workspace is prepared from a loaded managed source while holding the
+same cooperative directory lock used by the benchmark runner. Only `data/` is
+copied; logs start empty. The destination uses a new database ID and target
+installation identity while preserving the source SQL database and dataset
+binding. Copying is full and independent: symbolic links and other special
+entries in `data/` are rejected, and reflinks and hard links are not used. The
+destination is staged beside the database root and atomically published only
+after file counts and byte counts match.
+
+Copy provenance records the source database ID and path, version and binary
+checksum, source manifest checksum, timestamp, method, file count, and byte
+count. The target version must be exact and already installed. Copying does not
+assert that GreptimeDB supports downgrade or upgrade startup for those data
+files.

--- a/.agents/skills/setup-greptimedb/scripts/setup.py
+++ b/.agents/skills/setup-greptimedb/scripts/setup.py
@@ -4,7 +4,9 @@
 from __future__ import annotations
 
 import argparse
+import contextlib
 import datetime as dt
+import fcntl
 import hashlib
 import json
 import os
@@ -18,7 +20,7 @@ import tempfile
 import urllib.error
 import urllib.request
 from pathlib import Path, PurePosixPath
-from typing import Any, Sequence
+from typing import Any, Iterator, Sequence
 
 
 SCRIPT_PATH = Path(__file__).resolve()
@@ -310,6 +312,34 @@ def database_path(args: argparse.Namespace) -> Path:
     return (args.database_root or DEFAULT_DATABASE_ROOT).expanduser().resolve() / args.database_id
 
 
+@contextlib.contextmanager
+def lock_database(path: Path) -> Iterator[None]:
+    descriptor = os.open(path, os.O_RDONLY)
+    try:
+        try:
+            fcntl.flock(descriptor, fcntl.LOCK_EX | fcntl.LOCK_NB)
+        except BlockingIOError as exc:
+            raise SetupError(f"managed database workspace is locked: {path}") from exc
+        yield
+    finally:
+        fcntl.flock(descriptor, fcntl.LOCK_UN)
+        os.close(descriptor)
+
+
+def copy_tree_stats(path: Path) -> tuple[int, int]:
+    files = 0
+    size = 0
+    for entry in path.rglob("*"):
+        if entry.is_symlink():
+            raise SetupError(f"database data directory contains unsupported symlink: {entry}")
+        if entry.is_file():
+            files += 1
+            size += entry.stat().st_size
+        elif not entry.is_dir():
+            raise SetupError(f"database data directory contains unsupported entry: {entry}")
+    return files, size
+
+
 def validate_database(path: Path, expected_id: str | None = None) -> dict[str, Any]:
     manifest = read_json(path / "manifest.json")
     required = {
@@ -350,6 +380,71 @@ def prepare(args: argparse.Namespace) -> dict[str, Any]:
     return {**manifest, "database_path": str(path), "reused": False}
 
 
+def copy_database(args: argparse.Namespace) -> dict[str, Any]:
+    root = (args.database_root or DEFAULT_DATABASE_ROOT).expanduser().resolve()
+    source = root / args.source_database_id
+    destination = root / args.database_id
+    if source == destination:
+        raise SetupError("source and destination database IDs must differ")
+    if destination.exists():
+        raise SetupError(f"destination database workspace already exists: {destination}")
+
+    installed = validate_installation(installation_path(args), args.version)
+
+    root.mkdir(parents=True, exist_ok=True)
+    temporary = Path(tempfile.mkdtemp(prefix=f".{args.database_id}.copy-", dir=root))
+    try:
+        with lock_database(source):
+            source_manifest = validate_database(source, args.source_database_id)
+            if source_manifest["binding"] is None:
+                raise SetupError("source database workspace has no loaded dataset binding")
+            if installed["platform"] != source_manifest["platform"]:
+                raise SetupError("target installation platform differs from the source database platform")
+            source_data = source / "data"
+            if not source_data.is_dir():
+                raise SetupError(f"source database data directory does not exist: {source_data}")
+            file_count, byte_count = copy_tree_stats(source_data)
+            shutil.copytree(source_data, temporary / "data", copy_function=shutil.copy2)
+            copied_files, copied_bytes = copy_tree_stats(temporary / "data")
+            if (copied_files, copied_bytes) != (file_count, byte_count):
+                raise SetupError("copied database data does not match source file count and size")
+            (temporary / "logs").mkdir()
+            copied_at = utc_now()
+            manifest = {
+                "schema_version": SCHEMA_VERSION,
+                "kind": "greptimedb-database",
+                "database_id": args.database_id,
+                "version": args.version,
+                "version_source": args.version_source,
+                "platform": installed["platform"],
+                "installation_path": str(installation_path(args)),
+                "binary_sha256": installed["binary_sha256"],
+                "created_at": copied_at,
+                "updated_at": copied_at,
+                "database": source_manifest["database"],
+                "binding": source_manifest["binding"],
+                "copied_from": {
+                    "database_id": source_manifest["database_id"],
+                    "database_path": str(source),
+                    "version": source_manifest["version"],
+                    "binary_sha256": source_manifest["binary_sha256"],
+                    "manifest_sha256": sha256_file(source / "manifest.json"),
+                    "copied_at": copied_at,
+                    "method": "full",
+                    "files": copied_files,
+                    "bytes": copied_bytes,
+                },
+            }
+            save_json(temporary / "manifest.json", manifest)
+            if destination.exists():
+                raise SetupError(f"destination database workspace already exists: {destination}")
+            os.replace(temporary, destination)
+        return {**manifest, "database_path": str(destination), "reused": False}
+    finally:
+        if temporary.exists():
+            shutil.rmtree(temporary)
+
+
 def print_value(value: Any) -> None:
     print(json.dumps(value, indent=2, sort_keys=True))
 
@@ -358,6 +453,7 @@ def make_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description=__doc__); sub = parser.add_subparsers(dest="command", required=True)
     install_parser = sub.add_parser("install"); install_parser.add_argument("--version"); install_parser.add_argument("--install-root", type=Path); install_parser.add_argument("--reinstall", action="store_true")
     prepare_parser = sub.add_parser("prepare"); prepare_parser.add_argument("--database-id", required=True); prepare_parser.add_argument("--version"); prepare_parser.add_argument("--database", default="benchmark"); prepare_parser.add_argument("--install-root", type=Path); prepare_parser.add_argument("--database-root", type=Path)
+    copy_parser = sub.add_parser("copy"); copy_parser.add_argument("--source-database-id", required=True); copy_parser.add_argument("--database-id", required=True); copy_parser.add_argument("--version", required=True); copy_parser.add_argument("--install-root", type=Path); copy_parser.add_argument("--database-root", type=Path)
     list_parser = sub.add_parser("list"); list_parser.add_argument("--database-root", type=Path)
     inspect_parser = sub.add_parser("inspect"); inspect_parser.add_argument("--database-id", required=True); inspect_parser.add_argument("--database-root", type=Path)
     verify_parser = sub.add_parser("verify"); verify_parser.add_argument("--database-id", required=True); verify_parser.add_argument("--database-root", type=Path)
@@ -369,6 +465,8 @@ def validate_args(args: argparse.Namespace) -> None:
         normalize_version(args.version)
     if hasattr(args, "database_id") and not ID_RE.fullmatch(args.database_id):
         raise SetupError("--database-id contains invalid characters")
+    if hasattr(args, "source_database_id") and not ID_RE.fullmatch(args.source_database_id):
+        raise SetupError("--source-database-id contains invalid characters")
     if hasattr(args, "database") and (not args.database or "\x00" in args.database):
         raise SetupError("--database must not be empty or contain NUL")
 
@@ -377,12 +475,14 @@ def main(argv: Sequence[str] | None = None) -> int:
     args = make_parser().parse_args(argv)
     try:
         validate_args(args)
-        if args.command in ("install", "prepare"):
+        if args.command in ("install", "prepare", "copy"):
             resolve_args_version(args)
         if args.command == "install":
             value = install(args)
         elif args.command == "prepare":
             value = prepare(args)
+        elif args.command == "copy":
+            value = copy_database(args)
         elif args.command in ("inspect", "verify"):
             path = database_path(args); value = {**validate_database(path, args.database_id), "database_path": str(path)}
         else:

--- a/.agents/skills/setup-greptimedb/tests/test_setup.py
+++ b/.agents/skills/setup-greptimedb/tests/test_setup.py
@@ -114,11 +114,11 @@ class InstallationTests(unittest.TestCase):
 
 
 class DatabaseTests(unittest.TestCase):
-    def make_installation(self, root: Path) -> Path:
-        path = root / "installations/1.1.4/linux_amd64"; path.mkdir(parents=True)
-        binary = path / "greptime"; binary.write_text("#!/bin/sh\necho 'greptime 1.1.4'\n", encoding="utf-8"); binary.chmod(0o755)
+    def make_installation(self, root: Path, version: str = "1.1.4") -> Path:
+        path = root / f"installations/{version}/linux_amd64"; path.mkdir(parents=True)
+        binary = path / "greptime"; binary.write_text(f"#!/bin/sh\necho 'greptime {version}'\n", encoding="utf-8"); binary.chmod(0o755)
         manifest = {
-            "schema_version": 1, "kind": "greptimedb-installation", "version": "1.1.4",
+            "schema_version": 1, "kind": "greptimedb-installation", "version": version,
             "version_source": "explicit", "platform": "linux_amd64", "binary": "greptime",
             "binary_sha256": setup.sha256_file(binary), "archive_sha256": "a" * 64,
             "distribution_sha256": setup.distribution_sha256(path),
@@ -147,6 +147,61 @@ class DatabaseTests(unittest.TestCase):
             setup.save_json(path / "manifest.json", {"schema_version": 1, "kind": "greptimedb-database", "database_id": "db-a", "database": "benchmark", "binding": None})
             with mock.patch.object(setup, "platform_tag", return_value="linux_amd64"), self.assertRaisesRegex(setup.SetupError, "legacy"):
                 setup.prepare(self.args(root))
+
+    def test_copy_loaded_database_to_an_independent_version_bound_workspace(self) -> None:
+        with tempfile.TemporaryDirectory() as temp:
+            root = Path(temp); self.make_installation(root); self.make_installation(root, "1.0.0")
+            with mock.patch.object(setup, "platform_tag", return_value="linux_amd64"):
+                prepared = setup.prepare(self.args(root))
+            source = Path(prepared["database_path"])
+            source_file = source / "data/region/file.parquet"
+            source_file.parent.mkdir(parents=True); source_file.write_bytes(b"loaded-data")
+            manifest = setup.read_json(source / "manifest.json")
+            manifest["binding"] = {
+                "dataset_id": "data-a", "spec": {"scale": 10}, "format": "influx",
+                "bytes": 11, "sha256": "a" * 64,
+            }
+            setup.save_json(source / "manifest.json", manifest)
+            args = argparse.Namespace(
+                source_database_id="db-a", database_id="db-old", version="1.0.0",
+                version_source="explicit", install_root=root / "installations",
+                database_root=root / "databases",
+            )
+
+            with mock.patch.object(setup, "platform_tag", return_value="linux_amd64"):
+                result = setup.copy_database(args)
+
+            destination = Path(result["database_path"])
+            copied = setup.validate_database(destination, "db-old")
+            self.assertEqual(copied["version"], "1.0.0")
+            self.assertEqual(copied["binding"], manifest["binding"])
+            self.assertEqual(copied["copied_from"]["method"], "full")
+            self.assertEqual(copied["copied_from"]["files"], 1)
+            self.assertEqual(list((destination / "logs").iterdir()), [])
+            self.assertNotEqual(source_file.stat().st_ino, (destination / "data/region/file.parquet").stat().st_ino)
+            (destination / "data/region/file.parquet").write_bytes(b"changed")
+            self.assertEqual(source_file.read_bytes(), b"loaded-data")
+
+    def test_copy_rejects_unloaded_existing_and_locked_workspaces(self) -> None:
+        with tempfile.TemporaryDirectory() as temp:
+            root = Path(temp); self.make_installation(root); self.make_installation(root, "1.0.0")
+            with mock.patch.object(setup, "platform_tag", return_value="linux_amd64"):
+                source = Path(setup.prepare(self.args(root))["database_path"])
+            args = argparse.Namespace(
+                source_database_id="db-a", database_id="db-old", version="1.0.0",
+                version_source="explicit", install_root=root / "installations",
+                database_root=root / "databases",
+            )
+            with mock.patch.object(setup, "platform_tag", return_value="linux_amd64"), self.assertRaisesRegex(setup.SetupError, "no loaded dataset"):
+                setup.copy_database(args)
+            manifest = setup.read_json(source / "manifest.json")
+            manifest["binding"] = {"dataset_id": "a", "spec": {}, "format": "influx", "bytes": 0, "sha256": "a"}
+            setup.save_json(source / "manifest.json", manifest)
+            with setup.lock_database(source), mock.patch.object(setup, "platform_tag", return_value="linux_amd64"), self.assertRaisesRegex(setup.SetupError, "locked"):
+                setup.copy_database(args)
+            (root / "databases/db-old").mkdir()
+            with mock.patch.object(setup, "platform_tag", return_value="linux_amd64"), self.assertRaisesRegex(setup.SetupError, "already exists"):
+                setup.copy_database(args)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## What changed

- add a confirmed, query-only runtime version override for managed GreptimeDB workspaces
- add atomic full-copy creation of loaded workspaces bound to another installed version
- add immutable saved-run comparison reports with per-query latency deltas and regression classifications
- record runtime/workspace binary provenance and enrich query runs with the loaded dataset checksum
- document both cross-version workflows and their compatibility risks

## Why

Performance regressions need to be reproduced against the same loaded state without re-ingesting data. This supports both exact-path testing and isolated full-copy testing while keeping each measurement in an independent run.

## Impact

The change is limited to the GreptimeDB setup and benchmark skills. In-place overrides require explicit database-ID confirmation and are restricted to query runs. Comparisons reject mismatched or incomplete workloads and remain report-only.

## Validation

- `python3 -m unittest discover -s .agents/skills/setup-greptimedb/tests -v` (10 tests)
- `python3 -m unittest discover -s .agents/skills/benchmark-greptimedb/tests -v` (22 tests)
- `python3 -m py_compile ...`
- `git diff --check`