### PR TITLE
feat: add GreptimeDB explain analysis mode

### DIFF
--- a/.agents/skills/benchmark-greptimedb/SKILL.md
+++ b/.agents/skills/benchmark-greptimedb/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: benchmark-greptimedb
-description: Run repeatable GreptimeDB TSBS benchmarks with shared datasets, complete immutable query sets, reusable managed database workspaces, independent run logs, ingestion rates, and query-latency summaries. Use for GreptimeDB smoke or performance tests, ingestion measurements, query comparisons, managed local instances, or external GreptimeDB endpoints.
+description: Run repeatable GreptimeDB TSBS benchmarks and collect cold and hot EXPLAIN ANALYZE VERBOSE results with shared datasets, immutable query sets, reusable managed database workspaces, independent run logs, ingestion rates, and query summaries. Use for GreptimeDB smoke or performance tests, query analysis, ingestion measurements, query comparisons, managed local instances, or external GreptimeDB endpoints.
 ---
 
 # Benchmark GreptimeDB
@@ -15,12 +15,14 @@ verified repository-local fallback.
 
 ## Collect inputs
 
-1. Select a stage: `all`, `generate`, `load`, `query`, `summarize`, or
-   `compare`.
+1. Select a stage: `all`, `generate`, `load`, `query`, `analyze`, `summarize`,
+   or `compare`.
 2. For `all`, `load`, or `query`, select exactly one target:
    - managed: a prepared reusable `--database-id`; legacy workspaces also need
      an explicit GreptimeDB binary;
    - external: an HTTP endpoint.
+   `analyze` requires a managed target because it restarts GreptimeDB before
+   every selected query type.
 3. Select the SQL `--database`. For external loads, also select `create`,
    `reuse`, or explicitly confirmed `reset`. Never infer reset authorization.
 4. Use the `manual` profile unless the user requests `smoke` or overrides.
@@ -46,6 +48,9 @@ python3 .agents/skills/benchmark-greptimedb/scripts/benchmark.py query \
   --database-id loaded-db --greptime-version 1.1.4 \
   --confirm-version-override loaded-db --dataset-id DATASET_ID
 
+python3 .agents/skills/benchmark-greptimedb/scripts/benchmark.py analyze \
+  --profile smoke --database-id loaded-db --hot-runs 2
+
 python3 .agents/skills/benchmark-greptimedb/scripts/benchmark.py compare \
   --baseline-run .benchmarks/greptimedb/runs/BASELINE_RUN \
   --candidate-run .benchmarks/greptimedb/runs/CANDIDATE_RUN
@@ -62,14 +67,30 @@ per-type override must name a selected type. Resolved counts are part of the
 immutable query-set identity. Each selected query file is executed once. Start
 another run to make another measurement.
 
-For a cross-version query on the exact existing data directory, first install
-the alternate release with `$setup-greptimedb`, then pass its exact
+`analyze` executes the first generated SQL of each selected type as a cold
+`EXPLAIN ANALYZE VERBOSE` query immediately after a managed GreptimeDB restart.
+It then executes the next generated query records without restarting; these are
+the hot runs. Predicate-based types produce distinct SQL, while invariant types
+such as `lastpoint` repeat their SQL. `--hot-runs` defaults to `2` and must be
+positive. Every selected query type must contain at least `1 + hot-runs`
+generated queries. A cold run does not clear operating-system filesystem
+caches.
+
+Analysis results live under
+`results/analyze/QUERY_TYPE/run-NNN/{cold.json,hot-NNN.json,metrics.json}`.
+The matching runner and GreptimeDB process logs live under
+`logs/analyze/QUERY_TYPE/run-NNN/`. Repeating analysis in an existing run uses
+the next attempt directory and does not overwrite earlier results. The `all`
+stage does not run analysis.
+
+For a cross-version query or analysis on the exact existing data directory,
+first install the alternate release with `$setup-greptimedb`, then pass its exact
 `--greptime-version` and repeat the database ID with
-`--confirm-version-override`. This override is supported only by `query`, uses
-the existing workspace lock, and does not rewrite the workspace's bound
-installation identity. Use `--install-root` for a non-default managed install
-root. Startup can still mutate persistent metadata, so treat confirmation as
-authorization for that compatibility risk.
+`--confirm-version-override`. This override is supported by `query` and
+`analyze`, uses the existing workspace lock, and does not rewrite the
+workspace's bound installation identity. Use `--install-root` for a non-default
+managed install root. Startup can still mutate persistent metadata, so treat
+confirmation as authorization for that compatibility risk.
 
 For an independent copy, use `$setup-greptimedb` to copy the loaded workspace
 to a new database ID bound to the alternate release, then run a normal query
@@ -82,7 +103,7 @@ dataset identity/checksum, query-set identity/checksum, membership, query
 counts, and repetitions. Database IDs may differ. A valid comparison is
 report-only and succeeds even when candidates regress.
 
-Query-only commands prepare logical dataset metadata without generating data.
+Query and analysis commands prepare logical dataset metadata without generating data.
 Use `--dataset-id` or `--dataset-path` to pin a dataset. Shared query sets live
 under `--query-root` and are reused only after exact manifest, membership,
 size, and checksum validation.
@@ -93,8 +114,8 @@ size, and checksum validation.
   defaults to `.benchmarks/greptimedb/databases`.
 - Prepare new managed workspaces with `$setup-greptimedb`; the benchmark runner
   verifies and discovers their version-bound binary automatically.
-- Query-only version overrides resolve another checksum-validated managed
-  installation and record both runtime and workspace-bound identities.
+- Query and analysis version overrides resolve another checksum-validated
+  managed installation and record both runtime and workspace-bound identities.
 - Keep using `--greptime-bin` for legacy workspaces. Never silently adopt a
   legacy workspace into a downloaded installation.
 - Keep one SQL database and one loaded dataset per managed workspace. Reuse a
@@ -111,6 +132,10 @@ Read `summary.json` and report the dataset ID and checksum, query-set ID and
 manifest checksum, database ID or external target, metrics/second and
 rows/second for ingestion, weighted mean latency per query type, failures and
 their log paths, and the run directory. Preserve failed-run diagnostics.
+For analysis, also report each query type's attempt and cold/hot result paths,
+runner log, and GreptimeDB process log. Preserve the full GreptimeDB response;
+verbose plan fields are diagnostic text and should not be parsed as a stable
+metrics API.
 For comparisons, report the comparison directory, baseline and candidate run
 IDs and versions, improved/unchanged/regressed counts, the largest regression,
 and per-query latency delta, percentage, and candidate/baseline ratio.

--- a/.agents/skills/benchmark-greptimedb/agents/openai.yaml
+++ b/.agents/skills/benchmark-greptimedb/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "Benchmark GreptimeDB"
-  short_description: "Run reusable GreptimeDB TSBS benchmarks"
-  default_prompt: "Use $benchmark-greptimedb to run a shared-workspace TSBS benchmark against GreptimeDB and summarize the results."
+  short_description: "Benchmark and analyze GreptimeDB TSBS queries"
+  default_prompt: "Use $benchmark-greptimedb to run a shared-workspace TSBS benchmark or collect cold and hot EXPLAIN ANALYZE VERBOSE results against GreptimeDB, then summarize the results."

--- a/.agents/skills/benchmark-greptimedb/references/workload.md
+++ b/.agents/skills/benchmark-greptimedb/references/workload.md
@@ -11,7 +11,11 @@
 └── greptimedb/
     ├── installations/<version>/<platform>/{manifest.json,greptime,...}
     ├── databases/<database-id>/{manifest.json,data/,logs/}
-    ├── runs/<run-id>/{manifest.json,logs/,results/,summary.json,summary.md}
+    ├── runs/<run-id>/
+    │   ├── manifest.json
+    │   ├── summary.{json,md}
+    │   ├── results/analyze/<query-type>/run-NNN/{cold.json,hot-NNN.json,metrics.json}
+    │   └── logs/analyze/<query-type>/run-NNN/{runner.log,greptimedb.log}
     └── comparisons/<comparison-id>/{manifest.json,summary.json,summary.md}
 ```
 
@@ -36,6 +40,21 @@ use case `devops`, Influx line protocol data, and Greptime query format.
 | Batch size | 3000 | 3000 |
 
 The query generator receives the end timestamp plus one second.
+
+## Explain analysis
+
+Analysis is managed-only. For each selected query type, the runner restarts
+GreptimeDB and executes query index `0` as the cold `EXPLAIN ANALYZE VERBOSE`
+request. It then executes generated query indices `1..N` as hot requests without
+another restart. Predicate-based types vary their SQL; invariant types such as
+`lastpoint` repeat the same SQL. `N` defaults to two and is configurable with
+`--hot-runs`. The selected query-set count for every type must be at least
+`N + 1`.
+
+Each response artifact preserves the original SQL, executed explain SQL, phase,
+query index, and complete GreptimeDB HTTP JSON response. Attempts are immutable:
+repeating a type in one run creates `run-002`, then `run-003`, and so on. A
+process restart does not clear the operating-system filesystem cache.
 
 ## Query counts
 

--- a/.agents/skills/benchmark-greptimedb/scripts/benchmark.py
+++ b/.agents/skills/benchmark-greptimedb/scripts/benchmark.py
@@ -91,6 +91,8 @@ def validate_run_manifest(manifest: dict[str, Any], path: Path) -> None:
     events = manifest["events"]
     if not isinstance(events, dict) or not isinstance(events.get("loads"), list) or not isinstance(events.get("queries"), list):
         raise BenchmarkError(f"malformed run events: {path}")
+    if "analyses" in events and not isinstance(events["analyses"], list):
+        raise BenchmarkError(f"malformed run events: {path}")
     workload = manifest["workload"]
     workload_fields = ("start", "end", "scale", "seed", "log_interval", "load_workers", "query_workers", "batch_size", "query_counts")
     if not all(field in workload for field in workload_fields) or not isinstance(workload["query_counts"], dict):
@@ -131,8 +133,9 @@ def prepare_run(args: argparse.Namespace) -> tuple[Path, dict[str, Any]]:
         manifest = {
             "schema_version": SCHEMA_VERSION, "kind": "greptimedb-run", "run_id": run_dir.name,
             "created_at": utc_now(), "profile": profile, "database": getattr(args, "database", DEFAULT_DATABASE),
-            "workload": build_workload(args), "events": {"loads": [], "queries": []},
+            "workload": build_workload(args), "events": {"loads": [], "queries": [], "analyses": []},
         }
+    manifest["events"].setdefault("analyses", [])
     if hasattr(args, "database") and manifest.get("database") != args.database and manifest_path.exists():
         raise BenchmarkError("--database conflicts with the database pinned by this run")
     save_manifest(run_dir, manifest)
@@ -501,11 +504,7 @@ def load_data(args: argparse.Namespace, run_dir: Path, manifest: dict[str, Any],
 def run_queries(args: argparse.Namespace, run_dir: Path, manifest: dict[str, Any], endpoint: str, database_manifest: dict[str, Any] | None = None) -> None:
     query_dir = generate_queries(args, run_dir, manifest); set_manifest = validate_query_set(query_dir, manifest["query_set"]["spec"])
     if database_manifest is not None:
-        binding = database_manifest.get("binding")
-        if binding is None or binding["dataset_id"] != manifest["dataset"]["dataset_id"] or binding["spec"] != manifest["dataset"]["spec"]:
-            raise BenchmarkError("managed database is not loaded with the query set's dataset")
-        manifest["dataset"].update({key: binding[key] for key in ("format", "bytes", "sha256")})
-        save_manifest(run_dir, manifest)
+        validate_query_database_binding(run_dir, manifest, database_manifest)
     ensure_binaries(run_dir, ["query"], args.rebuild); workload = manifest["workload"]
     for query_type in set_manifest["spec"]["query_counts"]:
         attempt = next_attempt(manifest["events"]["queries"], query_type); log_path = run_dir / "logs" / f"query-{query_type}-run-{attempt:03d}.log"; result_path = run_dir / "results" / f"query-{query_type}-run-{attempt:03d}.json"
@@ -519,6 +518,101 @@ def run_queries(args: argparse.Namespace, run_dir: Path, manifest: dict[str, Any
         event.update(status="completed", finished_at=utc_now(), results=relative(run_dir, result_path)); save_manifest(run_dir, manifest)
 
 
+def validate_query_database_binding(run_dir: Path, manifest: dict[str, Any], database_manifest: dict[str, Any]) -> None:
+    binding = database_manifest.get("binding")
+    dataset = manifest["dataset"]
+    if binding is None or binding["dataset_id"] != dataset["dataset_id"] or binding["spec"] != dataset["spec"]:
+        raise BenchmarkError("managed database is not loaded with the query set's dataset")
+    dataset.update({key: binding[key] for key in ("format", "bytes", "sha256")})
+    save_manifest(run_dir, manifest)
+
+
+def run_analyses(
+    args: argparse.Namespace,
+    run_dir: Path,
+    manifest: dict[str, Any],
+    workspace: Path,
+    database_manifest: dict[str, Any],
+    binary: Path,
+) -> None:
+    execution_count = 1 + args.hot_runs
+    insufficient = {
+        query_type: count
+        for query_type, count in manifest["workload"]["query_counts"].items()
+        if count < execution_count
+    }
+    if insufficient:
+        details = ", ".join(f"{query_type}={count}" for query_type, count in sorted(insufficient.items()))
+        raise BenchmarkError(
+            f"analyze requires at least {execution_count} generated queries per type; insufficient counts: {details}"
+        )
+
+    query_dir = generate_queries(args, run_dir, manifest)
+    set_manifest = validate_query_set(query_dir, manifest["query_set"]["spec"])
+    validate_query_database_binding(run_dir, manifest, database_manifest)
+    ensure_binaries(run_dir, ["query"], args.rebuild)
+
+    analyses = manifest["events"].setdefault("analyses", [])
+    endpoint = f"http://127.0.0.1:{args.http_port}"
+    for query_type in set_manifest["spec"]["query_counts"]:
+        attempt = next_attempt(analyses, query_type)
+        result_dir = run_dir / "results" / "analyze" / query_type / f"run-{attempt:03d}"
+        log_dir = run_dir / "logs" / "analyze" / query_type / f"run-{attempt:03d}"
+        runner_log = log_dir / "runner.log"
+        process_log = log_dir / "greptimedb.log"
+        metrics_path = result_dir / "metrics.json"
+        cold_path = result_dir / "cold.json"
+        hot_paths = [result_dir / f"hot-{index:03d}.json" for index in range(1, execution_count)]
+        metadata = set_manifest["files"][query_type]
+        event = {
+            "query_type": query_type,
+            "attempt": attempt,
+            "database": args.database,
+            "query_set_id": set_manifest["query_set_id"],
+            "file": metadata["path"],
+            "file_bytes": metadata["bytes"],
+            "file_sha256": metadata["sha256"],
+            "cold_query_index": 0,
+            "hot_query_indices": list(range(1, execution_count)),
+            "hot_runs": args.hot_runs,
+            "result_dir": relative(run_dir, result_dir),
+            "cold_result": relative(run_dir, cold_path),
+            "hot_results": [relative(run_dir, path) for path in hot_paths],
+            "metrics": relative(run_dir, metrics_path),
+            "log": relative(run_dir, runner_log),
+            "server_log": relative(run_dir, process_log),
+            "status": "running",
+            "started_at": utc_now(),
+        }
+        analyses.append(event)
+        save_manifest(run_dir, manifest)
+        command = [
+            str(REPO_ROOT / "bin" / BINARIES["query"]),
+            f"--file={query_file_path(query_dir, query_type)}",
+            f"--db-name={args.database}",
+            f"--urls={endpoint}",
+            "--workers=1",
+            f"--max-queries={execution_count}",
+            "--print-interval=0",
+            "--explain-analyze-verbose",
+            f"--explain-results-dir={result_dir}",
+            f"--results-file={metrics_path}",
+        ]
+        try:
+            with managed_process(args, workspace, binary, process_log):
+                run_tee(command, runner_log)
+            expected = [cold_path, *hot_paths, metrics_path]
+            missing = [path for path in expected if not path.is_file()]
+            if missing:
+                raise BenchmarkError("analyze command did not produce expected results: " + ", ".join(map(str, missing)))
+        except Exception as exc:
+            event.update(status="failed", reason=str(exc), finished_at=utc_now())
+            save_manifest(run_dir, manifest)
+            raise
+        event.update(status="completed", finished_at=utc_now())
+        save_manifest(run_dir, manifest)
+
+
 def endpoint_ready(endpoint: str) -> bool:
     data = urllib.parse.urlencode({"sql": "SHOW DATABASES"}).encode(); request = urllib.request.Request(endpoint.rstrip("/") + "/v1/sql", data=data, headers={"Content-Type": "application/x-www-form-urlencoded"})
     try:
@@ -526,10 +620,72 @@ def endpoint_ready(endpoint: str) -> bool:
     except (OSError, urllib.error.URLError): return False
 
 
-def check_port_available(port: int) -> None:
+def port_available(port: int) -> bool:
     with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
-        try: sock.bind(("127.0.0.1", port))
-        except OSError as exc: raise BenchmarkError(f"managed GreptimeDB HTTP port {port} is unavailable") from exc
+        sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        try:
+            sock.bind(("127.0.0.1", port))
+            return True
+        except OSError:
+            return False
+
+
+def check_port_available(port: int, timeout: float = 5.0) -> None:
+    deadline = time.monotonic() + timeout
+    while not port_available(port):
+        if time.monotonic() >= deadline:
+            raise BenchmarkError(f"managed GreptimeDB HTTP port {port} is unavailable")
+        time.sleep(0.1)
+
+
+@contextlib.contextmanager
+def managed_workspace(
+    args: argparse.Namespace,
+    existing_target: dict[str, Any] | None = None,
+) -> Iterator[tuple[Path, dict[str, Any], Path, dict[str, Any]]]:
+    workspace, database_manifest = prepare_database_workspace(args)
+    with lock_database(workspace):
+        binary = managed_binary(args, database_manifest)
+        target = managed_target(args, database_manifest, binary)
+        if existing_target and not target_matches(existing_target, target):
+            raise BenchmarkError("run target is immutable; create a new run for another GreptimeDB version or target")
+        if not binary.is_file() or not os.access(binary, os.X_OK): raise BenchmarkError(f"GreptimeDB binary is not executable: {binary}")
+        yield workspace, database_manifest, binary, target
+
+
+@contextlib.contextmanager
+def managed_process(args: argparse.Namespace, workspace: Path, binary: Path, process_log_path: Path) -> Iterator[str]:
+    process_log_path.parent.mkdir(parents=True, exist_ok=True)
+    process_log = process_log_path.open("a", encoding="utf-8")
+    try:
+        check_port_available(args.http_port)
+    except Exception as exc:
+        process_log.write(f"{exc}\n")
+        process_log.close()
+        raise
+    endpoint = f"http://127.0.0.1:{args.http_port}"
+    command = [str(binary), "standalone", "start", "--http-addr", f"127.0.0.1:{args.http_port}", "--influxdb-enable", "--data-home", str(workspace / "data"), "--log-dir", str(workspace / "logs")]
+    process_log.write(f"$ {display_command(command)}\n")
+    process_log.flush()
+    try:
+        process = subprocess.Popen(command, cwd=workspace, stdout=process_log, stderr=subprocess.STDOUT, start_new_session=True)
+    except Exception:
+        process_log.close()
+        raise
+    try:
+        deadline = time.monotonic() + args.startup_timeout
+        while time.monotonic() < deadline:
+            if process.poll() is not None: raise BenchmarkError(f"GreptimeDB exited during startup; see {process_log_path}")
+            if endpoint_ready(endpoint): break
+            time.sleep(0.5)
+        else: raise BenchmarkError(f"GreptimeDB was not ready within {args.startup_timeout}s; see {process_log_path}")
+        yield endpoint
+    finally:
+        if process.poll() is None:
+            os.killpg(process.pid, signal.SIGTERM)
+            try: process.wait(timeout=15)
+            except subprocess.TimeoutExpired: os.killpg(process.pid, signal.SIGKILL); process.wait(timeout=5)
+        process_log.close()
 
 
 @contextlib.contextmanager
@@ -540,30 +696,9 @@ def connection(args: argparse.Namespace, run_dir: Path, existing_target: dict[st
         if existing_target and not target_matches(existing_target, target):
             raise BenchmarkError("run target is immutable; create a new run for another GreptimeDB version or target")
         yield endpoint, False, None, None, target; return
-    workspace, database_manifest = prepare_database_workspace(args)
-    with lock_database(workspace):
-        binary = managed_binary(args, database_manifest)
-        target = managed_target(args, database_manifest, binary)
-        if existing_target and not target_matches(existing_target, target):
-            raise BenchmarkError("run target is immutable; create a new run for another GreptimeDB version or target")
-        if not binary.is_file() or not os.access(binary, os.X_OK): raise BenchmarkError(f"GreptimeDB binary is not executable: {binary}")
-        check_port_available(args.http_port); endpoint = f"http://127.0.0.1:{args.http_port}"; process_log_path = run_dir / "logs" / "greptimedb-process.log"; process_log = process_log_path.open("a", encoding="utf-8")
-        command = [str(binary), "standalone", "start", "--http-addr", f"127.0.0.1:{args.http_port}", "--influxdb-enable", "--data-home", str(workspace / "data"), "--log-dir", str(workspace / "logs")]
-        process_log.write(f"$ {display_command(command)}\n"); process_log.flush(); process = subprocess.Popen(command, cwd=workspace, stdout=process_log, stderr=subprocess.STDOUT, start_new_session=True)
-        try:
-            deadline = time.monotonic() + args.startup_timeout
-            while time.monotonic() < deadline:
-                if process.poll() is not None: raise BenchmarkError(f"GreptimeDB exited during startup; see {process_log_path}")
-                if endpoint_ready(endpoint): break
-                time.sleep(0.5)
-            else: raise BenchmarkError(f"GreptimeDB was not ready within {args.startup_timeout}s; see {process_log_path}")
+    with managed_workspace(args, existing_target) as (workspace, database_manifest, binary, target):
+        with managed_process(args, workspace, binary, run_dir / "logs" / "greptimedb-process.log") as endpoint:
             yield endpoint, True, database_manifest, workspace, target
-        finally:
-            if process.poll() is None:
-                os.killpg(process.pid, signal.SIGTERM)
-                try: process.wait(timeout=15)
-                except subprocess.TimeoutExpired: os.killpg(process.pid, signal.SIGKILL); process.wait(timeout=5)
-            process_log.close()
 
 
 def add_run_options(parser: argparse.ArgumentParser) -> None:
@@ -595,6 +730,7 @@ def make_parser() -> argparse.ArgumentParser:
     generate = subparsers.add_parser("generate"); add_run_options(generate); generate.add_argument("--only", choices=("all", "data", "queries"), default="all")
     load = subparsers.add_parser("load"); add_run_options(load); add_connection_options(load); add_load_options(load)
     query = subparsers.add_parser("query"); add_run_options(query); add_connection_options(query); add_version_override_options(query)
+    analyze = subparsers.add_parser("analyze"); add_run_options(analyze); add_connection_options(analyze); add_version_override_options(analyze); analyze.add_argument("--hot-runs", type=int, default=2, help="number of generated queries to analyze after the cold query (default: 2)")
     all_command = subparsers.add_parser("all"); add_run_options(all_command); add_connection_options(all_command); add_load_options(all_command)
     summarize = subparsers.add_parser("summarize"); summarize.add_argument("--run-dir", required=True, type=Path)
     compare = subparsers.add_parser("compare"); compare.add_argument("--baseline-run", required=True, type=Path); compare.add_argument("--candidate-run", required=True, action="append", type=Path); compare.add_argument("--comparison-root", type=Path)
@@ -602,7 +738,7 @@ def make_parser() -> argparse.ArgumentParser:
 
 
 def validate_args(args: argparse.Namespace) -> None:
-    for name in ("scale", "load_workers", "query_workers", "batch_size", "queries"):
+    for name in ("scale", "load_workers", "query_workers", "batch_size", "queries", "hot_runs"):
         value = getattr(args, name, None)
         if value is not None and value <= 0: raise BenchmarkError(f"--{name.replace('_', '-')} must be positive")
     try:
@@ -615,7 +751,7 @@ def validate_args(args: argparse.Namespace) -> None:
     for name in ("dataset_id", "database_id"):
         value = getattr(args, name, None)
         if value and not ID_RE.fullmatch(value): raise BenchmarkError(f"--{name.replace('_', '-')} contains invalid characters")
-    if args.command in ("load", "query", "all"):
+    if args.command in ("load", "query", "analyze", "all"):
         greptime_version = getattr(args, "greptime_version", None)
         if args.endpoint and (args.greptime_bin or args.database_id or greptime_version): raise BenchmarkError("external GreptimeDB cannot use managed binary or database options")
         if not args.endpoint and not args.database_id: raise BenchmarkError("provide --database-id for managed GreptimeDB or --endpoint for external GreptimeDB")
@@ -626,6 +762,8 @@ def validate_args(args: argparse.Namespace) -> None:
         if args.endpoint:
             parsed = urllib.parse.urlparse(args.endpoint)
             if parsed.scheme not in ("http", "https") or not parsed.netloc: raise BenchmarkError("--endpoint must be an absolute HTTP or HTTPS URL")
+    if args.command == "analyze" and args.endpoint:
+        raise BenchmarkError("analyze requires a managed GreptimeDB workspace; external endpoints cannot be restarted")
     if args.command in ("load", "all"):
         if args.endpoint and args.database_mode is None: raise BenchmarkError("external loads require --database-mode=create|reuse|reset")
         if args.database_mode == "reset" and args.confirm_reset != args.database: raise BenchmarkError("reset requires --confirm-reset to exactly match --database")
@@ -651,6 +789,10 @@ def main(argv: Sequence[str] | None = None) -> int:
                 manifest["target"] = target; save_manifest(run_dir, manifest)
                 if args.command in ("load", "all"): load_data(args, run_dir, manifest, endpoint, managed, database_manifest, database_path)
                 if args.command in ("query", "all"): run_queries(args, run_dir, manifest, endpoint, database_manifest)
+        elif args.command == "analyze":
+            with managed_workspace(args, manifest.get("target")) as (workspace, database_manifest, binary, target):
+                manifest["target"] = target; save_manifest(run_dir, manifest)
+                run_analyses(args, run_dir, manifest, workspace, database_manifest, binary)
         summary = write_summary(run_dir, manifest); print(f"Run directory: {run_dir}"); print(f"Summary: {run_dir / 'summary.md'}"); return 1 if summary["failures"] else 0
     except (BenchmarkError, ComparisonError, TsbsEnvironmentError, OSError, json.JSONDecodeError, KeyError, TypeError) as exc:
         if run_dir is not None and manifest is not None:

--- a/.agents/skills/benchmark-greptimedb/scripts/benchmark.py
+++ b/.agents/skills/benchmark-greptimedb/scripts/benchmark.py
@@ -66,6 +66,11 @@ ID_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]*$")
 VERSION_RE = re.compile(r"^[0-9]+\.[0-9]+\.[0-9]+(?:[-+][A-Za-z0-9.-]+)?$")
 DATA_WORKLOAD_OPTIONS = ("start", "end", "scale", "seed", "log_interval")
 BINARIES = {"queries": "tsbs_generate_queries", "load": "tsbs_load_greptime", "query": "tsbs_run_queries_influx"}
+BINARY_BUILD_VERSIONS = {
+    "tsbs_generate_queries": 1,
+    "tsbs_load_greptime": 1,
+    "tsbs_run_queries_influx": 2,
+}
 BUILT_THIS_PROCESS: set[str] = set()
 GO_TOOLCHAIN: dict[str, Any] | None = None
 
@@ -175,7 +180,15 @@ def run_tee(command: Sequence[str], log_path: Path, *, stdout_path: Path | None 
 
 def binary_needs_build(run_dir: Path, name: str, target: Path, rebuild: bool) -> bool:
     marker = run_dir / "results" / f"built-{name}"
-    return name not in BUILT_THIS_PROCESS and (rebuild or not (target.exists() and marker.exists()))
+    if name in BUILT_THIS_PROCESS:
+        return False
+    if rebuild or not target.exists() or not marker.exists():
+        return True
+    try:
+        metadata = read_json(marker)
+    except BenchmarkError:
+        return True
+    return metadata.get("build_version", 1) != BINARY_BUILD_VERSIONS[name]
 
 
 def ensure_binaries(run_dir: Path, stages: Sequence[str], rebuild: bool) -> dict[str, dict[str, Any]]:
@@ -194,7 +207,7 @@ def ensure_binaries(run_dir: Path, stages: Sequence[str], rebuild: bool) -> dict
         with build_log.open("a", encoding="utf-8") as log:
             log.write(f"# Go toolchain: {json.dumps(GO_TOOLCHAIN, sort_keys=True)}\n")
         run_tee([GO_TOOLCHAIN["binary"], "build", "-o", str(target), f"./cmd/{name}"], build_log, append=True)
-        metadata = {"binary": f"bin/{name}", "binary_sha256": sha256_file(target), "built_at": utc_now(), "go_toolchain": GO_TOOLCHAIN}
+        metadata = {"binary": f"bin/{name}", "binary_sha256": sha256_file(target), "build_version": BINARY_BUILD_VERSIONS[name], "built_at": utc_now(), "go_toolchain": GO_TOOLCHAIN}
         save_json(marker, metadata); built[name] = metadata; BUILT_THIS_PROCESS.add(name)
     return built
 

--- a/.agents/skills/benchmark-greptimedb/scripts/summarize.py
+++ b/.agents/skills/benchmark-greptimedb/scripts/summarize.py
@@ -15,12 +15,73 @@ sys.path.insert(0, str(SCRIPT_PATH.parents[3] / "lib"))
 
 from tsbs_benchmark import (  # noqa: E402
     SummaryError,
-    build_summary,
+    build_summary as build_benchmark_summary,
     parse_load_log,
     parse_load_result,
     parse_query_log,
     parse_query_result,
 )
+
+
+def _validate_analysis_result(run_dir: Path, relative_path: str, phase: str, query_index: int) -> None:
+    path = run_dir / relative_path
+    try:
+        result = json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        raise SummaryError(f"malformed analysis result JSON {relative_path}: {exc}") from exc
+    if not isinstance(result, dict):
+        raise SummaryError(f"analysis result must be an object: {relative_path}")
+    required = {"phase", "query_index", "sql", "executed_sql", "response"}
+    if not required.issubset(result):
+        raise SummaryError(f"analysis result is missing required fields: {relative_path}")
+    if result["phase"] != phase or result["query_index"] != query_index:
+        raise SummaryError(f"analysis result phase or query index mismatch: {relative_path}")
+    if not isinstance(result["sql"], str) or not isinstance(result["executed_sql"], str):
+        raise SummaryError(f"analysis result SQL fields must be strings: {relative_path}")
+    if result["executed_sql"] != "EXPLAIN ANALYZE VERBOSE " + result["sql"]:
+        raise SummaryError(f"analysis result executed SQL mismatch: {relative_path}")
+    if not isinstance(result["response"], dict):
+        raise SummaryError(f"analysis response must be an object: {relative_path}")
+
+
+def build_summary(run_dir: Path, manifest: dict[str, Any]) -> dict[str, Any]:
+    summary = build_benchmark_summary(run_dir, manifest)
+    analyses: list[dict[str, Any]] = []
+    for event in manifest.get("events", {}).get("analyses", []):
+        base = {
+            "query_type": event["query_type"],
+            "attempt": event["attempt"],
+            "database": event["database"],
+            "hot_runs": event["hot_runs"],
+            "cold_query_index": event["cold_query_index"],
+            "hot_query_indices": event["hot_query_indices"],
+            "result_dir": event["result_dir"],
+            "cold_result": event["cold_result"],
+            "hot_results": event["hot_results"],
+            "metrics": event["metrics"],
+            "log": event["log"],
+            "server_log": event["server_log"],
+        }
+        if event.get("status") != "completed":
+            failure_log = event["log"] if (run_dir / event["log"]).is_file() else event["server_log"]
+            summary["failures"].append(
+                {"stage": "analyze", "log": failure_log, "reason": event.get("reason", event.get("status", "failed"))}
+            )
+            continue
+        try:
+            _validate_analysis_result(run_dir, event["cold_result"], "cold", event["cold_query_index"])
+            if len(event["hot_results"]) != len(event["hot_query_indices"]):
+                raise SummaryError(f"analysis hot result count mismatch: {event['result_dir']}")
+            for result_path, query_index in zip(event["hot_results"], event["hot_query_indices"]):
+                _validate_analysis_result(run_dir, result_path, "hot", query_index)
+            for artifact in (event["metrics"], event["log"], event["server_log"]):
+                if not (run_dir / artifact).is_file():
+                    raise SummaryError(f"missing analysis artifact: {artifact}")
+            analyses.append(base)
+        except (OSError, SummaryError) as exc:
+            summary["failures"].append({"stage": "analyze", "log": event["log"], "reason": str(exc)})
+    summary["analyses"] = analyses
+    return summary
 
 
 def render_markdown(summary: dict[str, Any]) -> str:
@@ -99,6 +160,24 @@ def render_markdown(summary: dict[str, Any]) -> str:
             )
     else:
         lines.append("No completed query runs.")
+
+    lines.extend(["", "## Analysis", ""])
+    if summary.get("analyses"):
+        lines.extend(
+            [
+                "| Database | Query type | Attempt | Cold query | Hot queries | Results | Runner log | Server log |",
+                "| --- | --- | ---: | ---: | --- | --- | --- | --- |",
+            ]
+        )
+        for analysis in summary["analyses"]:
+            hot_queries = ", ".join(str(index) for index in analysis["hot_query_indices"])
+            lines.append(
+                f"| `{analysis['database']}` | `{analysis['query_type']}` | {analysis['attempt']} | "
+                f"{analysis['cold_query_index']} | {hot_queries} | `{analysis['result_dir']}` | "
+                f"`{analysis['log']}` | `{analysis['server_log']}` |"
+            )
+    else:
+        lines.append("No completed analysis runs.")
 
     if summary["failures"]:
         lines.extend(

--- a/.agents/skills/benchmark-greptimedb/tests/test_benchmark.py
+++ b/.agents/skills/benchmark-greptimedb/tests/test_benchmark.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import argparse
+import contextlib
 import json
 import sys
 import tempfile
@@ -306,6 +307,143 @@ class QuerySetTests(unittest.TestCase):
             self.assertEqual(len(manifest["events"]["queries"]), 2)
             self.assertTrue(all(event["file_sha256"] for event in manifest["events"]["queries"]))
             self.assertEqual(manifest["dataset"]["sha256"], "d" * 64)
+
+
+class AnalyzeTests(unittest.TestCase):
+    def args(self, run_dir: Path, hot_runs: int = 2) -> argparse.Namespace:
+        return benchmark.make_parser().parse_args([
+            "analyze", "--run-dir", str(run_dir), "--database-id", "db-a",
+            "--database", "benchmark", "--profile", "smoke", "--hot-runs", str(hot_runs),
+        ])
+
+    def manifest(self, query_counts: dict[str, int]) -> dict:
+        return {
+            "schema_version": benchmark.SCHEMA_VERSION,
+            "kind": "greptimedb-run",
+            "run_id": "run",
+            "created_at": benchmark.utc_now(),
+            "profile": "smoke",
+            "database": "benchmark",
+            "workload": {"query_counts": query_counts},
+            "dataset": {"dataset_id": "data-a", "spec": {"scale": 10}},
+            "query_set": {"query_set_id": "set-a", "spec": {"query_counts": query_counts}},
+            "events": {"loads": [], "queries": [], "analyses": []},
+        }
+
+    def set_manifest(self, query_counts: dict[str, int]) -> dict:
+        return {
+            "query_set_id": "set-a",
+            "spec": {"query_counts": query_counts},
+            "files": {
+                query_type: {
+                    "path": f"queries/{query_type}.dat",
+                    "bytes": 100,
+                    "sha256": query_type.ljust(64, "0")[:64],
+                }
+                for query_type in query_counts
+            },
+        }
+
+    def execute(self, command, log_path, **_kwargs):
+        log_path.parent.mkdir(parents=True, exist_ok=True)
+        log_path.write_text("analysis completed\n", encoding="utf-8")
+        options = {part.split("=", 1)[0]: part.split("=", 1)[1] for part in command if part.startswith("--") and "=" in part}
+        result_dir = Path(options["--explain-results-dir"])
+        result_dir.mkdir(parents=True)
+        count = int(options["--max-queries"])
+        for index in range(count):
+            phase = "cold" if index == 0 else "hot"
+            name = "cold.json" if index == 0 else f"hot-{index:03d}.json"
+            sql = f"SELECT {index}"
+            benchmark.save_json(result_dir / name, {
+                "phase": phase,
+                "query_index": index,
+                "sql": sql,
+                "executed_sql": "EXPLAIN ANALYZE VERBOSE " + sql,
+                "response": {"output": [], "execution_time_ms": index},
+            })
+        benchmark.save_json(Path(options["--results-file"]), {"ResultFormatVersion": "0.2"})
+
+    def test_analyze_restarts_each_type_and_writes_attempt_artifacts(self) -> None:
+        with tempfile.TemporaryDirectory() as temp:
+            run_dir = Path(temp) / "run"; (run_dir / "logs").mkdir(parents=True); (run_dir / "results").mkdir()
+            query_counts = {"lastpoint": 3, "cpu-max-all-1": 3}
+            manifest = self.manifest(query_counts)
+            args = self.args(run_dir)
+            starts = []
+
+            @contextlib.contextmanager
+            def process(_args, _workspace, _binary, log_path):
+                log_path.parent.mkdir(parents=True, exist_ok=True)
+                log_path.write_text("server started\n", encoding="utf-8")
+                starts.append(log_path)
+                yield "http://127.0.0.1:4000"
+
+            patches = (
+                mock.patch.object(benchmark, "generate_queries", return_value=Path(temp) / "queries"),
+                mock.patch.object(benchmark, "validate_query_set", return_value=self.set_manifest(query_counts)),
+                mock.patch.object(benchmark, "validate_query_database_binding"),
+                mock.patch.object(benchmark, "ensure_binaries"),
+                mock.patch.object(benchmark, "managed_process", side_effect=process),
+                mock.patch.object(benchmark, "run_tee", side_effect=self.execute),
+            )
+            with patches[0], patches[1], patches[2], patches[3], patches[4], patches[5] as runner:
+                benchmark.run_analyses(args, run_dir, manifest, Path(temp), {"binding": {}}, Path("/greptime"))
+                benchmark.run_analyses(args, run_dir, manifest, Path(temp), {"binding": {}}, Path("/greptime"))
+
+            self.assertEqual(len(starts), 4)
+            self.assertEqual(runner.call_count, 4)
+            self.assertEqual([event["attempt"] for event in manifest["events"]["analyses"]], [1, 1, 2, 2])
+            for query_type in query_counts:
+                for attempt in (1, 2):
+                    result_dir = run_dir / "results/analyze" / query_type / f"run-{attempt:03d}"
+                    self.assertTrue((result_dir / "cold.json").is_file())
+                    self.assertTrue((result_dir / "hot-001.json").is_file())
+                    self.assertTrue((result_dir / "hot-002.json").is_file())
+                    self.assertTrue((result_dir / "metrics.json").is_file())
+            command = runner.call_args_list[0].args[0]
+            self.assertIn("--workers=1", command)
+            self.assertIn("--max-queries=3", command)
+            self.assertIn("--explain-analyze-verbose", command)
+
+            summary = summarize.build_summary(run_dir, manifest)
+            self.assertEqual(len(summary["analyses"]), 4)
+            self.assertFalse(summary["failures"])
+            self.assertIn("## Analysis", summarize.render_markdown(summary))
+
+    def test_analyze_rejects_insufficient_distinct_queries(self) -> None:
+        with tempfile.TemporaryDirectory() as temp:
+            run_dir = Path(temp) / "run"; (run_dir / "logs").mkdir(parents=True); (run_dir / "results").mkdir()
+            query_counts = {"lastpoint": 2}
+            manifest = self.manifest(query_counts)
+            args = self.args(run_dir)
+            with mock.patch.object(benchmark, "generate_queries", return_value=Path(temp) / "queries"), mock.patch.object(
+                benchmark, "validate_query_set", return_value=self.set_manifest(query_counts)
+            ), mock.patch.object(benchmark, "validate_query_database_binding"), mock.patch.object(
+                benchmark, "ensure_binaries"
+            ) as build:
+                with self.assertRaisesRegex(benchmark.BenchmarkError, "at least 3"):
+                    benchmark.run_analyses(args, run_dir, manifest, Path(temp), {"binding": {}}, Path("/greptime"))
+            build.assert_not_called()
+
+    def test_analyze_cli_is_managed_only_and_hot_runs_are_positive(self) -> None:
+        parser = benchmark.make_parser()
+        external = parser.parse_args(["analyze", "--endpoint", "http://localhost:4000"])
+        benchmark.resolve_database(external)
+        with self.assertRaisesRegex(benchmark.BenchmarkError, "managed"):
+            benchmark.validate_args(external)
+        invalid = parser.parse_args(["analyze", "--database-id", "db-a", "--hot-runs", "0"])
+        benchmark.resolve_database(invalid)
+        with self.assertRaisesRegex(benchmark.BenchmarkError, "positive"):
+            benchmark.validate_args(invalid)
+
+    def test_port_availability_retries_between_restarts(self) -> None:
+        with mock.patch.object(benchmark, "port_available", side_effect=[False, False, True]) as available, mock.patch.object(
+            benchmark.time, "sleep"
+        ) as sleep:
+            benchmark.check_port_available(4000)
+        self.assertEqual(available.call_count, 3)
+        self.assertEqual(sleep.call_count, 2)
 
 
 class BuildEnvironmentTests(unittest.TestCase):

--- a/.agents/skills/benchmark-greptimedb/tests/test_benchmark.py
+++ b/.agents/skills/benchmark-greptimedb/tests/test_benchmark.py
@@ -464,7 +464,69 @@ class BuildEnvironmentTests(unittest.TestCase):
             self.assertEqual(built[benchmark.BINARIES["queries"]]["go_toolchain"], toolchain)
             marker = json.loads((run_dir / "results" / f"built-{benchmark.BINARIES['queries']}").read_text(encoding="utf-8"))
             self.assertEqual(marker["go_toolchain"]["source"], "managed")
+            self.assertEqual(marker["build_version"], 1)
             self.assertIn('"version": "1.21.13"', (run_dir / "logs" / "build.log").read_text(encoding="utf-8"))
+
+    def test_legacy_query_runner_marker_forces_feature_build(self) -> None:
+        with tempfile.TemporaryDirectory() as temp:
+            root = Path(temp); run_dir = root / "run"
+            (run_dir / "results").mkdir(parents=True); (run_dir / "logs").mkdir()
+            name = benchmark.BINARIES["query"]
+            target = root / "bin" / name
+            target.parent.mkdir(parents=True); target.write_text("legacy", encoding="utf-8")
+            benchmark.save_json(run_dir / "results" / f"built-{name}", {"binary": f"bin/{name}"})
+            toolchain = {"source": "managed", "version": "1.21.13", "binary": "/managed/go", "binary_sha256": "a" * 64}
+
+            def build(command, _log_path, **_kwargs):
+                Path(command[3]).write_text("feature-capable", encoding="utf-8")
+
+            with mock.patch.object(benchmark, "REPO_ROOT", root), mock.patch.object(benchmark, "resolve_go", return_value=toolchain), mock.patch.object(
+                benchmark, "run_tee", side_effect=build
+            ) as runner, mock.patch.object(benchmark, "GO_TOOLCHAIN", None), mock.patch.object(benchmark, "BUILT_THIS_PROCESS", set()):
+                benchmark.ensure_binaries(run_dir, ["query"], False)
+
+            runner.assert_called_once()
+            marker = json.loads((run_dir / "results" / f"built-{name}").read_text(encoding="utf-8"))
+            self.assertEqual(marker["build_version"], 2)
+
+    def test_current_query_runner_marker_reuses_binary(self) -> None:
+        with tempfile.TemporaryDirectory() as temp:
+            root = Path(temp); run_dir = root / "run"
+            (run_dir / "results").mkdir(parents=True)
+            name = benchmark.BINARIES["query"]
+            target = root / "bin" / name
+            target.parent.mkdir(parents=True); target.write_text("feature-capable", encoding="utf-8")
+            benchmark.save_json(
+                run_dir / "results" / f"built-{name}",
+                {"binary": f"bin/{name}", "build_version": benchmark.BINARY_BUILD_VERSIONS[name]},
+            )
+
+            with mock.patch.object(benchmark, "REPO_ROOT", root), mock.patch.object(benchmark, "resolve_go") as resolve, mock.patch.object(
+                benchmark, "run_tee"
+            ) as runner, mock.patch.object(benchmark, "BUILT_THIS_PROCESS", set()):
+                built = benchmark.ensure_binaries(run_dir, ["query"], False)
+
+            self.assertEqual(built, {})
+            resolve.assert_not_called()
+            runner.assert_not_called()
+
+    def test_legacy_marker_reuses_unchanged_binary(self) -> None:
+        with tempfile.TemporaryDirectory() as temp:
+            root = Path(temp); run_dir = root / "run"
+            (run_dir / "results").mkdir(parents=True)
+            name = benchmark.BINARIES["queries"]
+            target = root / "bin" / name
+            target.parent.mkdir(parents=True); target.write_text("binary", encoding="utf-8")
+            benchmark.save_json(run_dir / "results" / f"built-{name}", {"binary": f"bin/{name}"})
+
+            with mock.patch.object(benchmark, "REPO_ROOT", root), mock.patch.object(benchmark, "resolve_go") as resolve, mock.patch.object(
+                benchmark, "run_tee"
+            ) as runner, mock.patch.object(benchmark, "BUILT_THIS_PROCESS", set()):
+                built = benchmark.ensure_binaries(run_dir, ["queries"], False)
+
+            self.assertEqual(built, {})
+            resolve.assert_not_called()
+            runner.assert_not_called()
 
 
 class ManagedDatabaseTests(unittest.TestCase):

--- a/cmd/tsbs_run_queries_influx/explain_results.go
+++ b/cmd/tsbs_run_queries_influx/explain_results.go
@@ -1,0 +1,99 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sync"
+)
+
+const explainPrefix = "EXPLAIN ANALYZE VERBOSE "
+
+type explainResult struct {
+	Phase       string          `json:"phase"`
+	QueryIndex  uint64          `json:"query_index"`
+	SQL         string          `json:"sql"`
+	ExecutedSQL string          `json:"executed_sql"`
+	Response    json.RawMessage `json:"response"`
+}
+
+type explainResultWriter struct {
+	directory string
+	mu        sync.Mutex
+}
+
+type greptimeResponse struct {
+	Code  *int   `json:"code"`
+	Error string `json:"error"`
+}
+
+func newExplainResultWriter(directory string) *explainResultWriter {
+	return &explainResultWriter{directory: directory}
+}
+
+func (w *explainResultWriter) write(queryIndex uint64, sql string, executedSQL string, response []byte) error {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+
+	if !json.Valid(response) {
+		return fmt.Errorf("GreptimeDB explain response for query %d is not valid JSON", queryIndex)
+	}
+	var envelope greptimeResponse
+	if err := json.Unmarshal(response, &envelope); err != nil {
+		return err
+	}
+	if envelope.Code != nil && *envelope.Code != 0 {
+		return fmt.Errorf("GreptimeDB explain query %d failed with code %d: %s", queryIndex, *envelope.Code, envelope.Error)
+	}
+	if envelope.Error != "" {
+		return fmt.Errorf("GreptimeDB explain query %d failed: %s", queryIndex, envelope.Error)
+	}
+	if err := os.MkdirAll(w.directory, 0755); err != nil {
+		return err
+	}
+
+	phase := "cold"
+	filename := "cold.json"
+	if queryIndex > 0 {
+		phase = "hot"
+		filename = fmt.Sprintf("hot-%03d.json", queryIndex)
+	}
+	destination := filepath.Join(w.directory, filename)
+	if _, err := os.Stat(destination); err == nil {
+		return fmt.Errorf("explain result already exists: %s", destination)
+	} else if !os.IsNotExist(err) {
+		return err
+	}
+
+	encoded, err := json.MarshalIndent(explainResult{
+		Phase:       phase,
+		QueryIndex:  queryIndex,
+		SQL:         sql,
+		ExecutedSQL: executedSQL,
+		Response:    json.RawMessage(response),
+	}, "", "  ")
+	if err != nil {
+		return err
+	}
+	encoded = append(encoded, '\n')
+
+	temporary, err := os.CreateTemp(w.directory, ".explain-result-*")
+	if err != nil {
+		return err
+	}
+	temporaryPath := temporary.Name()
+	defer os.Remove(temporaryPath)
+	if _, err := temporary.Write(encoded); err != nil {
+		temporary.Close()
+		return err
+	}
+	if err := temporary.Chmod(0644); err != nil {
+		temporary.Close()
+		return err
+	}
+	if err := temporary.Close(); err != nil {
+		return err
+	}
+	return os.Rename(temporaryPath, destination)
+}

--- a/cmd/tsbs_run_queries_influx/http_client.go
+++ b/cmd/tsbs_run_queries_influx/http_client.go
@@ -27,12 +27,14 @@ type HTTPClient struct {
 
 // HTTPClientDoOptions wraps options uses when calling `Do`.
 type HTTPClientDoOptions struct {
-	Debug                int
-	PrettyPrintResponses bool
-	chunkSize            uint64
-	database             string
-	isV2                 bool
-	authToken            string
+	Debug                 int
+	PrettyPrintResponses  bool
+	chunkSize             uint64
+	database              string
+	isV2                  bool
+	authToken             string
+	explainAnalyzeVerbose bool
+	explainResults        *explainResultWriter
 }
 
 var httpClientOnce = sync.Once{}
@@ -61,11 +63,20 @@ func NewHTTPClient(host string) *HTTPClient {
 // Do performs the action specified by the given Query. It uses fasthttp, and
 // tries to minimize heap allocations.
 func (w *HTTPClient) Do(q *query.HTTP, opts *HTTPClientDoOptions) (lag float64, err error) {
+	executedSQL := string(q.RawQuery)
+	requestPath := q.Path
+	if opts != nil && opts.explainAnalyzeVerbose {
+		executedSQL = explainPrefix + executedSQL
+		values := url.Values{}
+		values.Set("sql", executedSQL)
+		requestPath = []byte("/v1/sql?" + values.Encode())
+	}
+
 	// populate uri from the reusable byte slice:
 	w.uri = w.uri[:0]
 	w.uri = append(w.uri, w.Host...)
 	//w.uri = append(w.uri, bytesSlash...)
-	w.uri = append(w.uri, q.Path...)
+	w.uri = append(w.uri, requestPath...)
 	w.uri = append(w.uri, []byte("&db="+url.QueryEscape(opts.database))...)
 	if opts.chunkSize > 0 {
 		s := fmt.Sprintf("&chunked=true&chunk_size=%d", opts.chunkSize)
@@ -74,10 +85,10 @@ func (w *HTTPClient) Do(q *query.HTTP, opts *HTTPClientDoOptions) (lag float64, 
 
 	// populate a request with data from the Query:
 	req, err := http.NewRequest(string(q.Method), string(w.uri), nil)
-	req.Header.Add("Content-Type", "application/x-www-form-urlencoded")
 	if err != nil {
-		panic(err)
+		return 0, err
 	}
+	req.Header.Add("Content-Type", "application/x-www-form-urlencoded")
 
 	if isV2 {
 		req.Header.Add("Authorization", "Token "+authToken)
@@ -100,7 +111,7 @@ func (w *HTTPClient) Do(q *query.HTTP, opts *HTTPClientDoOptions) (lag float64, 
 	start := time.Now()
 	resp, err := w.client.Do(req)
 	if err != nil {
-		panic(err)
+		return 0, err
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusOK {
@@ -112,10 +123,15 @@ func (w *HTTPClient) Do(q *query.HTTP, opts *HTTPClientDoOptions) (lag float64, 
 	body, err = ioutil.ReadAll(resp.Body)
 
 	if err != nil {
-		panic(err)
+		return 0, err
 	}
 
 	lag = float64(time.Since(start).Nanoseconds()) / 1e6 // milliseconds
+	if opts != nil && opts.explainResults != nil {
+		if err := opts.explainResults.write(q.GetID(), string(q.RawQuery), executedSQL, body); err != nil {
+			return 0, err
+		}
+	}
 
 	if opts != nil {
 		// Print debug messages, if applicable:
@@ -143,7 +159,7 @@ func (w *HTTPClient) Do(q *query.HTTP, opts *HTTPClientDoOptions) (lag float64, 
 			var v interface{}
 			var line []byte
 			full := make(map[string]interface{})
-			full["influxql"] = string(q.RawQuery)
+			full["influxql"] = executedSQL
 			json.Unmarshal(body, &v)
 			full["response"] = v
 			line, err = json.MarshalIndent(full, prefix, "  ")

--- a/cmd/tsbs_run_queries_influx/http_client_test.go
+++ b/cmd/tsbs_run_queries_influx/http_client_test.go
@@ -1,0 +1,113 @@
+package main
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/timescale/tsbs/pkg/query"
+)
+
+func testQuery(sql string) *query.HTTP {
+	values := url.Values{}
+	values.Set("sql", sql)
+	q := query.NewHTTP()
+	q.Method = []byte(http.MethodPost)
+	q.Path = []byte("/v1/sql?" + values.Encode())
+	q.RawQuery = []byte(sql)
+	return q
+}
+
+func TestHTTPClientExplainAnalyzeVerbose(t *testing.T) {
+	var receivedSQL string
+	var receivedDatabase string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		receivedSQL = r.URL.Query().Get("sql")
+		receivedDatabase = r.URL.Query().Get("db")
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"output":[{"records":{"rows":[["plan"]]}}],"execution_time_ms":12}`))
+	}))
+	defer server.Close()
+
+	resultsDir := t.TempDir()
+	client := &HTTPClient{client: server.Client(), Host: []byte(server.URL)}
+	q := testQuery("SELECT 1")
+	q.SetID(0)
+	_, err := client.Do(q, &HTTPClientDoOptions{
+		database:              "benchmark",
+		explainAnalyzeVerbose: true,
+		explainResults:        newExplainResultWriter(resultsDir),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if got, want := receivedSQL, "EXPLAIN ANALYZE VERBOSE SELECT 1"; got != want {
+		t.Fatalf("executed SQL = %q, want %q", got, want)
+	}
+	if receivedDatabase != "benchmark" {
+		t.Fatalf("database = %q, want benchmark", receivedDatabase)
+	}
+	encoded, err := os.ReadFile(filepath.Join(resultsDir, "cold.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var result explainResult
+	if err := json.Unmarshal(encoded, &result); err != nil {
+		t.Fatal(err)
+	}
+	if result.Phase != "cold" || result.QueryIndex != 0 || result.SQL != "SELECT 1" || result.ExecutedSQL != receivedSQL {
+		t.Fatalf("unexpected explain result: %+v", result)
+	}
+	if !json.Valid(result.Response) {
+		t.Fatalf("saved response is not valid JSON: %s", result.Response)
+	}
+}
+
+func TestHTTPClientNormalQueryIsUnchanged(t *testing.T) {
+	var receivedSQL string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		receivedSQL = r.URL.Query().Get("sql")
+		_, _ = w.Write([]byte(`{"output":[]}`))
+	}))
+	defer server.Close()
+
+	client := &HTTPClient{client: server.Client(), Host: []byte(server.URL)}
+	q := testQuery("SELECT 1")
+	if _, err := client.Do(q, &HTTPClientDoOptions{database: "benchmark"}); err != nil {
+		t.Fatal(err)
+	}
+	if receivedSQL != "SELECT 1" {
+		t.Fatalf("executed SQL = %q, want SELECT 1", receivedSQL)
+	}
+}
+
+func TestExplainResultWriterUsesHotSequenceNamesAndRefusesOverwrite(t *testing.T) {
+	directory := t.TempDir()
+	writer := newExplainResultWriter(directory)
+	if err := writer.write(2, "SELECT 2", explainPrefix+"SELECT 2", []byte(`{"output":[]}`)); err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(directory, "hot-002.json")
+	if _, err := os.Stat(path); err != nil {
+		t.Fatal(err)
+	}
+	if err := writer.write(2, "SELECT 2", explainPrefix+"SELECT 2", []byte(`{"output":[]}`)); err == nil {
+		t.Fatal("expected duplicate explain result to fail")
+	}
+}
+
+func TestExplainResultWriterRejectsGreptimeError(t *testing.T) {
+	directory := t.TempDir()
+	writer := newExplainResultWriter(directory)
+	if err := writer.write(0, "SELECT bad", explainPrefix+"SELECT bad", []byte(`{"code":1004,"error":"bad query"}`)); err == nil {
+		t.Fatal("expected GreptimeDB error response to fail")
+	}
+	if _, err := os.Stat(filepath.Join(directory, "cold.json")); !os.IsNotExist(err) {
+		t.Fatalf("error response should not create cold.json: %v", err)
+	}
+}

--- a/cmd/tsbs_run_queries_influx/main.go
+++ b/cmd/tsbs_run_queries_influx/main.go
@@ -18,10 +18,13 @@ import (
 
 // Program option vars:
 var (
-	daemonUrls []string
-	chunkSize  uint64
-	isV2       bool
-	authToken  string
+	daemonUrls            []string
+	chunkSize             uint64
+	isV2                  bool
+	authToken             string
+	explainAnalyzeVerbose bool
+	explainResultsDir     string
+	explainResults        *explainResultWriter
 )
 
 // Global vars:
@@ -39,6 +42,8 @@ func init() {
 	pflag.Uint64("chunk-response-size", 0, "Number of series to chunk results into. 0 means no chunking.")
 	pflag.Bool("is-v2", false, "Is querying InfluxDB v2. false means querying InfluxDB v1.")
 	pflag.String("auth-token", "tsbs-token", "InfluxDB v2 auth token.")
+	pflag.Bool("explain-analyze-verbose", false, "Run GreptimeDB queries with EXPLAIN ANALYZE VERBOSE.")
+	pflag.String("explain-results-dir", "", "Write GreptimeDB EXPLAIN ANALYZE VERBOSE responses to this directory.")
 
 	pflag.Parse()
 
@@ -56,6 +61,17 @@ func init() {
 	chunkSize = viper.GetUint64("chunk-response-size")
 	isV2 = viper.GetBool("is-v2")
 	authToken = viper.GetString("auth-token")
+	explainAnalyzeVerbose = viper.GetBool("explain-analyze-verbose")
+	explainResultsDir = viper.GetString("explain-results-dir")
+	if explainResultsDir != "" && !explainAnalyzeVerbose {
+		log.Fatal("--explain-results-dir requires --explain-analyze-verbose")
+	}
+	if explainAnalyzeVerbose && config.Workers != 1 {
+		log.Fatal("--explain-analyze-verbose requires --workers=1 so cold and hot query order is deterministic")
+	}
+	if explainResultsDir != "" {
+		explainResults = newExplainResultWriter(explainResultsDir)
+	}
 
 	daemonUrls = strings.Split(csvDaemonUrls, ",")
 	if len(daemonUrls) == 0 {
@@ -78,10 +94,12 @@ func newProcessor() query.Processor { return &processor{} }
 
 func (p *processor) Init(workerNumber int) {
 	p.opts = &HTTPClientDoOptions{
-		Debug:                runner.DebugLevel(),
-		PrettyPrintResponses: runner.DoPrintResponses(),
-		chunkSize:            chunkSize,
-		database:             runner.DatabaseName(),
+		Debug:                 runner.DebugLevel(),
+		PrettyPrintResponses:  runner.DoPrintResponses(),
+		chunkSize:             chunkSize,
+		database:              runner.DatabaseName(),
+		explainAnalyzeVerbose: explainAnalyzeVerbose,
+		explainResults:        explainResults,
 	}
 	url := daemonUrls[workerNumber%len(daemonUrls)]
 	p.w = NewHTTPClient(url)

--- a/cmd/tsbs_run_queries_influx/main.go
+++ b/cmd/tsbs_run_queries_influx/main.go
@@ -63,11 +63,8 @@ func init() {
 	authToken = viper.GetString("auth-token")
 	explainAnalyzeVerbose = viper.GetBool("explain-analyze-verbose")
 	explainResultsDir = viper.GetString("explain-results-dir")
-	if explainResultsDir != "" && !explainAnalyzeVerbose {
-		log.Fatal("--explain-results-dir requires --explain-analyze-verbose")
-	}
-	if explainAnalyzeVerbose && config.Workers != 1 {
-		log.Fatal("--explain-analyze-verbose requires --workers=1 so cold and hot query order is deterministic")
+	if err := validateExplainOptions(config, explainAnalyzeVerbose, explainResultsDir); err != nil {
+		log.Fatal(err)
 	}
 	if explainResultsDir != "" {
 		explainResults = newExplainResultWriter(explainResultsDir)
@@ -79,6 +76,19 @@ func init() {
 	}
 
 	runner = query.NewBenchmarkRunner(config)
+}
+
+func validateExplainOptions(config query.BenchmarkRunnerConfig, explain bool, resultsDir string) error {
+	if resultsDir != "" && !explain {
+		return fmt.Errorf("--explain-results-dir requires --explain-analyze-verbose")
+	}
+	if resultsDir != "" && config.PrewarmQueries {
+		return fmt.Errorf("--explain-results-dir cannot be combined with --prewarm-queries")
+	}
+	if explain && config.Workers != 1 {
+		return fmt.Errorf("--explain-analyze-verbose requires --workers=1 so cold and hot query order is deterministic")
+	}
+	return nil
 }
 
 func main() {

--- a/cmd/tsbs_run_queries_influx/main_test.go
+++ b/cmd/tsbs_run_queries_influx/main_test.go
@@ -1,0 +1,64 @@
+package main
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/timescale/tsbs/pkg/query"
+)
+
+func TestValidateExplainOptions(t *testing.T) {
+	tests := []struct {
+		name       string
+		config     query.BenchmarkRunnerConfig
+		explain    bool
+		resultsDir string
+		wantError  string
+	}{
+		{
+			name:       "results require explain",
+			config:     query.BenchmarkRunnerConfig{Workers: 1},
+			resultsDir: "results",
+			wantError:  "--explain-results-dir requires --explain-analyze-verbose",
+		},
+		{
+			name:       "results reject prewarming",
+			config:     query.BenchmarkRunnerConfig{Workers: 1, PrewarmQueries: true},
+			explain:    true,
+			resultsDir: "results",
+			wantError:  "--explain-results-dir cannot be combined with --prewarm-queries",
+		},
+		{
+			name:      "explain requires one worker",
+			config:    query.BenchmarkRunnerConfig{Workers: 2},
+			explain:   true,
+			wantError: "--explain-analyze-verbose requires --workers=1",
+		},
+		{
+			name:       "explain results",
+			config:     query.BenchmarkRunnerConfig{Workers: 1},
+			explain:    true,
+			resultsDir: "results",
+		},
+		{
+			name:    "prewarmed explain without results",
+			config:  query.BenchmarkRunnerConfig{Workers: 1, PrewarmQueries: true},
+			explain: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateExplainOptions(tt.config, tt.explain, tt.resultsDir)
+			if tt.wantError == "" {
+				if err != nil {
+					t.Fatalf("validateExplainOptions() error = %v", err)
+				}
+				return
+			}
+			if err == nil || !strings.Contains(err.Error(), tt.wantError) {
+				t.Fatalf("validateExplainOptions() error = %v, want containing %q", err, tt.wantError)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- add a managed `analyze` operation that restarts GreptimeDB for each query type and captures one cold plus configurable hot runs
- execute queries as `EXPLAIN ANALYZE VERBOSE` and persist structured, immutable response artifacts with matching logs and summaries
- document the result directory layout and extend the Python and Go test coverage

## Why

TSBS query benchmarks report latency, but they do not preserve GreptimeDB execution plans. This adds repeatable diagnostic collection for comparing cold-cache and warmed executions of every query type.

## Impact

The existing query benchmark flow remains unchanged. The new operation is available for managed GreptimeDB workspaces and defaults to two hot runs after the cold run.

## Validation

- `python3 -m unittest discover -s .agents/skills/benchmark-greptimedb/tests` — 26 tests passed
- `go test ./cmd/tsbs_run_queries_influx ./pkg/query` — passed
- full live analyze run against GreptimeDB v1.2.0-beta.1 — 15 query types, 45 artifacts, zero failures
- live normal-query regression run — passed
- `git diff --check` — passed

## Known unrelated failures

`go test ./...` still fails in pre-existing generator expectations (`/query` versus `/v1/sql` and randomized hostnames) and stale `cmd/tsbs_load_influx2` test APIs. The packages changed by this PR pass.