### PR TITLE
feat: support custom GreptimeDB config files

### DIFF
--- a/.agents/skills/benchmark-greptimedb/SKILL.md
+++ b/.agents/skills/benchmark-greptimedb/SKILL.md
@@ -56,6 +56,10 @@ python3 .agents/skills/benchmark-greptimedb/scripts/benchmark.py query \
 python3 .agents/skills/benchmark-greptimedb/scripts/benchmark.py analyze \
   --profile smoke --database-id loaded-db --hot-runs 2
 
+python3 .agents/skills/benchmark-greptimedb/scripts/benchmark.py query \
+  --database-id loaded-db \
+  --greptime-config .benchmarks/greptimedb/configs/scan-1024.toml
+
 python3 .agents/skills/benchmark-greptimedb/scripts/benchmark.py compare \
   --baseline-run .benchmarks/greptimedb/runs/BASELINE_RUN \
   --candidate-run .benchmarks/greptimedb/runs/CANDIDATE_RUN
@@ -63,6 +67,37 @@ python3 .agents/skills/benchmark-greptimedb/scripts/benchmark.py compare \
 python3 .agents/skills/benchmark-greptimedb/scripts/benchmark.py summarize \
   --run-dir .benchmarks/greptimedb/runs/RUN_ID
 ```
+
+### Custom managed configuration
+
+When the user requests GreptimeDB settings but does not provide a TOML file,
+read GreptimeDB's official [standalone example](https://github.com/GreptimeTeam/greptimedb/blob/main/config/standalone.example.toml)
+before writing the config. The full set of examples is in the upstream
+[config directory](https://github.com/GreptimeTeam/greptimedb/tree/main/config).
+For a release runtime, replace `main` in the standalone URL with the exact
+`vVERSION` tag selected by the prepared workspace or `--greptime-version`.
+Use `main` only for a main or nightly runtime; if the matching release template
+is unavailable, report that instead of silently consulting a different
+version.
+
+Create a minimal file under
+`.benchmarks/greptimedb/configs/DESCRIPTIVE_NAME.toml` containing only the
+requested overrides, with the same table nesting and value types as the
+matching upstream example. Do not copy all default settings. For example:
+
+```toml
+[[region_engine]]
+[region_engine.mito]
+max_concurrent_scan_files = 1024
+```
+
+Pass the file with `--greptime-config`. It is a live source file: the run
+records its resolved path but does not copy or checksum-pin its contents, and
+later starts read its current contents. Resuming the same run without the flag
+reuses the recorded path; selecting another path requires a new run. The
+runner's CLI values for HTTP address, InfluxDB enablement, data home, and log
+directory override conflicting values in the TOML. Custom configs apply only
+to managed targets, not `--endpoint`.
 
 Repeat `--query-type` to define query-set membership; omit it for every type
 allowed by `--query-scope full|fixed-host` (default `full`). The fixed-host
@@ -110,7 +145,8 @@ baseline and one or more repeated `--candidate-run` paths. Comparison requires
 managed targets, complete successful query results, and identical SQL database,
 dataset identity/checksum, query-set identity/checksum, membership, query
 counts, and repetitions. Database IDs may differ. A valid comparison is
-report-only and succeeds even when candidates regress.
+report-only and succeeds even when candidates regress. Custom config paths may
+differ and are reported rather than treated as comparison compatibility fields.
 
 Query and analysis commands prepare logical dataset metadata without generating data.
 Use `--dataset-id` or `--dataset-path` to pin a dataset. Shared query sets live
@@ -144,7 +180,8 @@ directly into the loader without a temporary plain file.
 ## Report results
 
 Read `summary.json` and report the dataset ID and checksum, query-set ID and
-manifest checksum, database ID or external target, metrics/second and
+manifest checksum, database ID or external target, custom config path when
+present, metrics/second and
 rows/second for ingestion, weighted mean latency per query type, failures and
 their log paths, and the run directory. Preserve failed-run diagnostics.
 For analysis, also report each query type's attempt and cold/hot result paths,

--- a/.agents/skills/benchmark-greptimedb/references/workload.md
+++ b/.agents/skills/benchmark-greptimedb/references/workload.md
@@ -10,6 +10,7 @@
 │   └── queries/<query-type>.dat
 └── greptimedb/
     ├── installations/<version>/<platform>/{manifest.json,greptime,...}
+    ├── configs/<descriptive-name>.toml
     ├── databases/<database-id>/{manifest.json,data/,logs/}
     ├── runs/<run-id>/
     │   ├── manifest.json
@@ -107,7 +108,9 @@ The database manifest's installation identity describes the version bound when
 the workspace was prepared or copied. A confirmed query-only override does not
 change it. The run target records the actual runtime version and checksum plus
 the workspace-bound identity, making separate runs safe to compare without
-rebinding metadata.
+rebinding metadata. A custom managed configuration records only its resolved
+live source path. Its contents are read again on every server start and are not
+copied or checksum-pinned by the runner.
 
 Copied workspaces retain the source dataset binding and record their origin,
 source manifest checksum, full-copy method, and copied file and byte counts.

--- a/.agents/skills/benchmark-greptimedb/scripts/benchmark.py
+++ b/.agents/skills/benchmark-greptimedb/scripts/benchmark.py
@@ -805,16 +805,19 @@ def managed_process(
 
 
 @contextlib.contextmanager
-def connection(args: argparse.Namespace, run_dir: Path, existing_target: dict[str, Any] | None = None) -> Iterator[tuple[str, bool, dict[str, Any] | None, Path | None, dict[str, Any]]]:
+def connection(args: argparse.Namespace, run_dir: Path, manifest: dict[str, Any]) -> Iterator[tuple[str, bool, dict[str, Any] | None, Path | None]]:
+    existing_target = manifest.get("target")
     if args.endpoint:
         endpoint = args.endpoint.rstrip("/")
         target = {"mode": "external", "endpoint": endpoint, "database": args.database, "database_id": None, "version": None, "binary_sha256": None}
         if existing_target and not target_matches(existing_target, target):
             raise BenchmarkError("run target is immutable; create a new run for another GreptimeDB version or target")
-        yield endpoint, False, None, None, target; return
+        manifest["target"] = target; save_manifest(run_dir, manifest)
+        yield endpoint, False, None, None; return
     with managed_workspace(args, existing_target) as (workspace, database_manifest, binary, config_file, target):
+        manifest["target"] = target; save_manifest(run_dir, manifest)
         with managed_process(args, workspace, binary, run_dir / "logs" / "greptimedb-process.log", config_file) as endpoint:
-            yield endpoint, True, database_manifest, workspace, target
+            yield endpoint, True, database_manifest, workspace
 
 
 def add_run_options(parser: argparse.ArgumentParser) -> None:
@@ -904,8 +907,7 @@ def main(argv: Sequence[str] | None = None) -> int:
             if args.only in ("all", "data"): generate_data(args, run_dir, manifest)
             if args.only in ("all", "queries"): generate_queries(args, run_dir, manifest)
         elif args.command in ("load", "query", "all"):
-            with connection(args, run_dir, manifest.get("target")) as (endpoint, managed, database_manifest, database_path, target):
-                manifest["target"] = target; save_manifest(run_dir, manifest)
+            with connection(args, run_dir, manifest) as (endpoint, managed, database_manifest, database_path):
                 if args.command in ("load", "all"): load_data(args, run_dir, manifest, endpoint, managed, database_manifest, database_path)
                 if args.command in ("query", "all"): run_queries(args, run_dir, manifest, endpoint, database_manifest)
         elif args.command == "analyze":

--- a/.agents/skills/benchmark-greptimedb/scripts/benchmark.py
+++ b/.agents/skills/benchmark-greptimedb/scripts/benchmark.py
@@ -517,7 +517,31 @@ def managed_binary(args: argparse.Namespace, manifest: dict[str, Any]) -> Path:
     return args.greptime_bin.expanduser().resolve()
 
 
-def managed_target(args: argparse.Namespace, manifest: dict[str, Any], binary: Path) -> dict[str, Any]:
+def resolve_greptime_config(
+    args: argparse.Namespace,
+    existing_target: dict[str, Any] | None = None,
+) -> Path | None:
+    requested = getattr(args, "greptime_config", None)
+    recorded = (existing_target or {}).get("config_file")
+    path = requested.expanduser().resolve() if requested else Path(recorded) if recorded else None
+    if path is None:
+        return None
+    if not path.is_file():
+        raise BenchmarkError(f"GreptimeDB config file does not exist or is not a file: {path}")
+    try:
+        with path.open("rb"):
+            pass
+    except OSError as exc:
+        raise BenchmarkError(f"GreptimeDB config file is not readable: {path}") from exc
+    return path
+
+
+def managed_target(
+    args: argparse.Namespace,
+    manifest: dict[str, Any],
+    binary: Path,
+    config_file: Path | None = None,
+) -> dict[str, Any]:
     runtime_version = getattr(args, "greptime_version", None)
     if runtime_version:
         runtime_version = runtime_version.lstrip("v")
@@ -526,7 +550,7 @@ def managed_target(args: argparse.Namespace, manifest: dict[str, Any], binary: P
     workspace_version = manifest.get("version")
     workspace_checksum = manifest.get("binary_sha256")
     runtime_checksum = sha256_file(binary)
-    return {
+    target = {
         "mode": "managed",
         "endpoint": f"http://127.0.0.1:{args.http_port}",
         "database": args.database,
@@ -537,11 +561,16 @@ def managed_target(args: argparse.Namespace, manifest: dict[str, Any], binary: P
         "workspace_binary_sha256": workspace_checksum,
         "version_override": bool(runtime_version and workspace_version and runtime_version != workspace_version),
     }
+    if config_file is not None:
+        target["config_file"] = str(config_file)
+    return target
 
 
 def target_matches(existing: dict[str, Any], requested: dict[str, Any]) -> bool:
     if existing == requested:
         return True
+    if requested.get("config_file") is not None:
+        return False
     legacy_fields = {"mode", "endpoint", "database", "database_id", "version", "binary_sha256"}
     return not existing.keys() - legacy_fields and existing == {key: requested.get(key) for key in existing}
 
@@ -611,6 +640,7 @@ def run_analyses(
     workspace: Path,
     database_manifest: dict[str, Any],
     binary: Path,
+    config_file: Path | None = None,
 ) -> None:
     execution_count = 1 + args.hot_runs
     insufficient = {
@@ -676,7 +706,7 @@ def run_analyses(
             f"--results-file={metrics_path}",
         ]
         try:
-            with managed_process(args, workspace, binary, process_log):
+            with managed_process(args, workspace, binary, process_log, config_file):
                 run_tee(command, runner_log)
             expected = [cold_path, *hot_paths, metrics_path]
             missing = [path for path in expected if not path.is_file()]
@@ -719,19 +749,26 @@ def check_port_available(port: int, timeout: float = 5.0) -> None:
 def managed_workspace(
     args: argparse.Namespace,
     existing_target: dict[str, Any] | None = None,
-) -> Iterator[tuple[Path, dict[str, Any], Path, dict[str, Any]]]:
+) -> Iterator[tuple[Path, dict[str, Any], Path, Path | None, dict[str, Any]]]:
     workspace, database_manifest = prepare_database_workspace(args)
     with lock_database(workspace):
         binary = managed_binary(args, database_manifest)
-        target = managed_target(args, database_manifest, binary)
+        config_file = resolve_greptime_config(args, existing_target)
+        target = managed_target(args, database_manifest, binary, config_file)
         if existing_target and not target_matches(existing_target, target):
             raise BenchmarkError("run target is immutable; create a new run for another GreptimeDB version or target")
         if not binary.is_file() or not os.access(binary, os.X_OK): raise BenchmarkError(f"GreptimeDB binary is not executable: {binary}")
-        yield workspace, database_manifest, binary, target
+        yield workspace, database_manifest, binary, config_file, target
 
 
 @contextlib.contextmanager
-def managed_process(args: argparse.Namespace, workspace: Path, binary: Path, process_log_path: Path) -> Iterator[str]:
+def managed_process(
+    args: argparse.Namespace,
+    workspace: Path,
+    binary: Path,
+    process_log_path: Path,
+    config_file: Path | None = None,
+) -> Iterator[str]:
     process_log_path.parent.mkdir(parents=True, exist_ok=True)
     process_log = process_log_path.open("a", encoding="utf-8")
     try:
@@ -742,6 +779,8 @@ def managed_process(args: argparse.Namespace, workspace: Path, binary: Path, pro
         raise
     endpoint = f"http://127.0.0.1:{args.http_port}"
     command = [str(binary), "standalone", "start", "--http-addr", f"127.0.0.1:{args.http_port}", "--influxdb-enable", "--data-home", str(workspace / "data"), "--log-dir", str(workspace / "logs")]
+    if config_file is not None:
+        command.extend(["--config-file", str(config_file)])
     process_log.write(f"$ {display_command(command)}\n")
     process_log.flush()
     try:
@@ -773,8 +812,8 @@ def connection(args: argparse.Namespace, run_dir: Path, existing_target: dict[st
         if existing_target and not target_matches(existing_target, target):
             raise BenchmarkError("run target is immutable; create a new run for another GreptimeDB version or target")
         yield endpoint, False, None, None, target; return
-    with managed_workspace(args, existing_target) as (workspace, database_manifest, binary, target):
-        with managed_process(args, workspace, binary, run_dir / "logs" / "greptimedb-process.log") as endpoint:
+    with managed_workspace(args, existing_target) as (workspace, database_manifest, binary, config_file, target):
+        with managed_process(args, workspace, binary, run_dir / "logs" / "greptimedb-process.log", config_file) as endpoint:
             yield endpoint, True, database_manifest, workspace, target
 
 
@@ -788,7 +827,7 @@ def add_run_options(parser: argparse.ArgumentParser) -> None:
 
 
 def add_connection_options(parser: argparse.ArgumentParser) -> None:
-    parser.add_argument("--greptime-bin", type=Path); parser.add_argument("--endpoint"); parser.add_argument("--http-port", type=int, default=4000); parser.add_argument("--startup-timeout", type=int, default=60); parser.add_argument("--database", help=f"SQL database name (default: {DEFAULT_DATABASE})"); parser.add_argument("--database-id"); parser.add_argument("--database-root", type=Path)
+    parser.add_argument("--greptime-bin", type=Path); parser.add_argument("--greptime-config", type=Path, metavar="PATH", help="live GreptimeDB standalone TOML config for managed targets"); parser.add_argument("--endpoint"); parser.add_argument("--http-port", type=int, default=4000); parser.add_argument("--startup-timeout", type=int, default=60); parser.add_argument("--database", help=f"SQL database name (default: {DEFAULT_DATABASE})"); parser.add_argument("--database-id"); parser.add_argument("--database-root", type=Path)
 
 
 def add_version_override_options(parser: argparse.ArgumentParser) -> None:
@@ -830,7 +869,10 @@ def validate_args(args: argparse.Namespace) -> None:
         if value and not ID_RE.fullmatch(value): raise BenchmarkError(f"--{name.replace('_', '-')} contains invalid characters")
     if args.command in ("load", "query", "analyze", "all"):
         greptime_version = getattr(args, "greptime_version", None)
-        if args.endpoint and (args.greptime_bin or args.database_id or greptime_version): raise BenchmarkError("external GreptimeDB cannot use managed binary or database options")
+        greptime_config = getattr(args, "greptime_config", None)
+        if args.endpoint and (args.greptime_bin or args.database_id or greptime_version or greptime_config): raise BenchmarkError("external GreptimeDB cannot use managed binary, config, or database options")
+        if greptime_config:
+            resolve_greptime_config(args)
         if not args.endpoint and not args.database_id: raise BenchmarkError("provide --database-id for managed GreptimeDB or --endpoint for external GreptimeDB")
         if args.endpoint and args.database_id: raise BenchmarkError("--database-id is only valid with managed GreptimeDB")
         if greptime_version and args.greptime_bin: raise BenchmarkError("--greptime-version cannot be combined with --greptime-bin")
@@ -867,9 +909,9 @@ def main(argv: Sequence[str] | None = None) -> int:
                 if args.command in ("load", "all"): load_data(args, run_dir, manifest, endpoint, managed, database_manifest, database_path)
                 if args.command in ("query", "all"): run_queries(args, run_dir, manifest, endpoint, database_manifest)
         elif args.command == "analyze":
-            with managed_workspace(args, manifest.get("target")) as (workspace, database_manifest, binary, target):
+            with managed_workspace(args, manifest.get("target")) as (workspace, database_manifest, binary, config_file, target):
                 manifest["target"] = target; save_manifest(run_dir, manifest)
-                run_analyses(args, run_dir, manifest, workspace, database_manifest, binary)
+                run_analyses(args, run_dir, manifest, workspace, database_manifest, binary, config_file)
         summary = write_summary(run_dir, manifest); print(f"Run directory: {run_dir}"); print(f"Summary: {run_dir / 'summary.md'}"); return 1 if summary["failures"] else 0
     except (BenchmarkError, ComparisonError, TsbsEnvironmentError, OSError, ValueError, json.JSONDecodeError, KeyError, TypeError) as exc:
         if run_dir is not None and manifest is not None:

--- a/.agents/skills/benchmark-greptimedb/scripts/compare.py
+++ b/.agents/skills/benchmark-greptimedb/scripts/compare.py
@@ -88,6 +88,7 @@ def run_for_comparison(run_dir: Path) -> dict[str, Any]:
         "database_id": target.get("database_id"),
         "version": target["version"],
         "binary_sha256": target["binary_sha256"],
+        "config_file": target.get("config_file"),
         "manifest_sha256": sha256_file(run_dir / "manifest.json"),
         "identity": identity,
         "queries": queries,
@@ -95,7 +96,7 @@ def run_for_comparison(run_dir: Path) -> dict[str, Any]:
 
 
 def run_identity(run: dict[str, Any]) -> dict[str, Any]:
-    return {key: run[key] for key in ("path", "run_id", "database_id", "version", "binary_sha256", "manifest_sha256")}
+    return {key: run[key] for key in ("path", "run_id", "database_id", "version", "binary_sha256", "config_file", "manifest_sha256")}
 
 
 def compare_candidate(baseline: dict[str, Any], candidate: dict[str, Any]) -> dict[str, Any]:
@@ -150,12 +151,19 @@ def render_markdown(summary: dict[str, Any]) -> str:
     lines = [
         f"# GreptimeDB version comparison: {summary['comparison_id']}", "",
         f"- Baseline: `{baseline['version']}` (`{baseline['run_id']}`)",
-        f"- Baseline run: `{baseline['path']}`", "",
+        f"- Baseline run: `{baseline['path']}`",
     ]
+    if baseline.get("config_file"):
+        lines.append(f"- Baseline GreptimeDB config: `{baseline['config_file']}`")
+    lines.append("")
     for candidate in summary["candidates"]:
         lines.extend([
             f"## Candidate `{candidate['version']}` (`{candidate['run_id']}`)", "",
             f"- Candidate run: `{candidate['path']}`",
+        ])
+        if candidate.get("config_file"):
+            lines.append(f"- Candidate GreptimeDB config: `{candidate['config_file']}`")
+        lines.extend([
             f"- Improved: {candidate['counts']['improved']}; unchanged: {candidate['counts']['unchanged']}; regressed: {candidate['counts']['regressed']}", "",
             "| Query type | Baseline (ms) | Candidate (ms) | Delta (ms) | Delta (%) | Latency ratio | Result |",
             "| --- | ---: | ---: | ---: | ---: | ---: | --- |",

--- a/.agents/skills/benchmark-greptimedb/scripts/summarize.py
+++ b/.agents/skills/benchmark-greptimedb/scripts/summarize.py
@@ -101,6 +101,8 @@ def render_markdown(summary: dict[str, Any]) -> str:
         if target.get("binary_sha256"):
             label = "Runtime GreptimeDB binary SHA-256" if target.get("version_override") else "GreptimeDB binary SHA-256"
             lines.append(f"- {label}: `{target.get('binary_sha256')}`")
+        if target.get("config_file"):
+            lines.append(f"- GreptimeDB config file: `{target.get('config_file')}`")
         if target.get("version_override"):
             lines.append(f"- Workspace-bound GreptimeDB version: `{target.get('workspace_version')}`")
             lines.append(f"- Workspace-bound binary SHA-256: `{target.get('workspace_binary_sha256')}`")

--- a/.agents/skills/benchmark-greptimedb/tests/test_benchmark.py
+++ b/.agents/skills/benchmark-greptimedb/tests/test_benchmark.py
@@ -673,6 +673,47 @@ class ManagedDatabaseTests(unittest.TestCase):
             legacy_target = {key: target[key] for key in ("mode", "endpoint", "database", "database_id", "version", "binary_sha256")}
             self.assertFalse(benchmark.target_matches(legacy_target, target))
 
+    def test_connection_persists_config_before_startup_failure_and_reuses_it(self) -> None:
+        with tempfile.TemporaryDirectory() as temp:
+            root = Path(temp); run_dir = root / "run"; (run_dir / "logs").mkdir(parents=True)
+            config = root / "standalone.toml"; config.write_text("max_concurrent_queries = 1\n", encoding="utf-8")
+            database_root = root / "databases"
+            parser = benchmark.make_parser()
+            args = parser.parse_args([
+                "query", "--greptime-bin", sys.executable, "--database-id", "db-a",
+                "--database-root", str(database_root), "--greptime-config", str(config),
+            ])
+            benchmark.resolve_database(args); benchmark.validate_args(args)
+            manifest = {"events": {"loads": [], "queries": [], "analyses": []}}
+            benchmark.save_manifest(run_dir, manifest)
+
+            with mock.patch.object(
+                benchmark, "managed_process", side_effect=benchmark.BenchmarkError("startup failed")
+            ) as process:
+                with self.assertRaisesRegex(benchmark.BenchmarkError, "startup failed"):
+                    with benchmark.connection(args, run_dir, manifest):
+                        pass
+
+            resolved_config = config.resolve()
+            self.assertEqual(process.call_args.args[4], resolved_config)
+            saved = benchmark.read_json(run_dir / "manifest.json")
+            self.assertEqual(saved["target"]["config_file"], str(resolved_config))
+
+            resumed = parser.parse_args([
+                "query", "--greptime-bin", sys.executable, "--database-id", "db-a",
+                "--database-root", str(database_root),
+            ])
+            benchmark.resolve_database(resumed); benchmark.validate_args(resumed)
+            with mock.patch.object(
+                benchmark, "managed_process", side_effect=benchmark.BenchmarkError("startup failed again")
+            ) as resumed_process:
+                with self.assertRaisesRegex(benchmark.BenchmarkError, "startup failed again"):
+                    with benchmark.connection(resumed, run_dir, saved):
+                        pass
+
+            self.assertEqual(resumed_process.call_args.args[4], resolved_config)
+            self.assertEqual(benchmark.read_json(run_dir / "manifest.json")["target"]["config_file"], str(resolved_config))
+
     def test_config_file_rejects_invalid_paths_and_external_targets(self) -> None:
         with tempfile.TemporaryDirectory() as temp:
             root = Path(temp)

--- a/.agents/skills/benchmark-greptimedb/tests/test_benchmark.py
+++ b/.agents/skills/benchmark-greptimedb/tests/test_benchmark.py
@@ -55,7 +55,10 @@ class SummaryIntegrationTests(unittest.TestCase):
                     "run_id": "run",
                     "profile": "smoke",
                     "database": "benchmark",
-                    "target": {"mode": "managed", "database_id": "db-a", "version": "1.1.4", "binary_sha256": "def"},
+                    "target": {
+                        "mode": "managed", "database_id": "db-a", "version": "1.1.4",
+                        "binary_sha256": "def", "config_file": "/configs/scan.toml",
+                    },
                     "dataset": {"dataset_id": "data-a"},
                     "query_set": {
                         "query_set_id": "set-a",
@@ -69,6 +72,7 @@ class SummaryIntegrationTests(unittest.TestCase):
         self.assertIn("managed:db-a", rendered)
         self.assertIn("GreptimeDB version: `1.1.4`", rendered)
         self.assertIn("GreptimeDB binary SHA-256: `def`", rendered)
+        self.assertIn("GreptimeDB config file: `/configs/scan.toml`", rendered)
         self.assertIn("set-a", rendered)
 
     def test_version_override_identity_is_rendered(self) -> None:
@@ -107,7 +111,7 @@ class QuerySetIdentityTests(unittest.TestCase):
 
 
 class VersionComparisonTests(unittest.TestCase):
-    def make_run(self, root: Path, name: str, version: str, means: dict[str, float], *, dataset_id: str = "data-a") -> Path:
+    def make_run(self, root: Path, name: str, version: str, means: dict[str, float], *, dataset_id: str = "data-a", config_file: str | None = None) -> Path:
         run_dir = root / name; (run_dir / "results").mkdir(parents=True); (run_dir / "logs").mkdir()
         query_counts = {query_type: 10 for query_type in means}
         events = []
@@ -120,11 +124,14 @@ class VersionComparisonTests(unittest.TestCase):
                 "log": f"logs/{query_type}.log", "results": f"results/{query_type}.json",
                 "status": "completed",
             })
+        target = {"mode": "managed", "database_id": f"db-{version}", "version": version, "binary_sha256": version * 4}
+        if config_file:
+            target["config_file"] = config_file
         manifest = {
             "schema_version": 1, "kind": "greptimedb-run", "run_id": name,
             "created_at": benchmark.utc_now(), "profile": "manual", "database": "benchmark",
             "workload": {"query_counts": query_counts},
-            "target": {"mode": "managed", "database_id": f"db-{version}", "version": version, "binary_sha256": version * 4},
+            "target": target,
             "dataset": {"dataset_id": dataset_id, "spec": {"scale": 10}, "format": "influx", "bytes": 100, "sha256": "d" * 64},
             "query_set": {"query_set_id": "set-a", "manifest_sha256": "q" * 64, "spec": {"query_counts": query_counts}},
             "events": {"loads": [], "queries": events},
@@ -172,6 +179,19 @@ class VersionComparisonTests(unittest.TestCase):
             query = json.loads((output / "summary.json").read_text())["candidates"][0]["queries"][0]
             self.assertIsNone(query["delta_percent"])
             self.assertIsNone(query["latency_ratio"])
+
+    def test_allows_and_reports_different_config_files(self) -> None:
+        with tempfile.TemporaryDirectory() as temp:
+            root = Path(temp)
+            baseline = self.make_run(root, "baseline", "1.1.4", {"lastpoint": 10.0}, config_file="/configs/default.toml")
+            candidate = self.make_run(root, "candidate", "1.0.0", {"lastpoint": 12.0}, config_file="/configs/tuned.toml")
+            output = version_compare.create_comparison(baseline, [candidate], root / "comparisons")
+            summary = json.loads((output / "summary.json").read_text())
+            self.assertEqual(summary["baseline"]["config_file"], "/configs/default.toml")
+            self.assertEqual(summary["candidates"][0]["config_file"], "/configs/tuned.toml")
+            rendered = (output / "summary.md").read_text()
+            self.assertIn("Baseline GreptimeDB config: `/configs/default.toml`", rendered)
+            self.assertIn("Candidate GreptimeDB config: `/configs/tuned.toml`", rendered)
 
 
 class WorkspaceTests(unittest.TestCase):
@@ -415,13 +435,15 @@ class AnalyzeTests(unittest.TestCase):
             query_counts = {"lastpoint": 3, "cpu-max-all-1": 3}
             manifest = self.manifest(query_counts)
             args = self.args(run_dir)
+            config_file = Path(temp) / "standalone.toml"
+            config_file.write_text("max_concurrent_queries = 1\n", encoding="utf-8")
             starts = []
 
             @contextlib.contextmanager
-            def process(_args, _workspace, _binary, log_path):
+            def process(_args, _workspace, _binary, log_path, _config_file=None):
                 log_path.parent.mkdir(parents=True, exist_ok=True)
                 log_path.write_text("server started\n", encoding="utf-8")
-                starts.append(log_path)
+                starts.append(_config_file)
                 yield "http://127.0.0.1:4000"
 
             patches = (
@@ -433,10 +455,11 @@ class AnalyzeTests(unittest.TestCase):
                 mock.patch.object(benchmark, "run_tee", side_effect=self.execute),
             )
             with patches[0], patches[1], patches[2], patches[3], patches[4], patches[5] as runner:
-                benchmark.run_analyses(args, run_dir, manifest, Path(temp), {"binding": {}}, Path("/greptime"))
-                benchmark.run_analyses(args, run_dir, manifest, Path(temp), {"binding": {}}, Path("/greptime"))
+                benchmark.run_analyses(args, run_dir, manifest, Path(temp), {"binding": {}}, Path("/greptime"), config_file)
+                benchmark.run_analyses(args, run_dir, manifest, Path(temp), {"binding": {}}, Path("/greptime"), config_file)
 
             self.assertEqual(len(starts), 4)
+            self.assertEqual(starts, [config_file] * 4)
             self.assertEqual(runner.call_count, 4)
             self.assertEqual([event["attempt"] for event in manifest["events"]["analyses"]], [1, 1, 2, 2])
             for query_type in query_counts:
@@ -613,6 +636,86 @@ class ManagedDatabaseTests(unittest.TestCase):
         benchmark.resolve_database(args)
         with self.assertRaisesRegex(benchmark.BenchmarkError, "database-id"):
             benchmark.validate_args(args)
+
+    def test_config_file_is_validated_and_reused_by_path(self) -> None:
+        with tempfile.TemporaryDirectory() as temp:
+            root = Path(temp)
+            config_a = root / "a.toml"; config_a.write_text("max_concurrent_queries = 1\n", encoding="utf-8")
+            config_b = root / "b.toml"; config_b.write_text("max_concurrent_queries = 2\n", encoding="utf-8")
+            binary = root / "greptime"; binary.write_text("binary", encoding="utf-8")
+            parser = benchmark.make_parser()
+            args = parser.parse_args([
+                "query", "--greptime-bin", "/bin/true", "--database-id", "db-a",
+                "--greptime-config", str(config_a),
+            ])
+            benchmark.resolve_database(args); benchmark.validate_args(args)
+            resolved = benchmark.resolve_greptime_config(args)
+            self.assertEqual(resolved, config_a.resolve())
+            manifest = {"database_id": "db-a", "database": "benchmark", "binding": None}
+            target = benchmark.managed_target(args, manifest, binary, resolved)
+            self.assertEqual(target["config_file"], str(config_a.resolve()))
+
+            resumed = parser.parse_args(["query", "--greptime-bin", "/bin/true", "--database-id", "db-a"])
+            benchmark.resolve_database(resumed)
+            self.assertEqual(benchmark.resolve_greptime_config(resumed, target), config_a.resolve())
+            config_a.write_text("max_concurrent_queries = 3\n", encoding="utf-8")
+            self.assertEqual(benchmark.resolve_greptime_config(resumed, target), config_a.resolve())
+
+            changed = parser.parse_args([
+                "query", "--greptime-bin", "/bin/true", "--database-id", "db-a",
+                "--greptime-config", str(config_b),
+            ])
+            benchmark.resolve_database(changed)
+            changed_target = benchmark.managed_target(
+                changed, manifest, binary, benchmark.resolve_greptime_config(changed, target)
+            )
+            self.assertFalse(benchmark.target_matches(target, changed_target))
+            legacy_target = {key: target[key] for key in ("mode", "endpoint", "database", "database_id", "version", "binary_sha256")}
+            self.assertFalse(benchmark.target_matches(legacy_target, target))
+
+    def test_config_file_rejects_invalid_paths_and_external_targets(self) -> None:
+        with tempfile.TemporaryDirectory() as temp:
+            root = Path(temp)
+            parser = benchmark.make_parser()
+            missing = parser.parse_args([
+                "query", "--database-id", "db-a", "--greptime-config", str(root / "missing.toml"),
+            ])
+            benchmark.resolve_database(missing)
+            with self.assertRaisesRegex(benchmark.BenchmarkError, "does not exist"):
+                benchmark.validate_args(missing)
+
+            config = root / "config.toml"; config.write_text("max_concurrent_queries = 1\n", encoding="utf-8")
+            external = parser.parse_args([
+                "query", "--endpoint", "http://localhost:4000", "--greptime-config", str(config),
+            ])
+            benchmark.resolve_database(external)
+            with self.assertRaisesRegex(benchmark.BenchmarkError, "external GreptimeDB"):
+                benchmark.validate_args(external)
+
+    def test_managed_process_passes_config_and_managed_overrides(self) -> None:
+        with tempfile.TemporaryDirectory() as temp:
+            root = Path(temp); workspace = root / "workspace"; workspace.mkdir()
+            config = root / "config.toml"; config.write_text("[http]\naddr = \"0.0.0.0:9000\"\n", encoding="utf-8")
+            args = benchmark.make_parser().parse_args([
+                "query", "--database-id", "db-a", "--http-port", "4100",
+            ])
+            process = mock.Mock(pid=1234)
+            process.poll.return_value = None
+            process.wait.return_value = 0
+            with mock.patch.object(benchmark, "check_port_available"), mock.patch.object(
+                benchmark, "endpoint_ready", return_value=True
+            ), mock.patch.object(benchmark.subprocess, "Popen", return_value=process) as popen, mock.patch.object(
+                benchmark.os, "killpg"
+            ):
+                with benchmark.managed_process(args, workspace, Path("/greptime"), root / "process.log", config):
+                    pass
+            command = popen.call_args.args[0]
+            self.assertIn("--config-file", command)
+            self.assertEqual(command[command.index("--config-file") + 1], str(config))
+            self.assertEqual(command[command.index("--http-addr") + 1], "127.0.0.1:4100")
+            self.assertEqual(command[command.index("--data-home") + 1], str(workspace / "data"))
+            self.assertEqual(command[command.index("--log-dir") + 1], str(workspace / "logs"))
+            self.assertIn("--influxdb-enable", command)
 
     def test_gzip_dataset_is_streamed_to_loader_stdin(self) -> None:
         with tempfile.TemporaryDirectory() as temp:


### PR DESCRIPTION
## Summary

- add `--greptime-config` support for managed GreptimeDB benchmark runs and analysis restarts
- preserve the live config path in run summaries and version-comparison reports
- document version-matched upstream standalone config examples and minimal TOML generation

## Tests

- `python3 -m unittest discover -s .agents/skills/benchmark-greptimedb/tests -p 'test_*.py'`
- `python3 -m py_compile .agents/skills/benchmark-greptimedb/scripts/benchmark.py .agents/skills/benchmark-greptimedb/scripts/compare.py .agents/skills/benchmark-greptimedb/scripts/summarize.py`
- `python3 /Users/evenyag/.codex/skills/.system/skill-creator/scripts/quick_validate.py .agents/skills/benchmark-greptimedb`
- `git diff --check`