### PR TITLE
feat: support S3 benchmark storage

### DIFF
--- a/.agents/lib/tomli/LICENSE
+++ b/.agents/lib/tomli/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2021 Taneli Hukkinen
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/.agents/lib/tomli/__init__.py
+++ b/.agents/lib/tomli/__init__.py
@@ -1,0 +1,8 @@
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2021 Taneli Hukkinen
+# Licensed to PSF under a Contributor Agreement.
+
+__all__ = ("loads", "load", "TOMLDecodeError")
+__version__ = "2.4.1"  # DO NOT EDIT THIS LINE MANUALLY. LET bump2version UTILITY DO IT
+
+from ._parser import TOMLDecodeError, load, loads

--- a/.agents/lib/tomli/_parser.py
+++ b/.agents/lib/tomli/_parser.py
@@ -1,0 +1,793 @@
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2021 Taneli Hukkinen
+# Licensed to PSF under a Contributor Agreement.
+
+from __future__ import annotations
+
+import sys
+from types import MappingProxyType
+
+from ._re import (
+    RE_DATETIME,
+    RE_LOCALTIME,
+    RE_NUMBER,
+    match_to_datetime,
+    match_to_localtime,
+    match_to_number,
+)
+
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from collections.abc import Iterable
+    from typing import IO, Any, Final
+
+    from ._types import Key, ParseFloat, Pos
+
+# Inline tables/arrays are implemented using recursion. Pathologically
+# nested documents cause pure Python to raise RecursionError (which is OK),
+# but mypyc binary wheels will crash unrecoverably (not OK). According to
+# mypyc docs this will be fixed in the future:
+# https://mypyc.readthedocs.io/en/latest/differences_from_python.html#stack-overflows
+# Before mypyc's fix is in, recursion needs to be limited by this library.
+# Choosing `sys.getrecursionlimit()` as maximum inline table/array nesting
+# level, as it allows more nesting than pure Python, but still seems a far
+# lower number than where mypyc binaries crash.
+MAX_INLINE_NESTING: Final = sys.getrecursionlimit()
+
+# Pathologically excessive number of parts in a key runs into quadratic
+# behavior (e.g. in Flags.is_).
+# Even if keys aren't currently parsed using recursion, they name a
+# recursive structure, so it makes sense to limit it using getrecursionlimit()
+# and RecursionError.
+MAX_KEY_PARTS: Final = sys.getrecursionlimit()
+
+ASCII_CTRL: Final = frozenset(chr(i) for i in range(32)) | frozenset(chr(127))
+
+# Neither of these sets include quotation mark or backslash. They are
+# currently handled as separate cases in the parser functions.
+ILLEGAL_BASIC_STR_CHARS: Final = ASCII_CTRL - frozenset("\t")
+ILLEGAL_MULTILINE_BASIC_STR_CHARS: Final = ASCII_CTRL - frozenset("\t\n")
+
+ILLEGAL_LITERAL_STR_CHARS: Final = ILLEGAL_BASIC_STR_CHARS
+ILLEGAL_MULTILINE_LITERAL_STR_CHARS: Final = ILLEGAL_MULTILINE_BASIC_STR_CHARS
+
+ILLEGAL_COMMENT_CHARS: Final = ILLEGAL_BASIC_STR_CHARS
+
+TOML_WS: Final = frozenset(" \t")
+TOML_WS_AND_NEWLINE: Final = TOML_WS | frozenset("\n")
+BARE_KEY_CHARS: Final = frozenset(
+    "abcdefghijklmnopqrstuvwxyz" "ABCDEFGHIJKLMNOPQRSTUVWXYZ" "0123456789" "-_"
+)
+KEY_INITIAL_CHARS: Final = BARE_KEY_CHARS | frozenset("\"'")
+HEXDIGIT_CHARS: Final = frozenset("abcdef" "ABCDEF" "0123456789")
+
+BASIC_STR_ESCAPE_REPLACEMENTS: Final = MappingProxyType(
+    {
+        "\\b": "\u0008",  # backspace
+        "\\t": "\u0009",  # tab
+        "\\n": "\u000a",  # linefeed
+        "\\f": "\u000c",  # form feed
+        "\\r": "\u000d",  # carriage return
+        "\\e": "\u001b",  # escape
+        '\\"': "\u0022",  # quote
+        "\\\\": "\u005c",  # backslash
+    }
+)
+
+
+class DEPRECATED_DEFAULT:
+    """Sentinel to be used as default arg during deprecation
+    period of TOMLDecodeError's free-form arguments."""
+
+
+class TOMLDecodeError(ValueError):
+    """An error raised if a document is not valid TOML.
+
+    Adds the following attributes to ValueError:
+    msg: The unformatted error message
+    doc: The TOML document being parsed
+    pos: The index of doc where parsing failed
+    lineno: The line corresponding to pos
+    colno: The column corresponding to pos
+    """
+
+    def __init__(
+        self,
+        msg: str | type[DEPRECATED_DEFAULT] = DEPRECATED_DEFAULT,
+        doc: str | type[DEPRECATED_DEFAULT] = DEPRECATED_DEFAULT,
+        pos: Pos | type[DEPRECATED_DEFAULT] = DEPRECATED_DEFAULT,
+        *args: Any,
+    ):
+        if (
+            args
+            or not isinstance(msg, str)
+            or not isinstance(doc, str)
+            or not isinstance(pos, int)
+        ):
+            import warnings
+
+            warnings.warn(
+                "Free-form arguments for TOMLDecodeError are deprecated. "
+                "Please set 'msg' (str), 'doc' (str) and 'pos' (int) arguments only.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+            if pos is not DEPRECATED_DEFAULT:
+                args = pos, *args
+            if doc is not DEPRECATED_DEFAULT:
+                args = doc, *args
+            if msg is not DEPRECATED_DEFAULT:
+                args = msg, *args
+            ValueError.__init__(self, *args)
+            return
+
+        lineno = doc.count("\n", 0, pos) + 1
+        if lineno == 1:
+            colno = pos + 1
+        else:
+            colno = pos - doc.rindex("\n", 0, pos)
+
+        if pos >= len(doc):
+            coord_repr = "end of document"
+        else:
+            coord_repr = f"line {lineno}, column {colno}"
+        errmsg = f"{msg} (at {coord_repr})"
+        ValueError.__init__(self, errmsg)
+
+        self.msg = msg
+        self.doc = doc
+        self.pos = pos
+        self.lineno = lineno
+        self.colno = colno
+
+
+def load(__fp: IO[bytes], *, parse_float: ParseFloat = float) -> dict[str, Any]:
+    """Parse TOML from a binary file object."""
+    b = __fp.read()
+    try:
+        s = b.decode()
+    except AttributeError:
+        raise TypeError(
+            "File must be opened in binary mode, e.g. use `open('foo.toml', 'rb')`"
+        ) from None
+    return loads(s, parse_float=parse_float)
+
+
+def loads(__s: str, *, parse_float: ParseFloat = float) -> dict[str, Any]:
+    """Parse TOML from a string."""
+
+    # The spec allows converting "\r\n" to "\n", even in string
+    # literals. Let's do so to simplify parsing.
+    try:
+        src = __s.replace("\r\n", "\n")
+    except (AttributeError, TypeError):
+        raise TypeError(
+            f"Expected str object, not '{type(__s).__qualname__}'"
+        ) from None
+    pos = 0
+    out = Output()
+    header: Key = ()
+    parse_float = make_safe_parse_float(parse_float)
+
+    # Parse one statement at a time
+    # (typically means one line in TOML source)
+    while True:
+        # 1. Skip line leading whitespace
+        pos = skip_chars(src, pos, TOML_WS)
+
+        # 2. Parse rules. Expect one of the following:
+        #    - end of file
+        #    - end of line
+        #    - comment
+        #    - key/value pair
+        #    - append dict to list (and move to its namespace)
+        #    - create dict (and move to its namespace)
+        # Skip trailing whitespace when applicable.
+        try:
+            char = src[pos]
+        except IndexError:
+            break
+        if char == "\n":
+            pos += 1
+            continue
+        if char in KEY_INITIAL_CHARS:
+            pos = key_value_rule(src, pos, out, header, parse_float)
+            pos = skip_chars(src, pos, TOML_WS)
+        elif char == "[":
+            try:
+                second_char: str | None = src[pos + 1]
+            except IndexError:
+                second_char = None
+            out.flags.finalize_pending()
+            if second_char == "[":
+                pos, header = create_list_rule(src, pos, out)
+            else:
+                pos, header = create_dict_rule(src, pos, out)
+            pos = skip_chars(src, pos, TOML_WS)
+        elif char != "#":
+            raise TOMLDecodeError("Invalid statement", src, pos)
+
+        # 3. Skip comment
+        pos = skip_comment(src, pos)
+
+        # 4. Expect end of line or end of file
+        try:
+            char = src[pos]
+        except IndexError:
+            break
+        if char != "\n":
+            raise TOMLDecodeError(
+                "Expected newline or end of document after a statement", src, pos
+            )
+        pos += 1
+
+    return out.data.dict
+
+
+class Flags:
+    """Flags that map to parsed keys/namespaces."""
+
+    # Marks an immutable namespace (inline array or inline table).
+    FROZEN: Final = 0
+    # Marks a nest that has been explicitly created and can no longer
+    # be opened using the "[table]" syntax.
+    EXPLICIT_NEST: Final = 1
+
+    def __init__(self) -> None:
+        self._flags: dict[str, dict[Any, Any]] = {}
+        self._pending_flags: set[tuple[Key, int]] = set()
+
+    def add_pending(self, key: Key, flag: int) -> None:
+        self._pending_flags.add((key, flag))
+
+    def finalize_pending(self) -> None:
+        for key, flag in self._pending_flags:
+            self.set(key, flag, recursive=False)
+        self._pending_flags.clear()
+
+    def unset_all(self, key: Key) -> None:
+        cont = self._flags
+        for k in key[:-1]:
+            if k not in cont:
+                return
+            cont = cont[k]["nested"]
+        cont.pop(key[-1], None)
+
+    def set(self, key: Key, flag: int, *, recursive: bool) -> None:  # noqa: A003
+        cont = self._flags
+        key_parent, key_stem = key[:-1], key[-1]
+        for k in key_parent:
+            if k not in cont:
+                cont[k] = {"flags": set(), "recursive_flags": set(), "nested": {}}
+            cont = cont[k]["nested"]
+        if key_stem not in cont:
+            cont[key_stem] = {"flags": set(), "recursive_flags": set(), "nested": {}}
+        cont[key_stem]["recursive_flags" if recursive else "flags"].add(flag)
+
+    def is_(self, key: Key, flag: int) -> bool:
+        if not key:
+            return False  # document root has no flags
+        cont = self._flags
+        for k in key[:-1]:
+            if k not in cont:
+                return False
+            inner_cont = cont[k]
+            if flag in inner_cont["recursive_flags"]:
+                return True
+            cont = inner_cont["nested"]
+        key_stem = key[-1]
+        if key_stem in cont:
+            inner_cont = cont[key_stem]
+            return flag in inner_cont["flags"] or flag in inner_cont["recursive_flags"]
+        return False
+
+
+class NestedDict:
+    def __init__(self) -> None:
+        # The parsed content of the TOML document
+        self.dict: dict[str, Any] = {}
+
+    def get_or_create_nest(
+        self,
+        key: Key,
+        *,
+        access_lists: bool = True,
+    ) -> dict[str, Any]:
+        cont: Any = self.dict
+        for k in key:
+            if k not in cont:
+                cont[k] = {}
+            cont = cont[k]
+            if access_lists and isinstance(cont, list):
+                cont = cont[-1]
+            if not isinstance(cont, dict):
+                raise KeyError("There is no nest behind this key")
+        return cont  # type: ignore[no-any-return]
+
+    def append_nest_to_list(self, key: Key) -> None:
+        cont = self.get_or_create_nest(key[:-1])
+        last_key = key[-1]
+        if last_key in cont:
+            list_ = cont[last_key]
+            if not isinstance(list_, list):
+                raise KeyError("An object other than list found behind this key")
+            list_.append({})
+        else:
+            cont[last_key] = [{}]
+
+
+class Output:
+    def __init__(self) -> None:
+        self.data = NestedDict()
+        self.flags = Flags()
+
+
+def skip_chars(src: str, pos: Pos, chars: Iterable[str]) -> Pos:
+    try:
+        while src[pos] in chars:
+            pos += 1
+    except IndexError:
+        pass
+    return pos
+
+
+def skip_until(
+    src: str,
+    pos: Pos,
+    expect: str,
+    *,
+    error_on: frozenset[str],
+    error_on_eof: bool,
+) -> Pos:
+    try:
+        new_pos = src.index(expect, pos)
+    except ValueError:
+        new_pos = len(src)
+        if error_on_eof:
+            raise TOMLDecodeError(f"Expected {expect!r}", src, new_pos) from None
+
+    if not error_on.isdisjoint(src[pos:new_pos]):
+        while src[pos] not in error_on:
+            pos += 1
+        raise TOMLDecodeError(f"Found invalid character {src[pos]!r}", src, pos)
+    return new_pos
+
+
+def skip_comment(src: str, pos: Pos) -> Pos:
+    try:
+        char: str | None = src[pos]
+    except IndexError:
+        char = None
+    if char == "#":
+        return skip_until(
+            src, pos + 1, "\n", error_on=ILLEGAL_COMMENT_CHARS, error_on_eof=False
+        )
+    return pos
+
+
+def skip_comments_and_array_ws(src: str, pos: Pos) -> Pos:
+    while True:
+        pos_before_skip = pos
+        pos = skip_chars(src, pos, TOML_WS_AND_NEWLINE)
+        pos = skip_comment(src, pos)
+        if pos == pos_before_skip:
+            return pos
+
+
+def create_dict_rule(src: str, pos: Pos, out: Output) -> tuple[Pos, Key]:
+    pos += 1  # Skip "["
+    pos = skip_chars(src, pos, TOML_WS)
+    pos, key = parse_key(src, pos)
+
+    if out.flags.is_(key, Flags.EXPLICIT_NEST) or out.flags.is_(key, Flags.FROZEN):
+        raise TOMLDecodeError(f"Cannot declare {key} twice", src, pos)
+    out.flags.set(key, Flags.EXPLICIT_NEST, recursive=False)
+    try:
+        out.data.get_or_create_nest(key)
+    except KeyError:
+        raise TOMLDecodeError("Cannot overwrite a value", src, pos) from None
+
+    if not src.startswith("]", pos):
+        raise TOMLDecodeError(
+            "Expected ']' at the end of a table declaration", src, pos
+        )
+    return pos + 1, key
+
+
+def create_list_rule(src: str, pos: Pos, out: Output) -> tuple[Pos, Key]:
+    pos += 2  # Skip "[["
+    pos = skip_chars(src, pos, TOML_WS)
+    pos, key = parse_key(src, pos)
+
+    if out.flags.is_(key, Flags.FROZEN):
+        raise TOMLDecodeError(f"Cannot mutate immutable namespace {key}", src, pos)
+    # Free the namespace now that it points to another empty list item...
+    out.flags.unset_all(key)
+    # ...but this key precisely is still prohibited from table declaration
+    out.flags.set(key, Flags.EXPLICIT_NEST, recursive=False)
+    try:
+        out.data.append_nest_to_list(key)
+    except KeyError:
+        raise TOMLDecodeError("Cannot overwrite a value", src, pos) from None
+
+    if not src.startswith("]]", pos):
+        raise TOMLDecodeError(
+            "Expected ']]' at the end of an array declaration", src, pos
+        )
+    return pos + 2, key
+
+
+def key_value_rule(
+    src: str, pos: Pos, out: Output, header: Key, parse_float: ParseFloat
+) -> Pos:
+    pos, key, value = parse_key_value_pair(src, pos, parse_float, nest_lvl=0)
+    key_parent, key_stem = key[:-1], key[-1]
+    abs_key_parent = header + key_parent
+
+    relative_path_cont_keys = (header + key[:i] for i in range(1, len(key)))
+    for cont_key in relative_path_cont_keys:
+        # Check that dotted key syntax does not redefine an existing table
+        if out.flags.is_(cont_key, Flags.EXPLICIT_NEST):
+            raise TOMLDecodeError(f"Cannot redefine namespace {cont_key}", src, pos)
+        # Containers in the relative path can't be opened with the table syntax or
+        # dotted key/value syntax in following table sections.
+        out.flags.add_pending(cont_key, Flags.EXPLICIT_NEST)
+
+    if out.flags.is_(abs_key_parent, Flags.FROZEN):
+        raise TOMLDecodeError(
+            f"Cannot mutate immutable namespace {abs_key_parent}", src, pos
+        )
+
+    try:
+        nest = out.data.get_or_create_nest(abs_key_parent)
+    except KeyError:
+        raise TOMLDecodeError("Cannot overwrite a value", src, pos) from None
+    if key_stem in nest:
+        raise TOMLDecodeError("Cannot overwrite a value", src, pos)
+    # Mark inline table and array namespaces recursively immutable
+    if isinstance(value, (dict, list)):
+        out.flags.set(header + key, Flags.FROZEN, recursive=True)
+    nest[key_stem] = value
+    return pos
+
+
+def parse_key_value_pair(
+    src: str, pos: Pos, parse_float: ParseFloat, nest_lvl: int
+) -> tuple[Pos, Key, Any]:
+    pos, key = parse_key(src, pos)
+    try:
+        char: str | None = src[pos]
+    except IndexError:
+        char = None
+    if char != "=":
+        raise TOMLDecodeError("Expected '=' after a key in a key/value pair", src, pos)
+    pos += 1
+    pos = skip_chars(src, pos, TOML_WS)
+    pos, value = parse_value(src, pos, parse_float, nest_lvl)
+    return pos, key, value
+
+
+def parse_key(src: str, pos: Pos) -> tuple[Pos, Key]:
+    pos, key_part = parse_key_part(src, pos)
+    key: Key = (key_part,)
+    pos = skip_chars(src, pos, TOML_WS)
+    while True:
+        try:
+            char: str | None = src[pos]
+        except IndexError:
+            char = None
+        if char != ".":
+            return pos, key
+        pos += 1
+        pos = skip_chars(src, pos, TOML_WS)
+        pos, key_part = parse_key_part(src, pos)
+        key += (key_part,)
+        if len(key) > MAX_KEY_PARTS:
+            raise RecursionError(
+                f"TOML key has more than the allowed {MAX_KEY_PARTS} parts"
+            )
+        pos = skip_chars(src, pos, TOML_WS)
+
+
+def parse_key_part(src: str, pos: Pos) -> tuple[Pos, str]:
+    try:
+        char: str | None = src[pos]
+    except IndexError:
+        char = None
+    if char in BARE_KEY_CHARS:
+        start_pos = pos
+        pos = skip_chars(src, pos, BARE_KEY_CHARS)
+        return pos, src[start_pos:pos]
+    if char == "'":
+        return parse_literal_str(src, pos)
+    if char == '"':
+        return parse_one_line_basic_str(src, pos)
+    raise TOMLDecodeError("Invalid initial character for a key part", src, pos)
+
+
+def parse_one_line_basic_str(src: str, pos: Pos) -> tuple[Pos, str]:
+    pos += 1
+    return parse_basic_str(src, pos, multiline=False)
+
+
+def parse_array(
+    src: str, pos: Pos, parse_float: ParseFloat, nest_lvl: int
+) -> tuple[Pos, list[Any]]:
+    pos += 1
+    array: list[Any] = []
+
+    pos = skip_comments_and_array_ws(src, pos)
+    if src.startswith("]", pos):
+        return pos + 1, array
+    while True:
+        pos, val = parse_value(src, pos, parse_float, nest_lvl)
+        array.append(val)
+        pos = skip_comments_and_array_ws(src, pos)
+
+        c = src[pos : pos + 1]
+        if c == "]":
+            return pos + 1, array
+        if c != ",":
+            raise TOMLDecodeError("Unclosed array", src, pos)
+        pos += 1
+
+        pos = skip_comments_and_array_ws(src, pos)
+        if src.startswith("]", pos):
+            return pos + 1, array
+
+
+def parse_inline_table(
+    src: str, pos: Pos, parse_float: ParseFloat, nest_lvl: int
+) -> tuple[Pos, dict[str, Any]]:
+    pos += 1
+    nested_dict = NestedDict()
+    flags = Flags()
+
+    pos = skip_comments_and_array_ws(src, pos)
+    if src.startswith("}", pos):
+        return pos + 1, nested_dict.dict
+    while True:
+        pos, key, value = parse_key_value_pair(src, pos, parse_float, nest_lvl)
+        key_parent, key_stem = key[:-1], key[-1]
+        if flags.is_(key, Flags.FROZEN):
+            raise TOMLDecodeError(f"Cannot mutate immutable namespace {key}", src, pos)
+        try:
+            nest = nested_dict.get_or_create_nest(key_parent, access_lists=False)
+        except KeyError:
+            raise TOMLDecodeError("Cannot overwrite a value", src, pos) from None
+        if key_stem in nest:
+            raise TOMLDecodeError(f"Duplicate inline table key {key_stem!r}", src, pos)
+        nest[key_stem] = value
+        pos = skip_comments_and_array_ws(src, pos)
+        c = src[pos : pos + 1]
+        if c == "}":
+            return pos + 1, nested_dict.dict
+        if c != ",":
+            raise TOMLDecodeError("Unclosed inline table", src, pos)
+        pos += 1
+        pos = skip_comments_and_array_ws(src, pos)
+        if src.startswith("}", pos):
+            return pos + 1, nested_dict.dict
+        if isinstance(value, (dict, list)):
+            flags.set(key, Flags.FROZEN, recursive=True)
+
+
+def parse_basic_str_escape(
+    src: str, pos: Pos, *, multiline: bool = False
+) -> tuple[Pos, str]:
+    escape_id = src[pos : pos + 2]
+    pos += 2
+    if multiline and escape_id in {"\\ ", "\\\t", "\\\n"}:
+        # Skip whitespace until next non-whitespace character or end of
+        # the doc. Error if non-whitespace is found before newline.
+        if escape_id != "\\\n":
+            pos = skip_chars(src, pos, TOML_WS)
+            try:
+                char = src[pos]
+            except IndexError:
+                return pos, ""
+            if char != "\n":
+                raise TOMLDecodeError("Unescaped '\\' in a string", src, pos)
+            pos += 1
+        pos = skip_chars(src, pos, TOML_WS_AND_NEWLINE)
+        return pos, ""
+    if escape_id == "\\x":
+        return parse_hex_char(src, pos, 2)
+    if escape_id == "\\u":
+        return parse_hex_char(src, pos, 4)
+    if escape_id == "\\U":
+        return parse_hex_char(src, pos, 8)
+    try:
+        return pos, BASIC_STR_ESCAPE_REPLACEMENTS[escape_id]
+    except KeyError:
+        raise TOMLDecodeError("Unescaped '\\' in a string", src, pos) from None
+
+
+def parse_basic_str_escape_multiline(src: str, pos: Pos) -> tuple[Pos, str]:
+    return parse_basic_str_escape(src, pos, multiline=True)
+
+
+def parse_hex_char(src: str, pos: Pos, hex_len: int) -> tuple[Pos, str]:
+    hex_str = src[pos : pos + hex_len]
+    if len(hex_str) != hex_len or not HEXDIGIT_CHARS.issuperset(hex_str):
+        raise TOMLDecodeError("Invalid hex value", src, pos)
+    pos += hex_len
+    hex_int = int(hex_str, 16)
+    if not is_unicode_scalar_value(hex_int):
+        raise TOMLDecodeError(
+            "Escaped character is not a Unicode scalar value", src, pos
+        )
+    return pos, chr(hex_int)
+
+
+def parse_literal_str(src: str, pos: Pos) -> tuple[Pos, str]:
+    pos += 1  # Skip starting apostrophe
+    start_pos = pos
+    pos = skip_until(
+        src, pos, "'", error_on=ILLEGAL_LITERAL_STR_CHARS, error_on_eof=True
+    )
+    return pos + 1, src[start_pos:pos]  # Skip ending apostrophe
+
+
+def parse_multiline_str(src: str, pos: Pos, *, literal: bool) -> tuple[Pos, str]:
+    pos += 3
+    if src.startswith("\n", pos):
+        pos += 1
+
+    if literal:
+        delim = "'"
+        end_pos = skip_until(
+            src,
+            pos,
+            "'''",
+            error_on=ILLEGAL_MULTILINE_LITERAL_STR_CHARS,
+            error_on_eof=True,
+        )
+        result = src[pos:end_pos]
+        pos = end_pos + 3
+    else:
+        delim = '"'
+        pos, result = parse_basic_str(src, pos, multiline=True)
+
+    # Add at maximum two extra apostrophes/quotes if the end sequence
+    # is 4 or 5 chars long instead of just 3.
+    if not src.startswith(delim, pos):
+        return pos, result
+    pos += 1
+    if not src.startswith(delim, pos):
+        return pos, result + delim
+    pos += 1
+    return pos, result + (delim * 2)
+
+
+def parse_basic_str(src: str, pos: Pos, *, multiline: bool) -> tuple[Pos, str]:
+    if multiline:
+        error_on = ILLEGAL_MULTILINE_BASIC_STR_CHARS
+        parse_escapes = parse_basic_str_escape_multiline
+    else:
+        error_on = ILLEGAL_BASIC_STR_CHARS
+        parse_escapes = parse_basic_str_escape
+    result = ""
+    start_pos = pos
+    while True:
+        try:
+            char = src[pos]
+        except IndexError:
+            raise TOMLDecodeError("Unterminated string", src, pos) from None
+        if char == '"':
+            if not multiline:
+                return pos + 1, result + src[start_pos:pos]
+            if src.startswith('"""', pos):
+                return pos + 3, result + src[start_pos:pos]
+            pos += 1
+            continue
+        if char == "\\":
+            result += src[start_pos:pos]
+            pos, parsed_escape = parse_escapes(src, pos)
+            result += parsed_escape
+            start_pos = pos
+            continue
+        if char in error_on:
+            raise TOMLDecodeError(f"Illegal character {char!r}", src, pos)
+        pos += 1
+
+
+def parse_value(
+    src: str, pos: Pos, parse_float: ParseFloat, nest_lvl: int
+) -> tuple[Pos, Any]:
+    if nest_lvl > MAX_INLINE_NESTING:
+        # Pure Python should have raised RecursionError already.
+        # This ensures mypyc binaries eventually do the same.
+        raise RecursionError(  # pragma: no cover
+            "TOML inline arrays/tables are nested more than the allowed"
+            f" {MAX_INLINE_NESTING} levels"
+        )
+
+    try:
+        char: str | None = src[pos]
+    except IndexError:
+        char = None
+
+    # IMPORTANT: order conditions based on speed of checking and likelihood
+
+    # Basic strings
+    if char == '"':
+        if src.startswith('"""', pos):
+            return parse_multiline_str(src, pos, literal=False)
+        return parse_one_line_basic_str(src, pos)
+
+    # Literal strings
+    if char == "'":
+        if src.startswith("'''", pos):
+            return parse_multiline_str(src, pos, literal=True)
+        return parse_literal_str(src, pos)
+
+    # Booleans
+    if char == "t":
+        if src.startswith("true", pos):
+            return pos + 4, True
+    if char == "f":
+        if src.startswith("false", pos):
+            return pos + 5, False
+
+    # Arrays
+    if char == "[":
+        return parse_array(src, pos, parse_float, nest_lvl + 1)
+
+    # Inline tables
+    if char == "{":
+        return parse_inline_table(src, pos, parse_float, nest_lvl + 1)
+
+    # Dates and times
+    datetime_match = RE_DATETIME.match(src, pos)
+    if datetime_match:
+        try:
+            datetime_obj = match_to_datetime(datetime_match)
+        except ValueError as e:
+            raise TOMLDecodeError("Invalid date or datetime", src, pos) from e
+        return datetime_match.end(), datetime_obj
+    localtime_match = RE_LOCALTIME.match(src, pos)
+    if localtime_match:
+        return localtime_match.end(), match_to_localtime(localtime_match)
+
+    # Integers and "normal" floats.
+    # The regex will greedily match any type starting with a decimal
+    # char, so needs to be located after handling of dates and times.
+    number_match = RE_NUMBER.match(src, pos)
+    if number_match:
+        return number_match.end(), match_to_number(number_match, parse_float)
+
+    # Special floats
+    first_three = src[pos : pos + 3]
+    if first_three in {"inf", "nan"}:
+        return pos + 3, parse_float(first_three)
+    first_four = src[pos : pos + 4]
+    if first_four in {"-inf", "+inf", "-nan", "+nan"}:
+        return pos + 4, parse_float(first_four)
+
+    raise TOMLDecodeError("Invalid value", src, pos)
+
+
+def is_unicode_scalar_value(codepoint: int) -> bool:
+    return (0 <= codepoint <= 55295) or (57344 <= codepoint <= 1114111)
+
+
+def make_safe_parse_float(parse_float: ParseFloat) -> ParseFloat:
+    """A decorator to make `parse_float` safe.
+
+    `parse_float` must not return dicts or lists, because these types
+    would be mixed with parsed TOML tables and arrays, thus confusing
+    the parser. The returned decorated callable raises `ValueError`
+    instead of returning illegal types.
+    """
+    # The default `float` callable never returns illegal types. Optimize it.
+    if parse_float is float:
+        return float
+
+    def safe_parse_float(float_str: str) -> Any:
+        float_value = parse_float(float_str)
+        if isinstance(float_value, (dict, list)):
+            raise ValueError("parse_float must not return dicts or lists")
+        return float_value
+
+    return safe_parse_float

--- a/.agents/lib/tomli/_re.py
+++ b/.agents/lib/tomli/_re.py
@@ -1,0 +1,119 @@
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2021 Taneli Hukkinen
+# Licensed to PSF under a Contributor Agreement.
+
+from __future__ import annotations
+
+from datetime import date, datetime, time, timedelta, timezone, tzinfo
+from functools import lru_cache
+import re
+
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from typing import Any, Final
+
+    from ._types import ParseFloat
+
+_TIME_RE_STR: Final = r"""
+([01][0-9]|2[0-3])             # hours
+:([0-5][0-9])                  # minutes
+(?:
+    :([0-5][0-9])              # optional seconds
+    (?:\.([0-9]{1,6})[0-9]*)?  # optional fractions of a second
+)?
+"""
+
+RE_NUMBER: Final = re.compile(
+    r"""
+0
+(?:
+    x[0-9A-Fa-f](?:_?[0-9A-Fa-f])*   # hex
+    |
+    b[01](?:_?[01])*                 # bin
+    |
+    o[0-7](?:_?[0-7])*               # oct
+)
+|
+[+-]?(?:0|[1-9](?:_?[0-9])*)         # dec, integer part
+(?P<floatpart>
+    (?:\.[0-9](?:_?[0-9])*)?         # optional fractional part
+    (?:[eE][+-]?[0-9](?:_?[0-9])*)?  # optional exponent part
+)
+""",
+    flags=re.VERBOSE,
+)
+RE_LOCALTIME: Final = re.compile(_TIME_RE_STR, flags=re.VERBOSE)
+RE_DATETIME: Final = re.compile(
+    rf"""
+([0-9]{{4}})-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[01])  # date, e.g. 1988-10-27
+(?:
+    [Tt ]
+    {_TIME_RE_STR}
+    (?:([Zz])|([+-])([01][0-9]|2[0-3]):([0-5][0-9]))?  # optional time offset
+)?
+""",
+    flags=re.VERBOSE,
+)
+
+
+def match_to_datetime(match: re.Match[str]) -> datetime | date:
+    """Convert a `RE_DATETIME` match to `datetime.datetime` or `datetime.date`.
+
+    Raises ValueError if the match does not correspond to a valid date
+    or datetime.
+    """
+    (
+        year_str,
+        month_str,
+        day_str,
+        hour_str,
+        minute_str,
+        sec_str,
+        micros_str,
+        zulu_time,
+        offset_sign_str,
+        offset_hour_str,
+        offset_minute_str,
+    ) = match.groups()
+    year, month, day = int(year_str), int(month_str), int(day_str)
+    if hour_str is None:
+        return date(year, month, day)
+    hour, minute = int(hour_str), int(minute_str)
+    sec = int(sec_str) if sec_str else 0
+    micros = int(micros_str.ljust(6, "0")) if micros_str else 0
+    if offset_sign_str:
+        tz: tzinfo | None = cached_tz(
+            offset_hour_str, offset_minute_str, offset_sign_str
+        )
+    elif zulu_time:
+        tz = timezone.utc
+    else:  # local date-time
+        tz = None
+    return datetime(year, month, day, hour, minute, sec, micros, tzinfo=tz)
+
+
+# No need to limit cache size. This is only ever called on input
+# that matched RE_DATETIME, so there is an implicit bound of
+# 24 (hours) * 60 (minutes) * 2 (offset direction) = 2880.
+@lru_cache(maxsize=None)
+def cached_tz(hour_str: str, minute_str: str, sign_str: str) -> timezone:
+    sign = 1 if sign_str == "+" else -1
+    return timezone(
+        timedelta(
+            hours=sign * int(hour_str),
+            minutes=sign * int(minute_str),
+        )
+    )
+
+
+def match_to_localtime(match: re.Match[str]) -> time:
+    hour_str, minute_str, sec_str, micros_str = match.groups()
+    sec = int(sec_str) if sec_str else 0
+    micros = int(micros_str.ljust(6, "0")) if micros_str else 0
+    return time(int(hour_str), int(minute_str), sec, micros)
+
+
+def match_to_number(match: re.Match[str], parse_float: ParseFloat) -> Any:
+    if match.group("floatpart"):
+        return parse_float(match.group())
+    return int(match.group(), 0)

--- a/.agents/lib/tomli/_types.py
+++ b/.agents/lib/tomli/_types.py
@@ -1,0 +1,10 @@
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2021 Taneli Hukkinen
+# Licensed to PSF under a Contributor Agreement.
+
+from typing import Any, Callable, Tuple
+
+# Type annotations
+ParseFloat = Callable[[str], Any]
+Key = Tuple[str, ...]
+Pos = int

--- a/.agents/lib/tomli/py.typed
+++ b/.agents/lib/tomli/py.typed
@@ -1,0 +1,1 @@
+# Marker file for PEP 561

--- a/.agents/skills/benchmark-greptimedb/SKILL.md
+++ b/.agents/skills/benchmark-greptimedb/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: benchmark-greptimedb
-description: Run repeatable GreptimeDB TSBS benchmarks and collect cold and hot EXPLAIN ANALYZE VERBOSE results with shared datasets, immutable query sets, reusable managed database workspaces, independent run logs, ingestion rates, and query summaries. Use for GreptimeDB smoke or performance tests, query analysis, ingestion measurements, query comparisons, managed local instances, or external GreptimeDB endpoints.
+description: Run repeatable GreptimeDB TSBS benchmarks on file or S3 storage and collect cold/hot EXPLAIN ANALYZE VERBOSE results. Use for GreptimeDB performance tests, query analysis, ingestion measurements, storage or version comparisons, managed instances, or external endpoints.
 ---
 
 # Benchmark GreptimeDB
@@ -26,6 +26,8 @@ verified repository-local fallback.
 3. Select the SQL `--database`. For external loads, also select `create`,
    `reuse`, or explicitly confirmed `reset`. Never infer reset authorization.
 4. Use the `manual` profile unless the user requests `smoke` or overrides.
+5. For managed S3, use the config bound by `$setup-greptimedb`. Never request
+   credentials or credential-bearing TOML contents in conversation.
 
 ## Run benchmarks
 
@@ -74,6 +76,11 @@ python3 .agents/skills/benchmark-greptimedb/scripts/benchmark.py summarize \
 
 ### Custom managed configuration
 
+For a new S3 workspace, use `$setup-greptimedb configure-s3` and tell the user
+to run the generated command in their own terminal. A prepared S3 workspace
+uses its bound config automatically. `--greptime-config` may select another
+full TOML only when it has the same bucket/root identity.
+
 When the user requests GreptimeDB settings but does not provide a TOML file,
 read GreptimeDB's official [standalone example](https://github.com/GreptimeTeam/greptimedb/blob/main/config/standalone.example.toml)
 before writing the config. The full set of examples is in the upstream
@@ -102,6 +109,11 @@ reuses the recorded path; selecting another path requires a new run. The
 runner's CLI values for HTTP address, InfluxDB enablement, data home, and log
 directory override conflicting values in the TOML. Custom configs apply only
 to managed targets, not `--endpoint`.
+
+Do not create an S3 credential-bearing TOML under a tracked path or print its
+contents. Process logs redact configured access and secret keys. For S3,
+`data_home` remains local WAL/cache state; primary data resides in the configured
+bucket/root. Cold analysis restarts the process but does not clear that cache.
 
 Repeat `--query-type` to define query-set membership; omit it for every type
 allowed by `--query-scope full|fixed-host` (default `full`). The fixed-host
@@ -190,6 +202,8 @@ directly into the loader without a temporary plain file.
 - Rebind only with `--database-mode reset --confirm-reset DATABASE`, after the
   user explicitly authorizes dropping that SQL database.
 - Managed workspaces are locked while GreptimeDB uses them.
+- Storage identity is immutable. Reset drops/recreates the SQL database and
+  never directly empties a bucket or prefix.
 - For external loads, `reuse` can duplicate data. Prefer query-only runs after
   one successful load.
 
@@ -197,7 +211,7 @@ directly into the loader without a temporary plain file.
 
 Read `summary.json` and report the dataset ID and checksum, query-set ID and
 manifest checksum, database ID or external target, custom config path when
-present, metrics/second and
+present, sanitized storage type/location, metrics/second and
 rows/second for ingestion, weighted mean latency per query type, failures and
 their log paths, and the run directory. Preserve failed-run diagnostics.
 For analysis, also report each query type's attempt and cold/hot result paths,

--- a/.agents/skills/benchmark-greptimedb/agents/openai.yaml
+++ b/.agents/skills/benchmark-greptimedb/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "Benchmark GreptimeDB"
   short_description: "Benchmark and analyze GreptimeDB TSBS queries"
-  default_prompt: "Use $benchmark-greptimedb to run a shared-workspace TSBS benchmark or collect cold and hot EXPLAIN ANALYZE VERBOSE results against GreptimeDB, then summarize the results."
+  default_prompt: "Use $benchmark-greptimedb to benchmark a file- or S3-backed GreptimeDB workspace or collect cold and hot EXPLAIN ANALYZE VERBOSE results."

--- a/.agents/skills/benchmark-greptimedb/references/workload.md
+++ b/.agents/skills/benchmark-greptimedb/references/workload.md
@@ -11,7 +11,7 @@
 └── greptimedb/
     ├── installations/<version>/<platform>/{manifest.json,greptime,...}
     ├── configs/<descriptive-name>.toml
-    ├── databases/<database-id>/{manifest.json,data/,logs/}
+    ├── databases/<database-id>/{manifest.json,data/,logs/} # data is WAL/cache for S3
     ├── runs/<run-id>/
     │   ├── manifest.json
     │   ├── summary.{json,md}
@@ -111,6 +111,11 @@ the workspace-bound identity, making separate runs safe to compare without
 rebinding metadata. A custom managed configuration records only its resolved
 live source path. Its contents are read again on every server start and are not
 copied or checksum-pinned by the runner.
+
+Managed storage identity is `file` for legacy manifests. S3 workspaces pin the
+non-secret bucket, root, endpoint, and region plus the live config path. Runs
+record the sanitized identity. SQL reset never directly deletes a bucket or
+prefix, and cold analysis does not clear the local object cache.
 
 Copied workspaces retain the source dataset binding and record their origin,
 source manifest checksum, full-copy method, and copied file and byte counts.

--- a/.agents/skills/benchmark-greptimedb/scripts/benchmark.py
+++ b/.agents/skills/benchmark-greptimedb/scripts/benchmark.py
@@ -16,6 +16,7 @@ import subprocess
 import sys
 import tempfile
 import time
+import tomllib
 import urllib.error
 import urllib.parse
 import urllib.request
@@ -553,10 +554,12 @@ def explicit_binary_version(binary: Path) -> str:
 def resolve_greptime_config(
     args: argparse.Namespace,
     existing_target: dict[str, Any] | None = None,
+    database_manifest: dict[str, Any] | None = None,
 ) -> Path | None:
     requested = getattr(args, "greptime_config", None)
     recorded = (existing_target or {}).get("config_file")
-    path = requested.expanduser().resolve() if requested else Path(recorded) if recorded else None
+    prepared = (database_manifest or {}).get("storage", {}).get("config_file")
+    path = requested.expanduser().resolve() if requested else Path(recorded) if recorded else Path(prepared) if prepared else None
     if path is None:
         return None
     if not path.is_file():
@@ -567,6 +570,56 @@ def resolve_greptime_config(
     except OSError as exc:
         raise BenchmarkError(f"GreptimeDB config file is not readable: {path}") from exc
     return path
+
+
+def config_storage(path: Path) -> tuple[dict[str, Any], tuple[str, ...]]:
+    try:
+        with path.open("rb") as stream:
+            document = tomllib.load(stream)
+    except tomllib.TOMLDecodeError as exc:
+        raise BenchmarkError(f"invalid GreptimeDB TOML config {path}: {exc}") from exc
+    storage = document.get("storage")
+    if storage is None:
+        return {"type": "file"}, ()
+    if not isinstance(storage, dict):
+        raise BenchmarkError("GreptimeDB config storage must be a table")
+    storage_type = storage.get("type", "File")
+    if not isinstance(storage_type, str) or storage_type.lower() not in ("file", "s3"):
+        raise BenchmarkError("GreptimeDB managed storage type must be File or S3")
+    if storage_type.lower() == "file":
+        return {"type": "file"}, ()
+    for key in ("bucket", "root", "access_key_id", "secret_access_key"):
+        if not isinstance(storage.get(key), str) or not storage[key]:
+            raise BenchmarkError(f"GreptimeDB S3 config requires nonempty storage.{key}")
+    virtual_host = storage.get("enable_virtual_host_style", False)
+    if not isinstance(virtual_host, bool):
+        raise BenchmarkError("storage.enable_virtual_host_style must be a boolean")
+    identity = {
+        "type": "s3",
+        "bucket": storage["bucket"],
+        "root": storage["root"],
+        "endpoint": storage.get("endpoint"),
+        "region": storage.get("region"),
+        "enable_virtual_host_style": virtual_host,
+    }
+    return identity, (storage["access_key_id"], storage["secret_access_key"])
+
+
+def manifest_storage(manifest: dict[str, Any]) -> dict[str, Any]:
+    storage = manifest.get("storage", {"type": "file"})
+    if not isinstance(storage, dict) or storage.get("type") not in ("file", "s3"):
+        raise BenchmarkError("managed workspace storage identity is malformed")
+    return {key: value for key, value in storage.items() if key != "config_file"}
+
+
+def scrub_secrets(path: Path, secrets: Sequence[str]) -> None:
+    if not path.exists() or not secrets:
+        return
+    value = path.read_text(encoding="utf-8", errors="replace")
+    for secret in secrets:
+        if secret:
+            value = value.replace(secret, "<redacted-s3-credential>")
+    path.write_text(value, encoding="utf-8")
 
 
 def managed_target(
@@ -605,6 +658,7 @@ def managed_target(
         "workspace_binary_sha256": workspace_checksum,
         "binary_override": binary_override,
         "version_override": bool(runtime_version and workspace_version and runtime_version != workspace_version),
+        "storage": manifest_storage(manifest),
     }
     if config_file is not None:
         target["config_file"] = str(config_file)
@@ -620,7 +674,7 @@ def target_matches(existing: dict[str, Any], requested: dict[str, Any]) -> bool:
         "workspace_binary_sha256",
         "version_override",
     }
-    if previous_fields.issubset(existing) and not existing.keys() - (previous_fields | {"config_file"}):
+    if previous_fields.issubset(existing) and not existing.keys() - (previous_fields | {"config_file", "storage"}):
         if existing.get("config_file") != requested.get("config_file"):
             return False
         return existing == {key: requested.get(key) for key in existing}
@@ -807,7 +861,11 @@ def managed_workspace(
     workspace, database_manifest = prepare_database_workspace(args)
     with lock_database(workspace):
         binary = managed_binary(args, database_manifest)
-        config_file = resolve_greptime_config(args, existing_target)
+        config_file = resolve_greptime_config(args, existing_target, database_manifest)
+        workspace_storage = manifest_storage(database_manifest)
+        selected_storage, _ = config_storage(config_file) if config_file else ({"type": "file"}, ())
+        if selected_storage != workspace_storage:
+            raise BenchmarkError("GreptimeDB config storage does not match the prepared workspace storage identity")
         target = managed_target(args, database_manifest, binary, config_file)
         if existing_target and not target_matches(existing_target, target):
             raise BenchmarkError("run target is immutable; create a new run for another GreptimeDB version or target")
@@ -824,6 +882,7 @@ def managed_process(
     config_file: Path | None = None,
 ) -> Iterator[str]:
     process_log_path.parent.mkdir(parents=True, exist_ok=True)
+    _, secrets = config_storage(config_file) if config_file else ({"type": "file"}, ())
     process_log = process_log_path.open("a", encoding="utf-8")
     try:
         check_port_available(args.http_port)
@@ -856,6 +915,7 @@ def managed_process(
             try: process.wait(timeout=15)
             except subprocess.TimeoutExpired: os.killpg(process.pid, signal.SIGKILL); process.wait(timeout=5)
         process_log.close()
+        scrub_secrets(process_log_path, secrets)
 
 
 @contextlib.contextmanager

--- a/.agents/skills/benchmark-greptimedb/scripts/benchmark.py
+++ b/.agents/skills/benchmark-greptimedb/scripts/benchmark.py
@@ -16,7 +16,6 @@ import subprocess
 import sys
 import tempfile
 import time
-import tomllib
 import urllib.error
 import urllib.parse
 import urllib.request
@@ -25,6 +24,8 @@ from typing import Any, Iterator, Sequence
 
 SCRIPT_PATH = Path(__file__).resolve()
 sys.path.insert(0, str(SCRIPT_PATH.parents[3] / "lib"))
+
+import tomli  # noqa: E402
 
 from tsbs_benchmark import (  # noqa: E402
     FIXED_HOST_QUERY_TYPES,
@@ -575,8 +576,8 @@ def resolve_greptime_config(
 def config_storage(path: Path) -> tuple[dict[str, Any], tuple[str, ...]]:
     try:
         with path.open("rb") as stream:
-            document = tomllib.load(stream)
-    except tomllib.TOMLDecodeError as exc:
+            document = tomli.load(stream)
+    except tomli.TOMLDecodeError as exc:
         raise BenchmarkError(f"invalid GreptimeDB TOML config {path}: {exc}") from exc
     storage = document.get("storage")
     if storage is None:

--- a/.agents/skills/benchmark-greptimedb/scripts/summarize.py
+++ b/.agents/skills/benchmark-greptimedb/scripts/summarize.py
@@ -106,9 +106,12 @@ def render_markdown(summary: dict[str, Any]) -> str:
             lines.append(f"- GreptimeDB binary path: `{target.get('binary_path')}`")
         if target.get("config_file"):
             lines.append(f"- GreptimeDB config file: `{target.get('config_file')}`")
-        storage = target.get("storage", {"type": "file"})
-        lines.append(f"- Storage: `{storage.get('type')}`")
-        if storage.get("type") == "s3":
+        storage = target.get("storage")
+        if storage is None and target.get("mode") == "managed":
+            storage = {"type": "file"}
+        storage_type = storage.get("type") if isinstance(storage, dict) else "unknown"
+        lines.append(f"- Storage: `{storage_type}`")
+        if storage_type == "s3":
             lines.append(f"- S3 location: `{storage.get('bucket')}/{storage.get('root')}`")
             if storage.get("endpoint"):
                 lines.append(f"- S3 endpoint: `{storage.get('endpoint')}`")

--- a/.agents/skills/benchmark-greptimedb/scripts/summarize.py
+++ b/.agents/skills/benchmark-greptimedb/scripts/summarize.py
@@ -106,6 +106,12 @@ def render_markdown(summary: dict[str, Any]) -> str:
             lines.append(f"- GreptimeDB binary path: `{target.get('binary_path')}`")
         if target.get("config_file"):
             lines.append(f"- GreptimeDB config file: `{target.get('config_file')}`")
+        storage = target.get("storage", {"type": "file"})
+        lines.append(f"- Storage: `{storage.get('type')}`")
+        if storage.get("type") == "s3":
+            lines.append(f"- S3 location: `{storage.get('bucket')}/{storage.get('root')}`")
+            if storage.get("endpoint"):
+                lines.append(f"- S3 endpoint: `{storage.get('endpoint')}`")
         if runtime_override:
             lines.append(f"- Workspace-bound GreptimeDB version: `{target.get('workspace_version')}`")
             lines.append(f"- Workspace-bound binary SHA-256: `{target.get('workspace_binary_sha256')}`")

--- a/.agents/skills/benchmark-greptimedb/tests/test_benchmark.py
+++ b/.agents/skills/benchmark-greptimedb/tests/test_benchmark.py
@@ -701,6 +701,35 @@ class ManagedDatabaseTests(unittest.TestCase):
             legacy_target = {key: target[key] for key in ("mode", "endpoint", "database", "database_id", "version", "binary_sha256")}
             self.assertFalse(benchmark.target_matches(legacy_target, target))
 
+    def test_s3_workspace_defaults_to_its_config_and_rejects_location_changes(self) -> None:
+        with tempfile.TemporaryDirectory() as temp:
+            root = Path(temp); config = root / "s3.toml"
+            config.write_text(
+                '[storage]\ntype = "S3"\nbucket = "bench"\nroot = "db-a"\n'
+                'endpoint = "http://minio:9000"\nregion = "us-west-1"\n'
+                'access_key_id = "access-value"\nsecret_access_key = "secret-value"\n',
+                encoding="utf-8",
+            )
+            args = benchmark.make_parser().parse_args(["query", "--database-id", "db-a"])
+            benchmark.resolve_database(args)
+            database = {
+                "storage": {
+                    "type": "s3", "config_file": str(config.resolve()), "bucket": "bench",
+                    "root": "db-a", "endpoint": "http://minio:9000", "region": "us-west-1",
+                    "enable_virtual_host_style": False,
+                }
+            }
+            self.assertEqual(benchmark.resolve_greptime_config(args, None, database), config.resolve())
+            identity, secrets = benchmark.config_storage(config)
+            self.assertEqual(identity, benchmark.manifest_storage(database))
+            log = root / "process.log"; log.write_text("failed secret-value access-value", encoding="utf-8")
+            benchmark.scrub_secrets(log, secrets)
+            self.assertNotIn("secret-value", log.read_text(encoding="utf-8"))
+
+            config.write_text(config.read_text().replace('root = "db-a"', 'root = "db-b"'), encoding="utf-8")
+            changed, _ = benchmark.config_storage(config)
+            self.assertNotEqual(changed, benchmark.manifest_storage(database))
+
     def test_connection_persists_config_before_startup_failure_and_reuses_it(self) -> None:
         with tempfile.TemporaryDirectory() as temp:
             root = Path(temp); run_dir = root / "run"; (run_dir / "logs").mkdir(parents=True)

--- a/.agents/skills/benchmark-greptimedb/tests/test_benchmark.py
+++ b/.agents/skills/benchmark-greptimedb/tests/test_benchmark.py
@@ -85,6 +85,26 @@ class SummaryIntegrationTests(unittest.TestCase):
         self.assertIn("GreptimeDB config file: `/configs/scan.toml`", rendered)
         self.assertIn("set-a", rendered)
 
+    def test_external_target_storage_is_rendered_as_unknown(self) -> None:
+        with tempfile.TemporaryDirectory() as temp:
+            summary = summarize.build_summary(
+                Path(temp),
+                {
+                    "run_id": "run",
+                    "profile": "smoke",
+                    "database": "benchmark",
+                    "target": {
+                        "mode": "external",
+                        "endpoint": "http://localhost:4000",
+                    },
+                    "events": {"loads": [], "queries": []},
+                },
+            )
+
+        rendered = summarize.render_markdown(summary)
+        self.assertIn("Storage: `unknown`", rendered)
+        self.assertNotIn("Storage: `file`", rendered)
+
     def test_version_override_identity_is_rendered(self) -> None:
         summary = {
             "run_id": "run", "profile": "smoke", "database": "benchmark",

--- a/.agents/skills/benchmark-influxdb3/SKILL.md
+++ b/.agents/skills/benchmark-influxdb3/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: benchmark-influxdb3
-description: Run repeatable InfluxDB 3 Core and Enterprise TSBS benchmarks with shared datasets, immutable SQL query sets, reusable managed database workspaces, external clusters, independent logs, ingestion rates, and query-latency summaries. Use for InfluxDB 3 smoke or performance tests, Core-versus-Enterprise measurements, ingestion tests, query comparisons, or external InfluxDB 3 endpoints.
+description: Run repeatable InfluxDB 3 Core and Enterprise TSBS benchmarks on file or S3 storage. Use for smoke or performance tests, storage or edition comparisons, ingestion tests, query measurements, managed workspaces, or external endpoints.
 ---
 
 # Benchmark InfluxDB 3
@@ -27,6 +27,8 @@ the verified repository-local fallback.
    the measured non-durable throughput recipe, pass `--batch-size 3000`,
    `--load-workers 8`, and `--no-sync`; see
    `docs/influx3-ingestion-benchmark.md`.
+6. Managed S3 settings come from the prepared workspace. Use
+   `$setup-influxdb3 configure-s3`; never request credentials in conversation.
 
 ## Run benchmarks
 
@@ -74,6 +76,11 @@ Managed servers may take several minutes to initialize, so the runner waits up
 to 10 minutes by default. Override this with `--startup-timeout SECONDS` when a
 different allowance is required.
 
+S3-backed managed servers pass the user-owned native credentials file directly
+to InfluxDB and keep only logs locally. Credentials are never copied into run
+metadata or environment variables. Bucket, region, endpoint, and HTTP allowance
+are pinned by the workspace and reported without secret values.
+
 ## Authenticate external targets
 
 Set `INFLUXDB3_AUTH_TOKEN` for writes and queries and
@@ -94,11 +101,14 @@ to the same instance or cluster.
 - Rebind only with `--database-mode reset --confirm-reset DATABASE` after the
   user explicitly authorizes deletion.
 - Managed database workspaces remain locked while their server is running.
+- Storage identity is immutable. Reset uses the database API and never directly
+  empties an object-store bucket.
 - External `reuse` may duplicate data; prefer query-only runs after one load.
 
 ## Report results
 
-Read `summary.json` and report edition, version, database ID or URLs, dataset and
+Read `summary.json` and report edition, version, database ID or URLs, sanitized
+storage type/location, dataset and
 query-set checksums, durability flags, metrics/second and rows/second, weighted
 mean query latency, server diagnostics, failures and log paths, and the run
 directory. Ordinary server warnings and recoverable errors are diagnostics;

--- a/.agents/skills/benchmark-influxdb3/agents/openai.yaml
+++ b/.agents/skills/benchmark-influxdb3/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "Benchmark InfluxDB 3"
   short_description: "Run reusable InfluxDB 3 TSBS benchmarks"
-  default_prompt: "Use $benchmark-influxdb3 to run a repeatable TSBS benchmark against InfluxDB 3 Core or Enterprise."
+  default_prompt: "Use $benchmark-influxdb3 to run a repeatable TSBS benchmark against file- or S3-backed InfluxDB 3 Core or Enterprise."

--- a/.agents/skills/benchmark-influxdb3/references/workload.md
+++ b/.agents/skills/benchmark-influxdb3/references/workload.md
@@ -56,7 +56,8 @@ request exceeded 10 MiB, so do not assume arbitrarily larger batches are valid.
 ## Database and target state
 
 Managed database manifests pin the database ID, edition, exact version, binary
-checksum, node/cluster identity, SQL database, and one loaded dataset checksum. External
+checksum, node/cluster identity, sanitized file/S3 storage identity, SQL database,
+and one loaded dataset checksum. External
 targets require an explicit edition and may provide multiple URLs only when all
 URLs address the same Core instance or Enterprise cluster. The runner compares
 available `/ping` version metadata but cannot prove cluster membership. Use at

--- a/.agents/skills/benchmark-influxdb3/scripts/benchmark.py
+++ b/.agents/skills/benchmark-influxdb3/scripts/benchmark.py
@@ -446,7 +446,72 @@ def validate_database_manifest(path: Path, expected_id: str | None = None) -> di
     binding_fields = {"dataset_id", "spec", "format", "bytes", "sha256"}
     if binding is not None and (not isinstance(binding, dict) or set(binding) != binding_fields or not isinstance(binding.get("spec"), dict)):
         raise BenchmarkError(f"malformed database binding: {path / 'manifest.json'}")
+    manifest["storage"] = validate_storage(manifest.get("storage"))
     return manifest
+
+
+def read_aws_credentials(path: Path) -> tuple[str, ...]:
+    document = read_json(path)
+    for key in ("aws_access_key_id", "aws_secret_access_key"):
+        if not isinstance(document.get(key), str) or not document[key]:
+            raise BenchmarkError(f"InfluxDB S3 credentials file requires nonempty {key}")
+    return tuple(
+        document[key]
+        for key in ("aws_access_key_id", "aws_secret_access_key", "aws_session_token")
+        if isinstance(document.get(key), str) and document[key]
+    )
+
+
+def validate_storage(storage: Any) -> dict[str, Any]:
+    if storage is None:
+        return {"type": "file"}
+    if not isinstance(storage, dict) or storage.get("type") not in ("file", "s3"):
+        raise BenchmarkError("managed workspace storage identity is malformed")
+    if storage["type"] == "s3":
+        required = {"bucket", "credentials_file", "region", "endpoint", "allow_http"}
+        if (
+            not required.issubset(storage)
+            or not isinstance(storage["bucket"], str)
+            or not storage["bucket"]
+            or not isinstance(storage["region"], str)
+            or not storage["region"]
+            or storage["endpoint"] is not None and not isinstance(storage["endpoint"], str)
+            or not isinstance(storage["allow_http"], bool)
+        ):
+            raise BenchmarkError("managed workspace S3 identity is malformed")
+        if storage["endpoint"]:
+            parsed = urllib.parse.urlparse(storage["endpoint"])
+            if parsed.scheme not in ("http", "https") or not parsed.netloc:
+                raise BenchmarkError("managed workspace S3 endpoint is malformed")
+            if parsed.scheme == "http" and not storage["allow_http"]:
+                raise BenchmarkError("managed workspace HTTP S3 endpoint requires allow_http")
+        read_aws_credentials(Path(storage["credentials_file"]))
+    return storage
+
+
+def storage_command(storage: dict[str, Any], data_path: Path) -> list[str]:
+    if storage["type"] == "file":
+        return ["--object-store=file", f"--data-dir={data_path}"]
+    command = [
+        "--object-store=s3",
+        f"--bucket={storage['bucket']}",
+        f"--aws-credentials-file={storage['credentials_file']}",
+        f"--aws-default-region={storage['region']}",
+    ]
+    if storage.get("endpoint"):
+        command.append(f"--aws-endpoint={storage['endpoint']}")
+    if storage.get("allow_http"):
+        command.append("--aws-allow-http")
+    return command
+
+
+def scrub_secrets(path: Path, secrets: Sequence[str]) -> None:
+    if not path.exists() or not secrets:
+        return
+    value = path.read_text(encoding="utf-8", errors="replace")
+    for secret in secrets:
+        value = value.replace(secret, "<redacted-s3-credential>")
+    path.write_text(value, encoding="utf-8")
 
 
 def preflight_managed_binary(manifest: dict[str, Any]) -> None:
@@ -631,7 +696,8 @@ def connection(args: argparse.Namespace, run_dir: Path, manifest: dict[str, Any]
         except Exception:
             process_log.write(f"managed InfluxDB 3 HTTP port {args.http_port} is unavailable\n"); process_log.close()
             event.update(status="startup_failed", finished_at=utc_now()); save_manifest(run_dir, manifest); raise
-        command = [str(binary), "serve", "--object-store=file", f"--data-dir={workspace / 'data'}", f"--node-id={database_manifest['node_id']}", f"--http-bind=127.0.0.1:{args.http_port}", "--without-auth"]
+        storage = database_manifest["storage"]
+        command = [str(binary), "serve", *storage_command(storage, workspace / "data"), f"--node-id={database_manifest['node_id']}", f"--http-bind=127.0.0.1:{args.http_port}", "--without-auth"]
         if database_manifest["edition"] == "enterprise":
             command.append(f"--cluster-id={database_manifest['cluster_id']}")
             license_path = database_manifest.get("license", {}).get("path")
@@ -677,6 +743,8 @@ def connection(args: argparse.Namespace, run_dir: Path, manifest: dict[str, Any]
                 event["finished_at"] = utc_now()
             save_manifest(run_dir, manifest)
             process_log.close()
+            if storage["type"] == "s3":
+                scrub_secrets(process_log_path, read_aws_credentials(Path(storage["credentials_file"])))
 
 
 def add_run_options(parser: argparse.ArgumentParser) -> None:
@@ -754,11 +822,13 @@ def main(argv: Sequence[str] | None = None) -> int:
                 server = {"version": database_manifest.get("version"), "revision": None, "build": None} if managed else probe_servers(args.url, os.environ.get(args.auth_token_env, ""))
                 if previous and server["version"] is None:
                     server = {key: previous.get(key) for key in ("version", "revision", "build")}
-                target = {"mode": "managed" if managed else "external", "urls": endpoint.split(","), "database": args.database, "database_id": args.database_id if managed else None, "edition": edition, "version": server["version"], "revision": server["revision"], "build": server["build"], "binary_sha256": database_manifest.get("binary_sha256") if managed else None, "no_sync": getattr(args, "no_sync", previous.get("no_sync", False)), "accept_partial": getattr(args, "accept_partial", previous.get("accept_partial", False))}
+                storage = database_manifest["storage"] if managed else None
+                target = {"mode": "managed" if managed else "external", "urls": endpoint.split(","), "database": args.database, "database_id": args.database_id if managed else None, "edition": edition, "version": server["version"], "revision": server["revision"], "build": server["build"], "binary_sha256": database_manifest.get("binary_sha256") if managed else None, "storage": storage, "no_sync": getattr(args, "no_sync", previous.get("no_sync", False)), "accept_partial": getattr(args, "accept_partial", previous.get("accept_partial", False))}
                 identity = ("mode", "urls", "database", "database_id", "edition", "version", "binary_sha256")
                 if args.command in ("load", "all"):
                     identity += ("no_sync", "accept_partial")
-                if previous and any(previous.get(key) != target.get(key) for key in identity):
+                previous_storage = previous.get("storage", {"type": "file"} if managed else None)
+                if previous and (any(previous.get(key) != target.get(key) for key in identity) or previous_storage != storage):
                     raise BenchmarkError("target conflicts with the target pinned by this run")
                 manifest["target"] = target; save_manifest(run_dir, manifest)
                 if args.command in ("load", "all"): load_data(args, run_dir, manifest, endpoint, managed, database_manifest, database_path)

--- a/.agents/skills/benchmark-influxdb3/scripts/benchmark.py
+++ b/.agents/skills/benchmark-influxdb3/scripts/benchmark.py
@@ -455,6 +455,14 @@ def read_aws_credentials(path: Path) -> tuple[str, ...]:
     for key in ("aws_access_key_id", "aws_secret_access_key"):
         if not isinstance(document.get(key), str) or not document[key]:
             raise BenchmarkError(f"InfluxDB S3 credentials file requires nonempty {key}")
+    if "aws_session_token" in document and not isinstance(document["aws_session_token"], str):
+        raise BenchmarkError("InfluxDB S3 credentials field aws_session_token must be a string")
+    if "expiry" in document and (
+        isinstance(document["expiry"], bool)
+        or not isinstance(document["expiry"], int)
+        or not 0 <= document["expiry"] <= 2**64 - 1
+    ):
+        raise BenchmarkError("InfluxDB S3 credentials field expiry must be an unsigned 64-bit integer")
     return tuple(
         document[key]
         for key in ("aws_access_key_id", "aws_secret_access_key", "aws_session_token")

--- a/.agents/skills/benchmark-influxdb3/scripts/summarize.py
+++ b/.agents/skills/benchmark-influxdb3/scripts/summarize.py
@@ -138,9 +138,12 @@ def render_markdown(summary: dict[str, Any]) -> str:
         lines.append(f"- Edition: `{target.get('edition')}`")
         if target.get("version"):
             lines.append(f"- Version: `{target.get('version')}`")
-        storage = target.get("storage", {"type": "file"})
-        lines.append(f"- Storage: `{storage.get('type')}`")
-        if storage.get("type") == "s3":
+        storage = target.get("storage")
+        if storage is None and target.get("mode") == "managed":
+            storage = {"type": "file"}
+        storage_type = storage.get("type") if isinstance(storage, dict) else "unknown"
+        lines.append(f"- Storage: `{storage_type}`")
+        if storage_type == "s3":
             lines.append(f"- S3 bucket: `{storage.get('bucket')}`")
             if storage.get("endpoint"):
                 lines.append(f"- S3 endpoint: `{storage.get('endpoint')}`")

--- a/.agents/skills/benchmark-influxdb3/scripts/summarize.py
+++ b/.agents/skills/benchmark-influxdb3/scripts/summarize.py
@@ -138,6 +138,12 @@ def render_markdown(summary: dict[str, Any]) -> str:
         lines.append(f"- Edition: `{target.get('edition')}`")
         if target.get("version"):
             lines.append(f"- Version: `{target.get('version')}`")
+        storage = target.get("storage", {"type": "file"})
+        lines.append(f"- Storage: `{storage.get('type')}`")
+        if storage.get("type") == "s3":
+            lines.append(f"- S3 bucket: `{storage.get('bucket')}`")
+            if storage.get("endpoint"):
+                lines.append(f"- S3 endpoint: `{storage.get('endpoint')}`")
         lines.append(
             f"- Durable WAL acknowledgement: `{not target.get('no_sync', False)}`"
         )

--- a/.agents/skills/benchmark-influxdb3/tests/test_benchmark.py
+++ b/.agents/skills/benchmark-influxdb3/tests/test_benchmark.py
@@ -443,6 +443,49 @@ class ManagedDatabaseTests(unittest.TestCase):
             self.assertIsNone(persisted["database"])
             self.assertIsNone(persisted["binding"])
 
+    def test_s3_managed_connection_uses_credentials_file_and_scrubs_logs(self) -> None:
+        with tempfile.TemporaryDirectory() as temp:
+            root = Path(temp); path = self.prepare_database(root)
+            credentials = root / "aws.json"
+            credentials.write_text(json.dumps({
+                "aws_access_key_id": "access-value",
+                "aws_secret_access_key": "secret-value",
+            }), encoding="utf-8")
+            database = benchmark.read_json(path / "manifest.json")
+            database["storage"] = {
+                "type": "s3", "bucket": "bench", "credentials_file": str(credentials),
+                "region": "us-west-1", "endpoint": "http://minio:9000", "allow_http": True,
+            }
+            benchmark.save_json(path / "manifest.json", database)
+            args = benchmark.make_parser().parse_args([
+                "query", "--database-id", "db-a", "--database-root", str(root),
+            ])
+            benchmark.resolve_database(args)
+            run_dir = root / "run"; (run_dir / "logs").mkdir(parents=True)
+            manifest = {"events": {"servers": []}}
+            process = mock.Mock(pid=1234); process.poll.return_value = None; process.wait.return_value = 0
+
+            def start_process(command, **kwargs):
+                kwargs["stdout"].write("startup secret-value access-value\n")
+                kwargs["stdout"].flush()
+                return process
+
+            with mock.patch.object(benchmark, "preflight_managed_binary"), mock.patch.object(benchmark, "check_port_available"), mock.patch.object(
+                benchmark, "endpoint_ready", return_value=True
+            ), mock.patch.object(benchmark.subprocess, "Popen", side_effect=start_process) as popen, mock.patch.object(
+                benchmark.os, "killpg"
+            ):
+                with benchmark.connection(args, run_dir, manifest):
+                    pass
+            command = popen.call_args.args[0]
+            self.assertIn("--object-store=s3", command)
+            self.assertIn(f"--aws-credentials-file={credentials}", command)
+            self.assertFalse(any(part.startswith("--data-dir=") for part in command))
+            process_log = next((run_dir / "logs").glob("influxdb3-process-run-*.log"))
+            contents = process_log.read_text(encoding="utf-8")
+            self.assertNotIn("access-value", contents)
+            self.assertNotIn("secret-value", contents)
+
 
 class TargetTests(unittest.TestCase):
     def test_sync_is_default_and_no_sync_is_opt_in(self) -> None:

--- a/.agents/skills/benchmark-influxdb3/tests/test_benchmark.py
+++ b/.agents/skills/benchmark-influxdb3/tests/test_benchmark.py
@@ -133,6 +133,28 @@ class SummaryIntegrationTests(unittest.TestCase):
         self.assertIn("managed:db-a", rendered)
         self.assertIn("set-a", rendered)
 
+    def test_external_target_storage_is_rendered_as_unknown(self) -> None:
+        with tempfile.TemporaryDirectory() as temp:
+            summary = summarize.build_summary(
+                Path(temp),
+                {
+                    "run_id": "run",
+                    "profile": "smoke",
+                    "database": "benchmark",
+                    "target": {
+                        "mode": "external",
+                        "urls": ["http://localhost:8181"],
+                        "edition": "core",
+                        "storage": None,
+                    },
+                    "events": {"loads": [], "queries": [], "servers": []},
+                },
+            )
+
+        rendered = summarize.render_markdown(summary)
+        self.assertIn("Storage: `unknown`", rendered)
+        self.assertNotIn("Storage: `file`", rendered)
+
 
 class QuerySetIdentityTests(unittest.TestCase):
     def dataset(self) -> dict:
@@ -442,6 +464,19 @@ class ManagedDatabaseTests(unittest.TestCase):
             persisted = json.loads((path / "manifest.json").read_text(encoding="utf-8"))
             self.assertIsNone(persisted["database"])
             self.assertIsNone(persisted["binding"])
+
+    def test_s3_credentials_reject_server_incompatible_optional_types(self) -> None:
+        with tempfile.TemporaryDirectory() as temp:
+            credentials = Path(temp) / "aws.json"
+            required = {
+                "aws_access_key_id": "access-value",
+                "aws_secret_access_key": "secret-value",
+            }
+            for field, value in (("aws_session_token", 123), ("expiry", "123")):
+                with self.subTest(field=field):
+                    credentials.write_text(json.dumps({**required, field: value}), encoding="utf-8")
+                    with self.assertRaisesRegex(benchmark.BenchmarkError, field):
+                        benchmark.read_aws_credentials(credentials)
 
     def test_s3_managed_connection_uses_credentials_file_and_scrubs_logs(self) -> None:
         with tempfile.TemporaryDirectory() as temp:

--- a/.agents/skills/setup-greptimedb/SKILL.md
+++ b/.agents/skills/setup-greptimedb/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: setup-greptimedb
-description: Install checksum-verified latest-stable or version-pinned GreptimeDB native releases and prepare reusable local benchmark database workspaces. Use for local GreptimeDB installation, exact-version setup, installation verification, managed TSBS workspace preparation, or locating a managed GreptimeDB binary.
+description: Install checksum-verified GreptimeDB native releases and prepare reusable file- or S3-backed benchmark workspaces. Use for GreptimeDB installation, S3 configuration, exact-version setup, managed TSBS workspace preparation, verification, or locating a managed binary.
 ---
 
 # Setup GreptimeDB
@@ -45,6 +45,33 @@ command execution time and never upgrades an existing workspace automatically.
 Do not adopt or rewrite a legacy benchmark workspace; continue using it with an
 explicit binary or choose a new database ID.
 
+### Prepare S3 storage
+
+Never ask the user to paste S3 credentials into conversation. Ask only for
+non-secret values such as bucket, root, region, and endpoint, then give the
+user a command to run in their own interactive terminal:
+
+```bash
+python3 .agents/skills/setup-greptimedb/scripts/setup.py configure-s3 \
+  --output /secure/path/greptimedb-s3.toml \
+  --bucket BUCKET --root UNIQUE_ROOT --region REGION \
+  --endpoint ENDPOINT
+```
+
+The command prompts without echo for the access key ID and secret access key,
+creates an owner-only TOML without overwriting an existing file, and prints a
+sanitized next command. If the user already maintains a full standalone TOML,
+skip generation and use it directly:
+
+```bash
+python3 .agents/skills/setup-greptimedb/scripts/setup.py prepare \
+  --database-id greptime-s3 --greptime-config /secure/path/greptimedb-s3.toml
+```
+
+The config is live and user-owned. Its bucket/root identity is immutable for
+the workspace, but credentials may be rotated in place. Do not read, quote, or
+repeat credential-bearing config contents in conversation.
+
 ## Copy a loaded workspace for another version
 
 Install the target version first, then create a fully independent database
@@ -61,7 +88,8 @@ python3 .agents/skills/setup-greptimedb/scripts/setup.py copy \
 ```
 
 The source must be a loaded setup-managed workspace and the destination must
-not exist. The command locks the source, fully copies `data/` without reflinks
+not exist. S3-backed workspaces cannot be copied; use a confirmed query-only
+version override instead. For file storage, the command locks the source, fully copies `data/` without reflinks
 or hard links, creates empty logs, preserves the SQL database and dataset
 binding, records copy provenance, and publishes atomically. It never overwrites
 or resumes a destination. Manually started GreptimeDB processes do not

--- a/.agents/skills/setup-greptimedb/agents/openai.yaml
+++ b/.agents/skills/setup-greptimedb/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "Setup GreptimeDB"
-  short_description: "Install and prepare local GreptimeDB"
-  default_prompt: "Use $setup-greptimedb to install and prepare a verified local GreptimeDB database workspace."
+  short_description: "Prepare file or S3 GreptimeDB workspaces"
+  default_prompt: "Use $setup-greptimedb to install GreptimeDB and prepare a verified file- or S3-backed database workspace."

--- a/.agents/skills/setup-greptimedb/references/setup.md
+++ b/.agents/skills/setup-greptimedb/references/setup.md
@@ -1,4 +1,4 @@
-# GreptimeDB local setup reference
+# GreptimeDB managed setup reference
 
 ## Workspace
 
@@ -25,7 +25,10 @@ macOS ARM64. Windows, Android, Docker, Kubernetes, package managers, and nightly
 builds are outside this managed benchmark workflow.
 
 Prepared manifests bind the database ID, SQL database name, release version,
-platform, installation path, and binary checksum. Dataset binding remains owned
+platform, installation path, binary checksum, and storage identity. Manifests
+without storage metadata are file-backed for compatibility. S3 manifests record
+the live TOML path and non-secret bucket/root settings; credentials remain only
+in that file. Dataset binding remains owned
 by the benchmark skill. Legacy benchmark manifests intentionally lack release
 identity and require an explicit `--greptime-bin`.
 
@@ -43,3 +46,8 @@ checksum, source manifest checksum, timestamp, method, file count, and byte
 count. The target version must be exact and already installed. Copying does not
 assert that GreptimeDB supports downgrade or upgrade startup for those data
 files.
+
+S3-backed workspaces cannot use `copy` because their primary bytes are not in
+the local `data/` directory. That directory remains available for WAL and cache
+state. Credential-bearing TOML files are user-owned, never copied or
+checksummed, and must not be printed or requested through conversation.

--- a/.agents/skills/setup-greptimedb/scripts/setup.py
+++ b/.agents/skills/setup-greptimedb/scripts/setup.py
@@ -7,16 +7,19 @@ import argparse
 import contextlib
 import datetime as dt
 import fcntl
+import getpass
 import hashlib
 import json
 import os
 import platform
 import re
+import shlex
 import shutil
 import subprocess
 import sys
 import tarfile
 import tempfile
+import tomllib
 import urllib.error
 import urllib.request
 from pathlib import Path, PurePosixPath
@@ -62,6 +65,125 @@ def read_json(path: Path) -> dict[str, Any]:
     if not isinstance(value, dict):
         raise SetupError(f"manifest must be an object: {path}")
     return value
+
+
+def save_private_text(path: Path, value: str) -> None:
+    path = path.expanduser().resolve()
+    if not path.parent.is_dir():
+        raise SetupError(f"output parent directory does not exist: {path.parent}")
+    if path.exists() or path.is_symlink():
+        raise SetupError(f"refusing to overwrite existing S3 config: {path}")
+    descriptor, temporary_name = tempfile.mkstemp(prefix=f".{path.name}.", dir=path.parent)
+    temporary = Path(temporary_name)
+    try:
+        os.fchmod(descriptor, 0o600)
+        with os.fdopen(descriptor, "w", encoding="utf-8") as stream:
+            stream.write(value)
+            stream.flush()
+            os.fsync(stream.fileno())
+        try:
+            os.link(temporary, path)
+        except FileExistsError as exc:
+            raise SetupError(f"refusing to overwrite existing S3 config: {path}") from exc
+    finally:
+        temporary.unlink(missing_ok=True)
+
+
+def prompt_value(label: str, value: str | None = None, *, required: bool = True) -> str:
+    value = value.strip() if value is not None else ""
+    if not value:
+        value = input(f"{label}: ").strip()
+    if required and not value:
+        raise SetupError(f"{label} must not be empty")
+    return value
+
+
+def prompt_secret(label: str, *, confirm: bool = False) -> str:
+    value = getpass.getpass(f"{label}: ")
+    if not value:
+        raise SetupError(f"{label} must not be empty")
+    if confirm and getpass.getpass(f"Confirm {label}: ") != value:
+        raise SetupError(f"{label} confirmation does not match")
+    return value
+
+
+def read_greptime_storage_config(path: Path, *, require_credentials: bool = True) -> tuple[dict[str, Any], tuple[str, ...]]:
+    path = path.expanduser().resolve()
+    try:
+        with path.open("rb") as stream:
+            document = tomllib.load(stream)
+    except FileNotFoundError as exc:
+        raise SetupError(f"GreptimeDB config file does not exist: {path}") from exc
+    except tomllib.TOMLDecodeError as exc:
+        raise SetupError(f"invalid GreptimeDB TOML config {path}: {exc}") from exc
+    storage = document.get("storage")
+    if not isinstance(storage, dict):
+        raise SetupError("GreptimeDB S3 config requires a [storage] table")
+    storage_type = storage.get("type", "File")
+    if not isinstance(storage_type, str) or storage_type.lower() not in ("file", "s3"):
+        raise SetupError("GreptimeDB managed storage type must be File or S3")
+    if storage_type.lower() == "file":
+        return {"type": "file", "config_file": str(path)}, ()
+    required = ("bucket", "root")
+    if require_credentials:
+        required += ("access_key_id", "secret_access_key")
+    for key in required:
+        if not isinstance(storage.get(key), str) or not storage[key]:
+            raise SetupError(f"GreptimeDB S3 config requires nonempty storage.{key}")
+    virtual_host = storage.get("enable_virtual_host_style", False)
+    if not isinstance(virtual_host, bool):
+        raise SetupError("storage.enable_virtual_host_style must be a boolean")
+    identity = {
+        "type": "s3",
+        "config_file": str(path),
+        "bucket": storage["bucket"],
+        "root": storage["root"],
+        "endpoint": storage.get("endpoint"),
+        "region": storage.get("region"),
+        "enable_virtual_host_style": virtual_host,
+    }
+    secrets = tuple(
+        storage[key]
+        for key in ("access_key_id", "secret_access_key")
+        if isinstance(storage.get(key), str) and storage[key]
+    )
+    return identity, secrets
+
+
+def configure_s3(args: argparse.Namespace) -> dict[str, Any]:
+    if not sys.stdin.isatty():
+        raise SetupError("configure-s3 requires an interactive terminal; do not provide S3 credentials through redirected input")
+    bucket = prompt_value("S3 bucket", args.bucket)
+    root = prompt_value("S3 root prefix", args.root)
+    region = prompt_value("S3 region (optional)", args.region, required=False)
+    endpoint = prompt_value("S3 endpoint (optional)", args.endpoint, required=False)
+    access_key_id = prompt_secret("S3 access key ID")
+    secret_access_key = prompt_secret("S3 secret access key", confirm=True)
+    lines = [
+        "[storage]",
+        'type = "S3"',
+        f"bucket = {json.dumps(bucket)}",
+        f"root = {json.dumps(root)}",
+    ]
+    if region:
+        lines.append(f"region = {json.dumps(region)}")
+    if endpoint:
+        lines.append(f"endpoint = {json.dumps(endpoint)}")
+    lines.extend([
+        f"access_key_id = {json.dumps(access_key_id)}",
+        f"secret_access_key = {json.dumps(secret_access_key)}",
+    ])
+    if args.enable_virtual_host_style:
+        lines.append("enable_virtual_host_style = true")
+    output = args.output.expanduser().resolve()
+    save_private_text(output, "\n".join(lines) + "\n")
+    return {
+        "config_file": str(output),
+        "next_command": (
+            "python3 .agents/skills/setup-greptimedb/scripts/setup.py prepare "
+            f"--database-id DATABASE_ID --greptime-config {shlex.quote(str(output))}"
+        ),
+    }
 
 
 def sha256_file(path: Path) -> str:
@@ -354,18 +476,29 @@ def validate_database(path: Path, expected_id: str | None = None) -> dict[str, A
     installed = validate_installation(installation, manifest["version"])
     if installed["platform"] != manifest["platform"] or installed["binary_sha256"] != manifest["binary_sha256"]:
         raise SetupError("database installation identity mismatch")
+    storage = manifest.get("storage", {"type": "file"})
+    if not isinstance(storage, dict) or storage.get("type") not in ("file", "s3"):
+        raise SetupError("database storage identity is malformed")
+    if storage["type"] == "s3":
+        current, _ = read_greptime_storage_config(Path(storage.get("config_file", "")))
+        if current != storage:
+            raise SetupError("GreptimeDB S3 config no longer matches the workspace storage identity")
+    manifest["storage"] = storage
     return manifest
 
 
 def prepare(args: argparse.Namespace) -> dict[str, Any]:
     installation = installation_path(args); installed = validate_installation(installation, args.version)
+    storage = {"type": "file"}
+    if getattr(args, "greptime_config", None):
+        storage, _ = read_greptime_storage_config(args.greptime_config)
     path = database_path(args); manifest_path = path / "manifest.json"
     if manifest_path.exists():
         manifest = validate_database(path, args.database_id)
-        expected = (args.version, installed["platform"], installed["binary_sha256"], args.database)
-        actual = (manifest["version"], manifest["platform"], manifest["binary_sha256"], manifest["database"])
+        expected = (args.version, installed["platform"], installed["binary_sha256"], args.database, storage)
+        actual = (manifest["version"], manifest["platform"], manifest["binary_sha256"], manifest["database"], manifest["storage"])
         if actual != expected:
-            raise SetupError("database is already bound to another version, binary, platform, or SQL database")
+            raise SetupError("database is already bound to another version, binary, platform, SQL database, or storage identity")
         return {**manifest, "database_path": str(path), "reused": True}
     if path.exists() and any(path.iterdir()):
         raise SetupError(f"database workspace exists without a setup-compatible manifest: {path}")
@@ -375,6 +508,7 @@ def prepare(args: argparse.Namespace) -> dict[str, Any]:
         "version": args.version, "version_source": args.version_source, "platform": installed["platform"],
         "installation_path": str(installation), "binary_sha256": installed["binary_sha256"],
         "created_at": utc_now(), "updated_at": utc_now(), "database": args.database, "binding": None,
+        "storage": storage,
     }
     save_json(manifest_path, manifest)
     return {**manifest, "database_path": str(path), "reused": False}
@@ -396,6 +530,8 @@ def copy_database(args: argparse.Namespace) -> dict[str, Any]:
     try:
         with lock_database(source):
             source_manifest = validate_database(source, args.source_database_id)
+            if source_manifest["storage"]["type"] == "s3":
+                raise SetupError("copy is not supported for S3-backed GreptimeDB workspaces; use a query-only version override")
             if source_manifest["binding"] is None:
                 raise SetupError("source database workspace has no loaded dataset binding")
             if installed["platform"] != source_manifest["platform"]:
@@ -423,6 +559,7 @@ def copy_database(args: argparse.Namespace) -> dict[str, Any]:
                 "updated_at": copied_at,
                 "database": source_manifest["database"],
                 "binding": source_manifest["binding"],
+                "storage": {"type": "file"},
                 "copied_from": {
                     "database_id": source_manifest["database_id"],
                     "database_path": str(source),
@@ -451,8 +588,9 @@ def print_value(value: Any) -> None:
 
 def make_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description=__doc__); sub = parser.add_subparsers(dest="command", required=True)
+    configure_parser = sub.add_parser("configure-s3"); configure_parser.add_argument("--output", required=True, type=Path); configure_parser.add_argument("--bucket"); configure_parser.add_argument("--root"); configure_parser.add_argument("--region"); configure_parser.add_argument("--endpoint"); configure_parser.add_argument("--enable-virtual-host-style", action="store_true")
     install_parser = sub.add_parser("install"); install_parser.add_argument("--version"); install_parser.add_argument("--install-root", type=Path); install_parser.add_argument("--reinstall", action="store_true")
-    prepare_parser = sub.add_parser("prepare"); prepare_parser.add_argument("--database-id", required=True); prepare_parser.add_argument("--version"); prepare_parser.add_argument("--database", default="benchmark"); prepare_parser.add_argument("--install-root", type=Path); prepare_parser.add_argument("--database-root", type=Path)
+    prepare_parser = sub.add_parser("prepare"); prepare_parser.add_argument("--database-id", required=True); prepare_parser.add_argument("--version"); prepare_parser.add_argument("--database", default="benchmark"); prepare_parser.add_argument("--install-root", type=Path); prepare_parser.add_argument("--database-root", type=Path); prepare_parser.add_argument("--greptime-config", type=Path)
     copy_parser = sub.add_parser("copy"); copy_parser.add_argument("--source-database-id", required=True); copy_parser.add_argument("--database-id", required=True); copy_parser.add_argument("--version", required=True); copy_parser.add_argument("--install-root", type=Path); copy_parser.add_argument("--database-root", type=Path)
     list_parser = sub.add_parser("list"); list_parser.add_argument("--database-root", type=Path)
     inspect_parser = sub.add_parser("inspect"); inspect_parser.add_argument("--database-id", required=True); inspect_parser.add_argument("--database-root", type=Path)
@@ -477,7 +615,9 @@ def main(argv: Sequence[str] | None = None) -> int:
         validate_args(args)
         if args.command in ("install", "prepare", "copy"):
             resolve_args_version(args)
-        if args.command == "install":
+        if args.command == "configure-s3":
+            value = configure_s3(args)
+        elif args.command == "install":
             value = install(args)
         elif args.command == "prepare":
             value = prepare(args)

--- a/.agents/skills/setup-greptimedb/scripts/setup.py
+++ b/.agents/skills/setup-greptimedb/scripts/setup.py
@@ -19,7 +19,6 @@ import subprocess
 import sys
 import tarfile
 import tempfile
-import tomllib
 import urllib.error
 import urllib.request
 from pathlib import Path, PurePosixPath
@@ -27,6 +26,11 @@ from typing import Any, Iterator, Sequence
 
 
 SCRIPT_PATH = Path(__file__).resolve()
+sys.path.insert(0, str(SCRIPT_PATH.parents[3] / "lib"))
+
+import tomli  # noqa: E402
+
+
 REPO_ROOT = SCRIPT_PATH.parents[4]
 DEFAULT_ROOT = REPO_ROOT / ".benchmarks" / "greptimedb"
 DEFAULT_INSTALL_ROOT = DEFAULT_ROOT / "installations"
@@ -111,10 +115,10 @@ def read_greptime_storage_config(path: Path, *, require_credentials: bool = True
     path = path.expanduser().resolve()
     try:
         with path.open("rb") as stream:
-            document = tomllib.load(stream)
+            document = tomli.load(stream)
     except FileNotFoundError as exc:
         raise SetupError(f"GreptimeDB config file does not exist: {path}") from exc
-    except tomllib.TOMLDecodeError as exc:
+    except tomli.TOMLDecodeError as exc:
         raise SetupError(f"invalid GreptimeDB TOML config {path}: {exc}") from exc
     storage = document.get("storage")
     if not isinstance(storage, dict):

--- a/.agents/skills/setup-greptimedb/tests/test_setup.py
+++ b/.agents/skills/setup-greptimedb/tests/test_setup.py
@@ -203,6 +203,36 @@ class DatabaseTests(unittest.TestCase):
             with mock.patch.object(setup, "platform_tag", return_value="linux_amd64"), self.assertRaisesRegex(setup.SetupError, "already exists"):
                 setup.copy_database(args)
 
+    def test_s3_config_is_secret_only_and_binds_workspace_identity(self) -> None:
+        with tempfile.TemporaryDirectory() as temp:
+            root = Path(temp); output = root / "greptime-s3.toml"
+            args = setup.make_parser().parse_args([
+                "configure-s3", "--output", str(output), "--bucket", "bench",
+                "--root", "greptime/db-a", "--region", "us-west-1",
+                "--endpoint", "http://minio:9000",
+            ])
+            stdin = mock.Mock(); stdin.isatty.return_value = True
+            with mock.patch.object(setup.sys, "stdin", stdin), mock.patch.object(
+                setup.getpass, "getpass", side_effect=["access-value", "secret-value", "secret-value"]
+            ):
+                generated = setup.configure_s3(args)
+            self.assertEqual(output.stat().st_mode & 0o777, 0o600)
+            self.assertNotIn("access-value", json.dumps(generated))
+            self.assertNotIn("secret-value", json.dumps(generated))
+
+            self.make_installation(root)
+            prepare_args = self.args(root); prepare_args.greptime_config = output
+            with mock.patch.object(setup, "platform_tag", return_value="linux_amd64"):
+                prepared = setup.prepare(prepare_args)
+            persisted = json.dumps(setup.read_json(Path(prepared["database_path"]) / "manifest.json"))
+            self.assertNotIn("access-value", persisted)
+            self.assertNotIn("secret-value", persisted)
+            self.assertEqual(prepared["storage"]["bucket"], "bench")
+
+            output.write_text(output.read_text().replace('bucket = "bench"', 'bucket = "other"'), encoding="utf-8")
+            with self.assertRaisesRegex(setup.SetupError, "no longer matches"):
+                setup.validate_database(Path(prepared["database_path"]), "db-a")
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/.agents/skills/setup-influxdb3/SKILL.md
+++ b/.agents/skills/setup-influxdb3/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: setup-influxdb3
-description: Install checksum-verified latest or version-pinned InfluxDB 3 Core or Enterprise native distributions and prepare reusable local benchmark database workspaces. Use for local InfluxDB 3 installation, database setup, Enterprise trial/home activation, license-file setup, installation verification, or locating a managed binary for TSBS.
+description: Install checksum-verified InfluxDB 3 Core or Enterprise distributions and prepare reusable file- or S3-backed benchmark workspaces. Use for installation, guided S3 configuration, database setup, Enterprise licensing, verification, or locating a managed binary for TSBS.
 ---
 
 # Setup InfluxDB 3
@@ -37,10 +37,40 @@ python3 .agents/skills/setup-influxdb3/scripts/setup.py prepare \
   --database-id enterprise-311 --edition enterprise --version 3.11.1
 ```
 
-Database workspaces use a file object store and stable node/cluster identifiers.
+Database workspaces use a file object store by default and stable node/cluster identifiers.
 Existing workspaces are immutable with respect to edition, version, and binary checksum.
 Omitting `--version` resolves the official latest at command execution time;
 it never upgrades an existing database workspace automatically.
+
+### Prepare S3 storage
+
+Never ask the user to paste S3 credentials into conversation. Ask only for
+non-secret bucket, region, endpoint, and HTTP compatibility choices, then give
+the user a local interactive command:
+
+```bash
+python3 .agents/skills/setup-influxdb3/scripts/setup.py configure-s3 \
+  --output /secure/path/influxdb3-s3-credentials.json \
+  --bucket BUCKET --aws-default-region REGION \
+  --aws-endpoint ENDPOINT --aws-allow-http
+```
+
+The command prompts without echo, writes an owner-only native AWS credentials
+JSON without overwriting, and prints a sanitized `prepare` command.
+`--aws-allow-http` is required for an HTTP endpoint. Existing native credential
+files can be supplied directly:
+
+```bash
+python3 .agents/skills/setup-influxdb3/scripts/setup.py prepare \
+  --database-id core-s3 --edition core --object-store s3 \
+  --bucket BUCKET --aws-credentials-file /secure/path/aws.json \
+  --aws-default-region REGION
+```
+
+The file must contain `aws_access_key_id` and `aws_secret_access_key`; optional
+fields are `aws_session_token` and `expiry`. Never read, quote, or repeat its
+contents in conversation. Bucket/endpoint identity is immutable while the file
+contents may rotate in place.
 
 ## Activate Enterprise
 
@@ -76,6 +106,6 @@ python3 .agents/skills/setup-influxdb3/scripts/setup.py inspect --database-id co
 python3 .agents/skills/setup-influxdb3/scripts/setup.py verify --database-id core-311
 ```
 
-Report the database ID, edition, exact version, binary path and checksum, and
-Enterprise license status. Do not add the binary to `PATH` or alter system
+Report the database ID, edition, exact version, binary path and checksum,
+storage type/location, and Enterprise license status. Do not add the binary to `PATH` or alter system
 packages or services.

--- a/.agents/skills/setup-influxdb3/agents/openai.yaml
+++ b/.agents/skills/setup-influxdb3/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "Setup InfluxDB 3"
-  short_description: "Install and prepare local InfluxDB 3"
-  default_prompt: "Use $setup-influxdb3 to install and prepare a local InfluxDB 3 Core or Enterprise database workspace."
+  short_description: "Prepare file or S3 InfluxDB 3 workspaces"
+  default_prompt: "Use $setup-influxdb3 to install and prepare a file- or S3-backed InfluxDB 3 Core or Enterprise workspace."

--- a/.agents/skills/setup-influxdb3/references/setup.md
+++ b/.agents/skills/setup-influxdb3/references/setup.md
@@ -1,4 +1,4 @@
-# InfluxDB 3 local setup reference
+# InfluxDB 3 managed setup reference
 
 ## Workspace
 
@@ -30,6 +30,13 @@ Intel macOS and Windows are intentionally unsupported by the managed workflow.
 - Derive a stable node ID from the database ID.
 - Add a distinct stable cluster ID for Enterprise.
 - Use `--without-auth` for isolated managed benchmark databases.
+
+S3 workspaces instead use `--object-store=s3`, a bucket, region, optional
+compatible endpoint/HTTP opt-in, and a user-owned native AWS credentials JSON.
+They do not pass `--data-dir`. Manifests pin only the credentials-file path and
+non-secret storage settings; file contents may rotate in place and are never
+copied, checksummed, printed, or placed in process environment variables.
+Manifests without a storage field remain file-backed.
 
 Enterprise requires an active license. Trial/home activation supplies the email
 and license type only to the server process; neither value is written to the

--- a/.agents/skills/setup-influxdb3/scripts/setup.py
+++ b/.agents/skills/setup-influxdb3/scripts/setup.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Install and prepare reusable local InfluxDB 3 database workspaces."""
+"""Install InfluxDB 3 and prepare reusable file- or S3-backed workspaces."""
 
 from __future__ import annotations
 
@@ -11,6 +11,7 @@ import json
 import os
 import platform
 import re
+import shlex
 import shutil
 import signal
 import socket
@@ -21,6 +22,7 @@ import tempfile
 import threading
 import time
 import urllib.error
+import urllib.parse
 import urllib.request
 from pathlib import Path, PurePosixPath
 from typing import Any, Sequence
@@ -66,6 +68,178 @@ def read_json(path: Path) -> dict[str, Any]:
     if not isinstance(value, dict):
         raise SetupError(f"manifest must be an object: {path}")
     return value
+
+
+def save_private_json(path: Path, value: dict[str, Any]) -> None:
+    path = path.expanduser().resolve()
+    if not path.parent.is_dir():
+        raise SetupError(f"output parent directory does not exist: {path.parent}")
+    if path.exists() or path.is_symlink():
+        raise SetupError(f"refusing to overwrite existing S3 credentials file: {path}")
+    descriptor, temporary_name = tempfile.mkstemp(prefix=f".{path.name}.", dir=path.parent)
+    temporary = Path(temporary_name)
+    try:
+        os.fchmod(descriptor, 0o600)
+        with os.fdopen(descriptor, "w", encoding="utf-8") as stream:
+            json.dump(value, stream, indent=2, sort_keys=True)
+            stream.write("\n")
+            stream.flush()
+            os.fsync(stream.fileno())
+        try:
+            os.link(temporary, path)
+        except FileExistsError as exc:
+            raise SetupError(f"refusing to overwrite existing S3 credentials file: {path}") from exc
+    finally:
+        temporary.unlink(missing_ok=True)
+
+
+def prompt_value(label: str, value: str | None = None, *, required: bool = True) -> str:
+    value = value.strip() if value is not None else ""
+    if not value:
+        value = input(f"{label}: ").strip()
+    if required and not value:
+        raise SetupError(f"{label} must not be empty")
+    return value
+
+
+def prompt_secret(label: str, *, required: bool = True, confirm: bool = False) -> str:
+    value = getpass.getpass(f"{label}: ")
+    if required and not value:
+        raise SetupError(f"{label} must not be empty")
+    if confirm and getpass.getpass(f"Confirm {label}: ") != value:
+        raise SetupError(f"{label} confirmation does not match")
+    return value
+
+
+def read_aws_credentials(path: Path) -> tuple[Path, tuple[str, ...]]:
+    path = path.expanduser().resolve()
+    document = read_json(path)
+    for key in ("aws_access_key_id", "aws_secret_access_key"):
+        if not isinstance(document.get(key), str) or not document[key]:
+            raise SetupError(f"InfluxDB S3 credentials file requires nonempty {key}")
+    for key in ("aws_session_token", "expiry"):
+        if key in document and not isinstance(document[key], (str, int)):
+            raise SetupError(f"InfluxDB S3 credentials field {key} has an invalid type")
+    secrets = tuple(
+        str(document[key])
+        for key in ("aws_access_key_id", "aws_secret_access_key", "aws_session_token")
+        if document.get(key)
+    )
+    return path, secrets
+
+
+def configure_s3(args: argparse.Namespace) -> dict[str, Any]:
+    if not sys.stdin.isatty():
+        raise SetupError("configure-s3 requires an interactive terminal; do not provide S3 credentials through redirected input")
+    bucket = prompt_value("S3 bucket", args.bucket)
+    region = prompt_value("S3 region", args.aws_default_region or "us-east-1")
+    endpoint = prompt_value("S3 endpoint (optional)", args.aws_endpoint, required=False)
+    if endpoint:
+        parsed = urllib.parse.urlparse(endpoint)
+        if parsed.scheme not in ("http", "https") or not parsed.netloc:
+            raise SetupError("--aws-endpoint must be an absolute HTTP or HTTPS URL")
+        if parsed.scheme == "http" and not args.aws_allow_http:
+            raise SetupError("an HTTP S3 endpoint requires --aws-allow-http")
+    access_key_id = prompt_secret("S3 access key ID")
+    secret_access_key = prompt_secret("S3 secret access key", confirm=True)
+    session_token = prompt_secret("S3 session token (optional)", required=False)
+    credentials = {
+        "aws_access_key_id": access_key_id,
+        "aws_secret_access_key": secret_access_key,
+    }
+    if session_token:
+        credentials["aws_session_token"] = session_token
+    output = args.output.expanduser().resolve()
+    save_private_json(output, credentials)
+    options = [
+        "python3 .agents/skills/setup-influxdb3/scripts/setup.py prepare",
+        "--database-id DATABASE_ID --edition EDITION --object-store s3",
+        f"--bucket {shlex.quote(bucket)}",
+        f"--aws-credentials-file {shlex.quote(str(output))}",
+        f"--aws-default-region {shlex.quote(region)}",
+    ]
+    if endpoint:
+        options.append(f"--aws-endpoint {shlex.quote(endpoint)}")
+    if args.aws_allow_http:
+        options.append("--aws-allow-http")
+    return {"credentials_file": str(output), "next_command": " ".join(options)}
+
+
+def storage_from_args(args: argparse.Namespace) -> dict[str, Any]:
+    object_store = getattr(args, "object_store", None) or "file"
+    s3_values = (
+        getattr(args, "bucket", None),
+        getattr(args, "aws_credentials_file", None),
+        getattr(args, "aws_endpoint", None),
+        getattr(args, "aws_allow_http", False),
+    )
+    if object_store == "file":
+        if any(s3_values):
+            raise SetupError("S3 options require --object-store s3")
+        return {"type": "file"}
+    bucket = getattr(args, "bucket", None)
+    credentials_file = getattr(args, "aws_credentials_file", None)
+    if not bucket or not credentials_file:
+        raise SetupError("S3 storage requires --bucket and --aws-credentials-file")
+    credentials_path, _ = read_aws_credentials(credentials_file)
+    endpoint = getattr(args, "aws_endpoint", None)
+    if endpoint:
+        parsed = urllib.parse.urlparse(endpoint)
+        if parsed.scheme not in ("http", "https") or not parsed.netloc:
+            raise SetupError("--aws-endpoint must be an absolute HTTP or HTTPS URL")
+        if parsed.scheme == "http" and not getattr(args, "aws_allow_http", False):
+            raise SetupError("an HTTP S3 endpoint requires --aws-allow-http")
+    return {
+        "type": "s3",
+        "bucket": bucket,
+        "credentials_file": str(credentials_path),
+        "region": getattr(args, "aws_default_region", None) or "us-east-1",
+        "endpoint": endpoint,
+        "allow_http": bool(getattr(args, "aws_allow_http", False)),
+    }
+
+
+def validate_storage(storage: Any) -> dict[str, Any]:
+    if storage is None:
+        return {"type": "file"}
+    if not isinstance(storage, dict) or storage.get("type") not in ("file", "s3"):
+        raise SetupError("database storage identity is malformed")
+    if storage["type"] == "s3":
+        required = {"bucket", "credentials_file", "region", "endpoint", "allow_http"}
+        if (
+            not required.issubset(storage)
+            or not isinstance(storage["bucket"], str)
+            or not storage["bucket"]
+            or not isinstance(storage["region"], str)
+            or not storage["region"]
+            or storage["endpoint"] is not None and not isinstance(storage["endpoint"], str)
+            or not isinstance(storage["allow_http"], bool)
+        ):
+            raise SetupError("database S3 storage identity is malformed")
+        if storage["endpoint"]:
+            parsed = urllib.parse.urlparse(storage["endpoint"])
+            if parsed.scheme not in ("http", "https") or not parsed.netloc:
+                raise SetupError("database S3 endpoint is malformed")
+            if parsed.scheme == "http" and not storage["allow_http"]:
+                raise SetupError("database HTTP S3 endpoint requires allow_http")
+        read_aws_credentials(Path(storage["credentials_file"]))
+    return storage
+
+
+def storage_command(storage: dict[str, Any], data_path: Path) -> list[str]:
+    if storage["type"] == "file":
+        return ["--object-store=file", f"--data-dir={data_path}"]
+    command = [
+        "--object-store=s3",
+        f"--bucket={storage['bucket']}",
+        f"--aws-credentials-file={storage['credentials_file']}",
+        f"--aws-default-region={storage['region']}",
+    ]
+    if storage.get("endpoint"):
+        command.append(f"--aws-endpoint={storage['endpoint']}")
+    if storage.get("allow_http"):
+        command.append("--aws-allow-http")
+    return command
 
 
 def sha256_file(path: Path) -> str:
@@ -351,19 +525,21 @@ def validate_database(path: Path, expected_id: str | None = None) -> dict[str, A
     installed = validate_installation(installation, manifest["edition"], manifest["version"])
     if installed["binary_sha256"] != manifest["binary_sha256"]:
         raise SetupError("database installation checksum mismatch")
+    manifest["storage"] = validate_storage(manifest.get("storage"))
     return manifest
 
 
 def prepare(args: argparse.Namespace) -> dict[str, Any]:
     installation = installation_path(args)
     installed = validate_installation(installation, args.edition, args.version)
+    storage = storage_from_args(args)
     path = database_path(args)
     if (path / "manifest.json").exists():
         manifest = validate_database(path, args.database_id)
-        identity = (manifest["edition"], manifest["version"], manifest["binary_sha256"])
-        expected = (args.edition, args.version, installed["binary_sha256"])
+        identity = (manifest["edition"], manifest["version"], manifest["binary_sha256"], manifest["storage"])
+        expected = (args.edition, args.version, installed["binary_sha256"], storage)
         if identity != expected:
-            raise SetupError("database is already bound to another edition, version, or binary")
+            raise SetupError("database is already bound to another edition, version, binary, or storage identity")
         return {**manifest, "database_path": str(path), "reused": True}
     path.mkdir(parents=True, exist_ok=True)
     (path / "data").mkdir(); (path / "logs").mkdir()
@@ -375,7 +551,7 @@ def prepare(args: argparse.Namespace) -> dict[str, Any]:
         "installation_path": str(installation), "binary_sha256": installed["binary_sha256"],
         "node_id": f"{stem}-node", "cluster_id": f"{stem}-cluster" if args.edition == "enterprise" else None,
         "created_at": utc_now(), "updated_at": utc_now(), "license": {"status": "not-required" if args.edition == "core" else "unconfigured", "source": None},
-        "database": None, "binding": None,
+        "database": None, "binding": None, "storage": storage,
     }
     save_json(path / "manifest.json", manifest)
     return {**manifest, "database_path": str(path), "reused": False}
@@ -453,7 +629,7 @@ def activate(args: argparse.Namespace) -> dict[str, Any]:
     if not wait_port_available(args.http_port):
         raise SetupError(f"HTTP port {args.http_port} is unavailable")
     installation = Path(manifest["installation_path"]); binary = installation / "influxdb3"
-    command = [str(binary), "serve", "--object-store=file", f"--data-dir={path / 'data'}", f"--node-id={manifest['node_id']}", f"--cluster-id={manifest['cluster_id']}", f"--http-bind=127.0.0.1:{args.http_port}", "--without-auth"]
+    command = [str(binary), "serve", *storage_command(manifest["storage"], path / "data"), f"--node-id={manifest['node_id']}", f"--cluster-id={manifest['cluster_id']}", f"--http-bind=127.0.0.1:{args.http_port}", "--without-auth"]
     env = os.environ.copy(); source: str
     if args.license_file:
         license_file = args.license_file.expanduser().resolve()
@@ -466,7 +642,10 @@ def activate(args: argparse.Namespace) -> dict[str, Any]:
         env["INFLUXDB3_LICENSE_TYPE"] = args.license_type
         source = args.license_type
     log_path = path / "logs" / "license-activation.log"
-    secrets = (license_email,) if args.license_type else ()
+    storage_secrets: tuple[str, ...] = ()
+    if manifest["storage"]["type"] == "s3":
+        _, storage_secrets = read_aws_credentials(Path(manifest["storage"]["credentials_file"]))
+    secrets = (*storage_secrets, license_email) if args.license_type else storage_secrets
     try:
         with log_path.open("a", encoding="utf-8") as log:
             log.write(f"\nActivation attempt at {utc_now()} (source={source})\n"); log.flush()
@@ -502,8 +681,9 @@ def print_value(value: Any) -> None:
 
 def make_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description=__doc__); sub = parser.add_subparsers(dest="command", required=True)
+    configure_parser = sub.add_parser("configure-s3"); configure_parser.add_argument("--output", required=True, type=Path); configure_parser.add_argument("--bucket"); configure_parser.add_argument("--aws-default-region"); configure_parser.add_argument("--aws-endpoint"); configure_parser.add_argument("--aws-allow-http", action="store_true")
     install_parser = sub.add_parser("install"); install_parser.add_argument("--edition", choices=("core", "enterprise"), required=True); install_parser.add_argument("--version"); install_parser.add_argument("--install-root", type=Path); install_parser.add_argument("--reinstall", action="store_true")
-    prepare_parser = sub.add_parser("prepare"); prepare_parser.add_argument("--database-id", required=True); prepare_parser.add_argument("--edition", choices=("core", "enterprise"), required=True); prepare_parser.add_argument("--version"); prepare_parser.add_argument("--install-root", type=Path); prepare_parser.add_argument("--database-root", type=Path)
+    prepare_parser = sub.add_parser("prepare"); prepare_parser.add_argument("--database-id", required=True); prepare_parser.add_argument("--edition", choices=("core", "enterprise"), required=True); prepare_parser.add_argument("--version"); prepare_parser.add_argument("--install-root", type=Path); prepare_parser.add_argument("--database-root", type=Path); prepare_parser.add_argument("--object-store", choices=("file", "s3"), default="file"); prepare_parser.add_argument("--bucket"); prepare_parser.add_argument("--aws-credentials-file", type=Path); prepare_parser.add_argument("--aws-default-region"); prepare_parser.add_argument("--aws-endpoint"); prepare_parser.add_argument("--aws-allow-http", action="store_true")
     activate_parser = sub.add_parser("activate"); activate_parser.add_argument("--database-id", required=True); activate_parser.add_argument("--database-root", type=Path); license_group = activate_parser.add_mutually_exclusive_group(required=True); license_group.add_argument("--license-file", type=Path); license_group.add_argument("--license-type", choices=("trial", "home")); activate_parser.add_argument("--license-email-env", default="INFLUXDB3_LICENSE_EMAIL"); activate_parser.add_argument("--license-email-stdin", action="store_true", help="read the activation email securely from one line of standard input"); activate_parser.add_argument("--http-port", type=int, default=8181); activate_parser.add_argument("--activation-timeout", type=int, default=600)
     list_parser = sub.add_parser("list"); list_parser.add_argument("--database-root", type=Path)
     inspect_parser = sub.add_parser("inspect"); inspect_parser.add_argument("--database-id", required=True); inspect_parser.add_argument("--database-root", type=Path)
@@ -531,7 +711,8 @@ def main(argv: Sequence[str] | None = None) -> int:
         validate_args(args)
         if args.command in ("install", "prepare"):
             resolve_args_version(args)
-        if args.command == "install": value = install(args)
+        if args.command == "configure-s3": value = configure_s3(args)
+        elif args.command == "install": value = install(args)
         elif args.command == "prepare": value = prepare(args)
         elif args.command == "activate": value = activate(args)
         elif args.command in ("inspect", "verify"):

--- a/.agents/skills/setup-influxdb3/scripts/setup.py
+++ b/.agents/skills/setup-influxdb3/scripts/setup.py
@@ -117,9 +117,14 @@ def read_aws_credentials(path: Path) -> tuple[Path, tuple[str, ...]]:
     for key in ("aws_access_key_id", "aws_secret_access_key"):
         if not isinstance(document.get(key), str) or not document[key]:
             raise SetupError(f"InfluxDB S3 credentials file requires nonempty {key}")
-    for key in ("aws_session_token", "expiry"):
-        if key in document and not isinstance(document[key], (str, int)):
-            raise SetupError(f"InfluxDB S3 credentials field {key} has an invalid type")
+    if "aws_session_token" in document and not isinstance(document["aws_session_token"], str):
+        raise SetupError("InfluxDB S3 credentials field aws_session_token must be a string")
+    if "expiry" in document and (
+        isinstance(document["expiry"], bool)
+        or not isinstance(document["expiry"], int)
+        or not 0 <= document["expiry"] <= 2**64 - 1
+    ):
+        raise SetupError("InfluxDB S3 credentials field expiry must be an unsigned 64-bit integer")
     secrets = tuple(
         str(document[key])
         for key in ("aws_access_key_id", "aws_secret_access_key", "aws_session_token")

--- a/.agents/skills/setup-influxdb3/tests/test_setup.py
+++ b/.agents/skills/setup-influxdb3/tests/test_setup.py
@@ -235,6 +235,19 @@ class DatabaseTests(unittest.TestCase):
         with mock.patch.object(setup, "port_available", side_effect=[False, True]), mock.patch.object(setup.time, "sleep"):
             self.assertTrue(setup.wait_port_available(8181))
 
+    def test_s3_credentials_reject_server_incompatible_optional_types(self) -> None:
+        with tempfile.TemporaryDirectory() as temp:
+            credentials = Path(temp) / "aws.json"
+            required = {
+                "aws_access_key_id": "access-value",
+                "aws_secret_access_key": "secret-value",
+            }
+            for field, value in (("aws_session_token", 123), ("expiry", "123")):
+                with self.subTest(field=field):
+                    credentials.write_text(json.dumps({**required, field: value}), encoding="utf-8")
+                    with self.assertRaisesRegex(setup.SetupError, field):
+                        setup.read_aws_credentials(credentials)
+
     def test_s3_credentials_are_private_and_not_persisted_in_workspace(self) -> None:
         with tempfile.TemporaryDirectory() as temp:
             root = Path(temp); credentials = root / "aws.json"

--- a/.agents/skills/setup-influxdb3/tests/test_setup.py
+++ b/.agents/skills/setup-influxdb3/tests/test_setup.py
@@ -235,6 +235,39 @@ class DatabaseTests(unittest.TestCase):
         with mock.patch.object(setup, "port_available", side_effect=[False, True]), mock.patch.object(setup.time, "sleep"):
             self.assertTrue(setup.wait_port_available(8181))
 
+    def test_s3_credentials_are_private_and_not_persisted_in_workspace(self) -> None:
+        with tempfile.TemporaryDirectory() as temp:
+            root = Path(temp); credentials = root / "aws.json"
+            args = setup.make_parser().parse_args([
+                "configure-s3", "--output", str(credentials), "--bucket", "bench",
+                "--aws-default-region", "us-west-1", "--aws-endpoint", "http://minio:9000",
+                "--aws-allow-http",
+            ])
+            stdin = mock.Mock(); stdin.isatty.return_value = True
+            with mock.patch.object(setup.sys, "stdin", stdin), mock.patch.object(
+                setup.getpass, "getpass", side_effect=["access-value", "secret-value", "secret-value", ""]
+            ):
+                generated = setup.configure_s3(args)
+            self.assertEqual(credentials.stat().st_mode & 0o777, 0o600)
+            self.assertNotIn("access-value", json.dumps(generated))
+            self.assertNotIn("secret-value", json.dumps(generated))
+
+            self.make_installation(root)
+            prepare_args = self.args(root)
+            prepare_args.object_store = "s3"; prepare_args.bucket = "bench"
+            prepare_args.aws_credentials_file = credentials
+            prepare_args.aws_default_region = "us-west-1"; prepare_args.aws_endpoint = "http://minio:9000"
+            prepare_args.aws_allow_http = True
+            with mock.patch.object(setup, "platform_tag", return_value="linux_amd64"):
+                prepared = setup.prepare(prepare_args)
+            persisted = json.dumps(setup.read_json(Path(prepared["database_path"]) / "manifest.json"))
+            self.assertNotIn("access-value", persisted)
+            self.assertNotIn("secret-value", persisted)
+            self.assertEqual(prepared["storage"]["type"], "s3")
+            command = setup.storage_command(prepared["storage"], Path(prepared["database_path"]) / "data")
+            self.assertIn("--object-store=s3", command)
+            self.assertFalse(any(part.startswith("--data-dir=") for part in command))
+
 
 class ArgumentTests(unittest.TestCase):
     def test_version_must_be_omitted_or_exact_and_activation_email_is_required(self) -> None:


### PR DESCRIPTION
## Summary

- add secure configure-s3 helpers for GreptimeDB and InfluxDB 3
- support managed AWS S3 and S3-compatible benchmark workspaces
- keep credentials out of conversation, manifests, summaries, commands, environments, and process logs
- preserve existing file-backed workspace compatibility

## Validation

- 97 setup and benchmark tests pass
- all four modified skills pass quick_validate.py
- Python compilation and git diff checks pass
- S3 CLI options verified against installed InfluxDB 3.10.5 and 3.11.1 binaries